### PR TITLE
feat: add image support for Claude 3.5

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -190,6 +190,7 @@ MODEL_SETTINGS = [
         use_repo_map=True,
         examples_as_sys_msg=True,
         can_prefill=True,
+        accepts_images=True,
     ),
     ModelSettings(
         "anthropic/claude-3-5-sonnet-20240620",
@@ -206,6 +207,7 @@ MODEL_SETTINGS = [
         use_repo_map=True,
         examples_as_sys_msg=True,
         can_prefill=True,
+        accepts_images=True,
     ),
     # Vertex AI Claude models
     ModelSettings(
@@ -215,6 +217,7 @@ MODEL_SETTINGS = [
         use_repo_map=True,
         examples_as_sys_msg=True,
         can_prefill=True,
+        accepts_images=True,
     ),
     ModelSettings(
         "vertex_ai/claude-3-opus@20240229",

--- a/website/index.md
+++ b/website/index.md
@@ -93,7 +93,7 @@ and can [connect to almost any LLM](https://aider.chat/docs/llms.html).
 - Edit files in your editor while chatting with aider,
 and it will always use the latest version.
 Pair program with AI.
-- Add images to the chat (GPT-4o, GPT-4 Turbo, etc).
+- Add images to the chat (GPT-4o, GPT-4 Turbo, Claude 3.5 Sonnet, etc).
 - Add URLs to the chat and aider will read their content.
 - [Code with your voice](https://aider.chat/docs/voice.html).
 


### PR DESCRIPTION
I've made changes to the settings in Claude 3.5 Sonnet to allow for `/add` -ing images.

Tested in vertex_ai/claude-3-5-sonnet@20240620.

Fixes #751

This does not involve handling in openrouter, but a configuration change in Sonnet itself, so it does not add support for openrouter/openai/gpt-4-turbo as described in #556.