### PR TITLE
docs: update instructions for AWS Bedrock pipx installation to include boto3 inject step

### DIFF
--- a/aider/website/docs/install/pipx.md
+++ b/aider/website/docs/install/pipx.md
@@ -26,6 +26,13 @@ Install [pipx](https://pipx.pypa.io/stable/) then just do:
 pipx install aider-chat
 ```
 
+## pipx installation with AWS Bedrock provider
+The AWS Bedrock provider requires the `boto3` package in order to function correctly. To use aider installed via `pipx` with AWS Bedrock, you must add the `boto3` dependency to aider's virtual environment by running
+
+```
+pipx inject aider boto3
+```
+
 
 ## pipx on replit
 

--- a/aider/website/docs/install/pipx.md
+++ b/aider/website/docs/install/pipx.md
@@ -26,13 +26,6 @@ Install [pipx](https://pipx.pypa.io/stable/) then just do:
 pipx install aider-chat
 ```
 
-## pipx installation with AWS Bedrock provider
-The AWS Bedrock provider requires the `boto3` package in order to function correctly. To use aider installed via `pipx` with AWS Bedrock, you must add the `boto3` dependency to aider's virtual environment by running
-
-```
-pipx inject aider boto3
-```
-
 
 ## pipx on replit
 

--- a/aider/website/docs/llms/bedrock.md
+++ b/aider/website/docs/llms/bedrock.md
@@ -39,6 +39,14 @@ export AWS_PROFILE=your-profile
 You can add these to your 
 [.env file](/docs/config/dotenv.html).
 
+## Bedrock with `pipx` installation
+
+The AWS Bedrock provider requires the `boto3` package in order to function correctly. To use aider installed via `pipx` with AWS Bedrock, you must add the `boto3` dependency to aider's virtual environment by running
+
+```
+pipx inject aider boto3
+```
+
 
 ## Running Aider with Bedrock
 


### PR DESCRIPTION
This change hopefully avoids confusion like in #1582. (I faced the same issue 😄)