### PR TITLE
AIDER-1977: Add a new argument litellm-extra-params

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -186,6 +186,12 @@ def get_parser(default_config_files, git_root):
         help="Specify a file with context window and costs for unknown models",
     )
     group.add_argument(
+        "--litellm-extra-params",
+        metavar="LITELLM_EXTRA_PARAMS",
+        default=None,
+        help="Specify global litellm extra parameters as JSON string",
+    )
+    group.add_argument(
         "--verify-ssl",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -99,6 +99,7 @@ class Coder:
         io=None,
         from_coder=None,
         summarize_from_coder=True,
+        litellm_extra_params=None,
         **kwargs,
     ):
         import aider.coders as coders
@@ -149,7 +150,7 @@ class Coder:
 
         for coder in coders.__all__:
             if hasattr(coder, "edit_format") and coder.edit_format == edit_format:
-                res = coder(main_model, io, **kwargs)
+                res = coder(main_model, io, litellm_extra_params=litellm_extra_params, **kwargs)
                 res.original_kwargs = dict(kwargs)
                 return res
 
@@ -263,6 +264,7 @@ class Coder:
         num_cache_warming_pings=0,
         suggest_shell_commands=True,
         chat_language=None,
+        litellm_extra_params=None,
     ):
         self.chat_language = chat_language
         self.commit_before_message = []

--- a/aider/main.py
+++ b/aider/main.py
@@ -582,6 +582,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         weak_model=args.weak_model,
         editor_model=args.editor_model,
         editor_edit_format=args.editor_edit_format,
+        litellm_extra_params=args.litellm_extra_params,
     )
 
     if args.verbose:
@@ -674,6 +675,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             num_cache_warming_pings=args.cache_keepalive_pings,
             suggest_shell_commands=args.suggest_shell_commands,
             chat_language=args.chat_language,
+            litellm_extra_params=args.litellm_extra_params,
         )
     except ValueError as err:
         io.tool_error(str(err))

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -166,6 +166,14 @@ cog.outl("```")
 ## Specify the .env file to load (default: .env in git root)
 #env-file: .env
 
+## Add a JSON blob of extra parameters to pass to LiteLLM.  Handy for global setting overrides.
+#litellm-extra-params: >
+#   {
+#     "extra_headers": {
+#       "header_name": "header_value"
+#     }
+#   }
+
 #################
 # Cache Settings:
 


### PR DESCRIPTION
Add a new config argument `litellm-extra-params` that takes a string of JSON that should be used as a global litellm config base.  Values set in the model settings will override those in the global config.