### PR TITLE
doc: fix leftover /clipboard mention

### DIFF
--- a/aider/website/_includes/multi-line.md
+++ b/aider/website/_includes/multi-line.md
@@ -2,4 +2,4 @@ You can send long, multi-line messages in the chat in a few ways:
   - Paste a multi-line message directly into the chat.
   - Enter `{` alone on the first line to start a multiline message and `}` alone on the last line to end it.
   - Use Meta-ENTER to start a new line without sending the message (Esc+ENTER in some environments).
-  - Use `/clipboard` to paste text from the clipboard into the chat.
+  - Use `/paste` to paste text from the clipboard into the chat.

--- a/aider/website/docs/config/adv-model-settings.md
+++ b/aider/website/docs/config/adv-model-settings.md
@@ -550,7 +550,7 @@ cog.out("```\n")
   use_repo_map: true
   use_system_prompt: true
   use_temperature: true
-  weak_model_name: openrouter/anthropic/claude-3-haiku-20240307
+  weak_model_name: openrouter/anthropic/claude-3-haiku
 - accepts_images: true
   cache_control: true
   caches_by_default: false
@@ -568,7 +568,7 @@ cog.out("```\n")
   use_repo_map: true
   use_system_prompt: true
   use_temperature: true
-  weak_model_name: openrouter/anthropic/claude-3-haiku-20240307
+  weak_model_name: openrouter/anthropic/claude-3-haiku:beta
 - accepts_images: true
   cache_control: false
   caches_by_default: false


### PR DESCRIPTION
See title.

Includes doc fixes for the last emergency OpenRouter weak model fix.