### PR TITLE
fix broken link to individual contributor agreement doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ ensure that your contributions can be integrated smoothly.
 ## Licensing
 
 Before contributing a PR, please review our
-[Individual Contributor License Agreement](/docs/legal/contributor-agreement.html).
+[Individual Contributor License Agreement](/aider/website/docs/legal/contributor-agreement.md).
 All contributors will be asked to complete the agreement as part of the PR process.
 
 ## Setting up a Development Environment


### PR DESCRIPTION
I was going through the contributing doc and noticed the link was broken.