### PR TITLE
fix: Impossible to /read-only from another working directory

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1170,7 +1170,7 @@ class Commands:
         # First collect all expanded paths
         for pattern in filenames:
             expanded_pattern = expanduser(pattern)
-            expanded_paths = glob.glob(expanded_pattern, recursive=True)
+            expanded_paths = glob.glob(expanded_pattern, recursive=True, root_dir=self.coder.root)
             if not expanded_paths:
                 self.io.tool_error(f"No matches found for: {pattern}")
             else:


### PR DESCRIPTION
Looks like a bug with this Note: in-chat filenames are always relative to the git working dir, not the current working dir.

```bash
➜  aider-pull-2126 git:(main) tree
.
└── subdir
    └── test_read_only_file.txt

2 directories, 1 file
➜  aider-pull-2126 git:(main) cd subdir
➜  subdir git:(main) aider
────────────────────────────────────────────────────────────────────────────────────
Update git name with: git config user.name "Your Name"
Update git email with: git config user.email "you@example.com"
Add .aider*, .env to .gitignore (recommended)? (Y)es/(N)o [Yes]: n
Aider v0.60.0
Main model: anthropic/claude-3-5-sonnet-20241022 with diff edit format, infinite output
Weak model: claude-3-haiku-20240307
Git repo: ../.git with 1 files
Repo-map: using 1024 tokens, auto refresh
Use /help <question> for help, run "aider --help" to see cmd line args
Note: in-chat filenames are always relative to the git working dir, not the current working dir.
Cur working dir: /private/tmp/aider-pull-2126/subdir
Git working dir: /private/tmp/aider-pull-2126
────────────────────────────────────────────────────────────────────────────────────
> /read-only subdir/test_read_only_file.txt

No matches found for: subdir/test_read_only_file.txt
────────────────────────────────────────────────────────────────────────────────────
> /read-only test_read_only_file.txt

Not a file or directory: /private/tmp/aider-pull-2126/test_read_only_file.txt
```