### PR TITLE
/read-only by glob pattern

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1140,9 +1140,7 @@ class Commands:
 
         all_matched_files = set()
 
-        parsed_args = parse_quoted_filenames(args)
-        force = "--force" in parsed_args
-        filenames = [fn for fn in parsed_args if fn != "--force"]
+        filenames = parse_quoted_filenames(args)
         for word in filenames:
             # Expand the home directory if the path starts with "~"
             expanded_path = os.path.expanduser(word)
@@ -1150,25 +1148,18 @@ class Commands:
 
             if Path(abs_path).exists():
                 if Path(abs_path).is_file():
-                    # add individually listed files outside repo even without --force
+                    # add individually listed files outside repo
                     all_matched_files.add(abs_path)
                     continue
                 # an existing dir, escape any special chars so they won't be globs
                 abs_path = re.sub(r"([\*\?\[\]])", r"[\1]", abs_path)
 
-            if force:
-                # with a --force option, glob all, not only non-ignored repository files
-                matched_files: list[str] = [
-                    str(path)
-                    for match in Path("/").glob(os.path.relpath(abs_path, "/"))
-                    for path in expand_subdir(match)
-                ]
-            else:
-                # without a --force option, glob only non-ignored repository files
-                matched_files: list[str] = [
-                    self.coder.abs_root_path(path)
-                    for path in self.glob_filtered_to_repo(word)
-                ]
+            # glob only non-ignored repository files
+            # note: there's no way to force globbing all files in the repository
+            matched_files: list[str] = [
+                self.coder.abs_root_path(path)
+                for path in self.glob_filtered_to_repo(word)
+            ]
             if matched_files:
                 all_matched_files.update(matched_files)
                 continue

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -1008,6 +1008,53 @@ class TestCommands(TestCase):
             # Check if all files were removed from abs_read_only_fnames
             self.assertEqual(len(coder.abs_read_only_fnames), 0)
 
+    def test_cmd_read_only_drop_directory(self):
+        with GitTemporaryDirectory():
+            io = InputOutput(pretty=False, yes=False)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            # Create a directory and add files to it using pathlib
+            Path("test_dir").mkdir()
+            Path("test_dir/another_dir").mkdir()
+            Path("test_dir/test_file1.txt").write_text("Test file 1")
+            Path("test_dir/test_file2.txt").write_text("Test file 2")
+            Path("test_dir/another_dir/test_file.txt").write_text("Test file 3")
+
+            # Call the cmd_read_only method with a directory
+            commands.cmd_read_only("test_dir test_dir/test_file2.txt")
+
+            # Check if the files have been added to the read-only files
+            self.assertIn(str(Path("test_dir/test_file1.txt").resolve()), coder.abs_read_only_fnames)
+            self.assertIn(str(Path("test_dir/test_file2.txt").resolve()), coder.abs_read_only_fnames)
+            self.assertIn(str(Path("test_dir/another_dir/test_file.txt").resolve()), coder.abs_read_only_fnames)
+
+            commands.cmd_drop("test_dir/another_dir")
+            self.assertIn(str(Path("test_dir/test_file1.txt").resolve()), coder.abs_read_only_fnames)
+            self.assertIn(str(Path("test_dir/test_file2.txt").resolve()), coder.abs_read_only_fnames)
+            self.assertNotIn(str(Path("test_dir/another_dir/test_file.txt").resolve()), coder.abs_read_only_fnames)
+
+            # Issue #139 /add problems when cwd != git_root
+
+            # remember the proper abs path to this file
+            abs_fname = str(Path("test_dir/another_dir/test_file.txt").resolve())
+
+            # chdir to someplace other than git_root
+            Path("side_dir").mkdir()
+            os.chdir("side_dir")
+
+            # add it via it's git_root referenced name
+            commands.cmd_read_only("test_dir/another_dir/test_file.txt")
+
+            # it should be there, but was not in v0.10.0
+            self.assertIn(abs_fname, coder.abs_read_only_fnames)
+
+            # drop it via it's git_root referenced name
+            commands.cmd_drop("test_dir/another_dir/test_file.txt")
+
+            # it should be there, but was not in v0.10.0
+            self.assertNotIn(abs_fname, coder.abs_read_only_fnames)
+
     def test_cmd_read_only_with_tilde_path(self):
         with GitTemporaryDirectory():
             io = InputOutput(pretty=False, yes=False)

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -181,6 +181,31 @@ class TestCommands(TestCase):
         # Check if the text file has not been added to the chat session
         self.assertNotIn(str(Path("test.txt").resolve()), coder.abs_fnames)
 
+    def test_cmd_read_only_with_glob_patterns(self):
+        # Initialize the Commands and InputOutput objects
+        io = InputOutput(pretty=False, yes=True)
+
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+
+        # Create some test files
+        with open("test1.py", "w") as f:
+            f.write("print('test1')")
+        with open("test2.py", "w") as f:
+            f.write("print('test2')")
+        with open("test.txt", "w") as f:
+            f.write("test")
+
+        # Call the cmd_read_only method with a glob pattern
+        commands.cmd_read_only("*.py")
+
+        # Check if the Python files have been added to the read-only files
+        self.assertIn(str(Path("test1.py").resolve()), coder.abs_read_only_fnames)
+        self.assertIn(str(Path("test2.py").resolve()), coder.abs_read_only_fnames)
+
+        # Check if the text file has not been added to the read-only files
+        self.assertNotIn(str(Path("test.txt").resolve()), coder.abs_read_only_fnames)
+
     def test_cmd_add_no_match(self):
         # yes=False means we will *not* create the file when it is not found
         io = InputOutput(pretty=False, yes=False)


### PR DESCRIPTION
_**Work in progress – basic use cases verified, need tests for more complex scenarios**_
- [x] remove `--force` option
- [ ] debug [Windows test failure](/paul-gauthier/aider/actions/runs/11093040291/job/30818824151?pr=1176) (see [comment below](/paul-gauthier/aider/pull/1176#issuecomment-2383207855))

---

This patch modifies the `/read-only` command to behave like `/add` by accepting directories and glob patterns.

A directory is walked recursively and all files added:
```shell
/read-only tests
```
This would add all files in `tests/`, `tests/basic/`, `tests/browser/`, `tests/fixtures/`, `tests/help/` and `tests/scrape/` when run in the Aider source tree.

A glob pattern is matched against and all matching files added:
```shell
/read-only aider/repo*.py
```
This would add `aider/repo.py` and `aider/repomap.py` if used in the Aider source tree.

Both of the above limit to non-ignored files in the repository ~~unless a `--force` option is provided~~. Non-glob explicit file paths still are added to the read-only file set ~~even if `--force` is not specified~~. So:
```shell
/read-only ~/example.py        # will add since this is not a glob pattern
/read-only dist/aider_chat-0.52.2.dev0-py3-none-any.whl  # will add since this is not a glob pattern
/read-only dist/*.whl          # won't add by glob pattern since `dist/` is in `.gitignore`
/read-only dist                # wont add by directory name since `dist/` is in `.gitignore`
```