### PR TITLE
add format_files_for_input and compute_minimal_fileids to beautify the shown session context

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -5,8 +5,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
-from jinja2.lexer import TOKEN_DOT
-from numpy.distutils.misc_util import rel_path
 from prompt_toolkit.completion import Completer, Completion, ThreadedCompleter
 from prompt_toolkit.cursor_shapes import ModalCursorShapeConfig
 from prompt_toolkit.enums import EditingMode

--- a/aider/io.py
+++ b/aider/io.py
@@ -5,6 +5,8 @@ from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
+from jinja2.lexer import TOKEN_DOT
+from numpy.distutils.misc_util import rel_path
 from prompt_toolkit.completion import Completer, Completion, ThreadedCompleter
 from prompt_toolkit.cursor_shapes import ModalCursorShapeConfig
 from prompt_toolkit.enums import EditingMode
@@ -358,7 +360,8 @@ class InputOutput:
         rel_fnames = list(rel_fnames)
         show = ""
         if rel_fnames:
-            show = " ".join(rel_fnames) + "\n"
+            rel_read_only_fnames = [os.path.relpath(fname, root) for fname in (abs_read_only_fnames or [])]
+            show = self.format_files_for_input(rel_fnames, rel_read_only_fnames)
         if edit_format:
             show += edit_format
         show += "> "
@@ -695,3 +698,59 @@ class InputOutput:
                     " Permission denied."
                 )
                 self.chat_history_file = None  # Disable further attempts to write
+
+    def format_files_for_input(self, rel_fnames, rel_read_only_fnames):
+        minimal_unique_fileids = self.compute_minimal_fileids(rel_fnames)
+
+        # Format the filename for display in the prompt, with disambiguating path
+        # in parentheses, if needed.
+        def format_minimal_fileid(fname):
+            pth = Path(minimal_unique_fileids[fname])
+            if len(pth.parts) > 1:
+                return f"{pth.name} ({'/'.join(pth.parts[:-1])})"
+            else:
+                return pth.name
+
+        read_only_files = []
+        for full_path in (rel_read_only_fnames or []):
+            name = format_minimal_fileid(full_path)
+            read_only_files.append(f" R {name}")
+
+        editable_files = []
+        for full_path in rel_fnames:
+            if full_path in rel_read_only_fnames:
+                continue
+            name = format_minimal_fileid(full_path)
+            editable_files.append(f"   {name}")
+
+        return "\n".join(read_only_files + editable_files) + '\n'
+
+    def compute_minimal_fileids(self, rel_fnames):
+        # First pass: group files with the same name
+        grouped_fnames = defaultdict(list)
+        for full_path in rel_fnames:
+            pth = Path(full_path)
+            fname = pth.name
+            grouped_fnames[fname].append(list(pth.parts))
+
+        # Second pass: compute the shared prefix of each group of files.
+        shared_prefixes = {}
+        for fname, paths in grouped_fnames.items():
+            shared_prefix = []
+            while all(len(path) > 1 for path in paths):
+                next_part = paths[0][0]
+                if not all(path[0] == next_part for path in paths):
+                    break
+                shared_prefix.append(next_part)
+                paths = [path[1:] for path in paths]
+            shared_prefixes[fname] = Path(*shared_prefix)
+
+        # Third pass: subtract the shared prefix from the full path to get the minimal unique id
+        minimal_unique_ids = {}
+        for full_path in rel_fnames:
+            pth = Path(full_path)
+            fname = pth.name
+            prefix = shared_prefixes[fname]
+            minimal_unique_ids[full_path] = str(pth.relative_to(prefix))
+
+        return minimal_unique_ids


### PR DESCRIPTION
Before: it's not easy to tell what is in the context (filenames get truncated, and even when they don't it is difficult to read long paths because the most important part is at the end of a variable-length string), read-only files are not identifiable from the context shown.
```
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
> /add src/backend/base/langflow/base/chains/model.py src/backend/base/langflow/base/document_transformers/model.py src/
backend/base/langflow/base/embeddings/model.py

Added /home/jonathan/Projects/langflow/src/backend/base/langflow/base/document_transformers/model.py to the chat
Added /home/jonathan/Projects/langflow/src/backend/base/langflow/base/chains/model.py to the chat
Added /home/jonathan/Projects/langflow/src/backend/base/langflow/base/embeddings/model.py to the chat
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
src/backend/base/langflow/base/chains/model.py src/backend/base/langflow/base/document_transformers/model.py src/backend
> /read src/backend/base/langflow/base/langchain_utilities/model.py

Added src/backend/base/langflow/base/langchain_utilities/model.py to read-only files.
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
src/backend/base/langflow/base/chains/model.py src/backend/base/langflow/base/document_transformers/model.py src/backend
>
```

After: only enough of the filename is shown to uniquely identify it in your session.  When the name itself is not enough, the name is still shown first.  Filenames are never truncated and read-only files are easily identified.
```
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
> /add src/backend/base/langflow/base/chains/model.py src/backend/base/langflow/base/document_transformers/model.py src/backend/ba
se/langflow/base/embeddings/model.py

Added /home/jonathan/Projects/langflow/src/backend/base/langflow/base/document_transformers/model.py to the chat
Added /home/jonathan/Projects/langflow/src/backend/base/langflow/base/embeddings/model.py to the chat
Added /home/jonathan/Projects/langflow/src/backend/base/langflow/base/chains/model.py to the chat
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
   model.py (chains)
   model.py (document_transformers)
   model.py (embeddings)
> /read src/backend/base/langflow/base/langchain_utilities/model.py

Added src/backend/base/langflow/base/langchain_utilities/model.py to read-only files.
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
 R model.py (langchain_utilities)
   model.py (chains)
   model.py (document_transformers)
   model.py (embeddings)
>
```

Objection: this uses more vertical space than packing it all into one line.

Response: it is easier for the eye to scan a compact vertical list (lots of research on this), vertical space is cheap via mousewheel.

fixes #1675