### PR TITLE
Fix uncaught AttributeError in pathlib.py line 953

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -653,7 +653,8 @@ class Commands:
                 raw_matched_files = [Path(pattern)]
             else:
                 try:
-                    raw_matched_files = list(Path(self.coder.root).glob(pattern))
+                    # Using glob.glob instead of Path.glob to avoid AttributeError
+                    raw_matched_files = glob.glob(os.path.join(self.coder.root, pattern))
                 except (IndexError, AttributeError):
                     raw_matched_files = []
         except ValueError as err:


### PR DESCRIPTION
Fixes #1946

Fix uncaught `AttributeError` in `pathlib.py` line 953

* Replace `Path(self.coder.root).glob(pattern)` with `glob.glob(os.path.join(self.coder.root, pattern))` in `glob_filtered_to_repo` method in `aider/commands.py`.
* Add a comment explaining the reason for using `glob.glob` instead of `Path.glob`.
* Import `glob` and `os` modules at the top of the file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Aider-AI/aider/issues/1946?shareId=0e2cd114-dbc4-4f72-be62-b805e22ac7ac).