### PR TITLE
changed prompt: replace all to replace first

### DIFF
--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -159,7 +159,7 @@ Use the *FULL* file path, as shown to you by the user.
 Every *SEARCH* section must *EXACTLY MATCH* the existing file content, character for character, including all comments, docstrings, etc.
 If the file contains code or other data wrapped/escaped in json/xml/quotes or other containers, you need to propose edits to the literal contents of the file, including the container markup.
 
-*SEARCH/REPLACE* blocks will replace the *first* matching occurrences.
+*SEARCH/REPLACE* blocks will replace the *first* matching occurrence.
 Include enough lines to make the SEARCH blocks uniquely match the lines to change.
 
 Keep *SEARCH/REPLACE* blocks concise.

--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -159,7 +159,7 @@ Use the *FULL* file path, as shown to you by the user.
 Every *SEARCH* section must *EXACTLY MATCH* the existing file content, character for character, including all comments, docstrings, etc.
 If the file contains code or other data wrapped/escaped in json/xml/quotes or other containers, you need to propose edits to the literal contents of the file, including the container markup.
 
-*SEARCH/REPLACE* blocks will replace *all* matching occurrences.
+*SEARCH/REPLACE* blocks will replace the *first* matching occurrences.
 Include enough lines to make the SEARCH blocks uniquely match the lines to change.
 
 Keep *SEARCH/REPLACE* blocks concise.


### PR DESCRIPTION
i think this prompt is wrong. 
SEARCH/REPLACE blocks will only replace the first occurrence not all.

edit: fixed typo in sentence after first change