### PR TITLE
feature: Show voice-format when voice first initialised

### DIFF
--- a/aider/voice.py
+++ b/aider/voice.py
@@ -47,6 +47,10 @@ class Voice:
         if audio_format not in ["wav", "mp3", "webm"]:
             raise ValueError(f"Unsupported audio format: {audio_format}")
         self.audio_format = audio_format
+        if self.audio_format == "wav":
+            print("Using default WAV format. Use --voice-format webm (or mp3) for 90% smaller uploads.")
+        else:
+            print(f"Using audio format: {self.audio_format}")
 
     def callback(self, indata, frames, time, status):
         """This is called (from a separate thread) for each audio block."""


### PR DESCRIPTION
This provides the user with:

- An easy way to confirm that voice compression is being used.
- Notification that it's an option (if default wav being used).

It is only shown the first time `/voice` is used in a session so doesn't add a lot of noise to output.

```
> /voice

Initializing sound device...
Using default WAV format. Use --voice-format webm (or mp3) for 90% smaller uploads.
Recording, press ENTER when done... 4.6sec ░░████████
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
> /voice

Recording, press ENTER when done... 1.6sec ░░████████
```