### PR TITLE
Fix uncaught ValueError in <frozen ntpath> line 783

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1656,7 +1656,7 @@ class Coder:
         try:
             return os.path.relpath(fname, self.root)
         except ValueError:
-            return fname
+            return os.path.abspath(fname)
 
     def get_inchat_relative_files(self):
         files = [self.get_rel_fname(fname) for fname in self.abs_fnames]

--- a/aider/io.py
+++ b/aider/io.py
@@ -360,7 +360,7 @@ class InputOutput:
         show = ""
         if rel_fnames:
             rel_read_only_fnames = [
-                get_rel_fname(fname, root) for fname in (abs_read_only_fnames or [])
+                self.get_rel_fname(fname, root) for fname in (abs_read_only_fnames or [])
             ]
             show = self.format_files_for_input(rel_fnames, rel_read_only_fnames)
         if edit_format:
@@ -713,9 +713,8 @@ class InputOutput:
 
         return "\n".join(read_only_files + editable_files) + "\n"
 
-
-def get_rel_fname(fname, root):
-    try:
-        return os.path.relpath(fname, root)
-    except ValueError:
-        return fname
+    def get_rel_fname(self, fname, root):
+        try:
+            return os.path.relpath(fname, root)
+        except ValueError:
+            return os.path.abspath(fname)


### PR DESCRIPTION
Fixes #2136

Fix ValueError related to path mounts in `get_input` methods.

* Modify `get_input` method in `aider/io.py` to handle different drive paths by using `os.path.abspath` instead of `os.path.relpath`.
* Add `get_rel_fname` method in `aider/io.py` to handle different drive paths.
* Modify `get_rel_fname` method in `aider/coders/base_coder.py` to use `os.path.abspath` instead of `os.path.relpath` for different drive paths.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Aider-AI/aider/issues/2136?shareId=9d26fed1-2edd-4396-a2d9-eff301f5a00b).