### PR TITLE
feat: add workflow to check for generating website files

### DIFF
--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -39,7 +39,7 @@ jobs:
         bash ./scripts/update-docs.sh
         
         # Compare the original and potentially updated website folders
-        if ! diff --recursive website_original aider/website ; then
+        if ! diff --recursive --unified website_original aider/website ; then
           echo "Error: Changes were detected in the website folder."
           echo "Please run ./scripts/update-docs.sh locally and commit the changes."
           rm -rf website_original

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -39,9 +39,10 @@ jobs:
         bash ./scripts/update-docs.sh
         
         # Compare the original and potentially updated website folders
-        if ! diff --recursive website_original aider/website > /dev/null; then
+        if ! diff --recursive website_original aider/website ; then
           echo "Error: Changes were detected in the website folder."
           echo "Please run ./scripts/update-docs.sh locally and commit the changes."
+          rm -rf website_original
           exit 1
         else
           echo "No changes were detected. Workflow passed."

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -27,8 +27,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install cog
         pip install .
+        pip install cogapp==3.4.1
 
     - name: Check if website should have been generated
       run: |

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -36,7 +36,7 @@ jobs:
         cp -a aider/website website_original
         
         # Run the update script
-        bash ./scripts/update-docs.sh
+        bash ./scripts/update-docs-workflow.sh
         
         # Compare the original and potentially updated website folders
         if ! diff --recursive --unified website_original aider/website ; then

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -1,0 +1,51 @@
+name: Website files check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install cog
+        pip install .
+
+    - name: Check if website should have been generated
+      run: |
+        # Create a copy of the original website folder
+        cp -a aider/website website_original
+        
+        # Run the update script
+        bash ./scripts/update-docs.sh
+        
+        # Compare the original and potentially updated website folders
+        if ! diff --recursive website_original aider/website > /dev/null; then
+          echo "Error: Changes were detected in the website folder."
+          echo "Please run ./scripts/update-docs.sh locally and commit the changes."
+          exit 1
+        else
+          echo "No changes were detected. Workflow passed."
+        fi
+        
+        # Clean up the temporary folder
+        rm -rf website_original

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -27,6 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install .
         pip install -r requirements/requirements-dev.txt
 
     - name: Check if website should have been generated

--- a/.github/workflows/website-check.yml
+++ b/.github/workflows/website-check.yml
@@ -27,8 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .
-        pip install cogapp==3.4.1
+        pip install -r requirements/requirements-dev.txt
 
     - name: Check if website should have been generated
       run: |

--- a/scripts/update-docs-workflow.sh
+++ b/scripts/update-docs-workflow.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# exit when any command fails
+set -e
+
+if [ -z "$1" ]; then
+  ARG=-r
+else
+  ARG=$1
+fi
+
+# README.md before index.md, because index.md uses cog to include README.md
+cog $ARG \
+    README.md \
+    aider/website/index.md \
+    aider/website/HISTORY.md \
+    aider/website/docs/usage/commands.md \
+    aider/website/docs/languages.md \
+    aider/website/docs/config/dotenv.md \
+    aider/website/docs/config/options.md \
+    aider/website/docs/config/aider_conf.md \
+    aider/website/docs/config/adv-model-settings.md \
+    aider/website/docs/more/infinite-output.md


### PR DESCRIPTION
This workflow checks if website files should have been generated.

Problems I noticed while building this:
- https://github.com/Aider-AI/aider/blob/main/aider/website/docs/llms/other.md?plain=1#L50 this relies on https://github.com/BerriAI/litellm existing alongside the aider repository
- https://github.com/Aider-AI/aider/blob/main/aider/website/docs/leaderboards/index.md?plain=1#L314 this does not work inside the workflow as it always returns a fresh modified date

These two problematic files get excluded via a fresh script for this workflow (should get removed if those two problems above get addressed).

Update: Improved wording a bit.