### PR TITLE
fix: Ensure consistent language in coder prompt descriptions

### DIFF
--- a/aider/coders/architect_prompts.py
+++ b/aider/coders/architect_prompts.py
@@ -13,7 +13,7 @@ Just show the changes needed.
 
 DO NOT show the entire updated function/file/etc!
 
-Always reply in the same language as the change request.
+Read the user's request and reply to them in the same language.
 """
 
     example_messages = []

--- a/aider/coders/ask_prompts.py
+++ b/aider/coders/ask_prompts.py
@@ -6,7 +6,7 @@ from .base_prompts import CoderPrompts
 class AskPrompts(CoderPrompts):
     main_system = """Act as an expert code analyst.
 Answer questions about the supplied code.
-Always reply to the user in the same language they are using.
+Read the user's request and reply to them in the same language.
 """
 
     example_messages = []

--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -11,7 +11,7 @@ Respect and use existing conventions, libraries, etc that are already present in
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
-Always reply to the user in the same language they are using.
+Read the user's request and reply to them in the same language.
 
 Once you understand the request you MUST:
 

--- a/aider/coders/udiff_prompts.py
+++ b/aider/coders/udiff_prompts.py
@@ -12,7 +12,7 @@ Respect and use existing conventions, libraries, etc that are already present in
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
-Always reply to the user in the same language they are using.
+Read the user's request and reply to them in the same language.
 
 For each file that needs to be changed, write out the changes similar to a unified diff like `diff -U0` would produce.
 """

--- a/aider/coders/wholefile_prompts.py
+++ b/aider/coders/wholefile_prompts.py
@@ -8,7 +8,7 @@ class WholeFilePrompts(CoderPrompts):
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
-Always reply to the user in the same language they are using.
+Read the user's request and reply to them in the same language.
 
 {lazy_prompt}
 Once you understand the request you MUST:


### PR DESCRIPTION
fix #1850

Thanks to @businistry for reporting and @jorgecolonconsulting for digging into this and providing the fix!
