### PR TITLE
bug fix and test improvements

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -296,14 +296,14 @@ class InputOutput:
             with open(str(filename), "rb") as image_file:
                 encoded_string = base64.b64encode(image_file.read())
                 return encoded_string.decode("utf-8")
-        except OSError as err:
-            self.tool_error(f"{filename}: unable to read: {err}")
-            return
         except FileNotFoundError:
             self.tool_error(f"{filename}: file not found error")
             return
         except IsADirectoryError:
             self.tool_error(f"{filename}: is a directory")
+            return
+        except OSError as err:
+            self.tool_error(f"{filename}: unable to read: {err}")
             return
         except Exception as e:
             self.tool_error(f"{filename}: {e}")

--- a/aider/io.py
+++ b/aider/io.py
@@ -13,7 +13,8 @@ from prompt_toolkit.key_binding import KeyBindings
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
 from prompt_toolkit.styles import Style
-from pygments.lexers import MarkdownLexer, guess_lexer_for_filename
+from pygments.lexers import guess_lexer_for_filename
+from pygments.lexers.markup import MarkdownLexer
 from pygments.token import Token
 from rich.console import Console
 from rich.markdown import Markdown

--- a/aider/io.py
+++ b/aider/io.py
@@ -437,8 +437,8 @@ class InputOutput:
             return
         FileHistory(self.input_history_file).append_string(inp)
         # Also add to the in-memory history if it exists
-        if hasattr(self, "session") and hasattr(self.session, "history"):
-            self.session.history.append_string(inp)
+        if hasattr(self, "prompt_session") and hasattr(self.prompt_session, "history"):
+            self.prompt_session.history.append_string(inp)
 
     def get_input_history(self):
         if not self.input_history_file:

--- a/aider/io.py
+++ b/aider/io.py
@@ -316,9 +316,6 @@ class InputOutput:
         try:
             with open(str(filename), "r", encoding=self.encoding) as f:
                 return f.read()
-        except OSError as err:
-            self.tool_error(f"{filename}: unable to read: {err}")
-            return
         except FileNotFoundError:
             self.tool_error(f"{filename}: file not found error")
             return
@@ -328,6 +325,9 @@ class InputOutput:
         except UnicodeError as e:
             self.tool_error(f"{filename}: {e}")
             self.tool_error("Use --encoding to set the unicode encoding.")
+            return
+        except OSError as err:
+            self.tool_error(f"{filename}: unable to read: {err}")
             return
 
     def write_text(self, filename, content):

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 from prompt_toolkit.completion import CompleteEvent
 from prompt_toolkit.document import Document
+from prompt_toolkit.history import InMemoryHistory
 
 from aider.dump import dump  # noqa: F401
 from aider.io import AutoCompleter, ConfirmGroup, InputOutput
@@ -257,6 +258,34 @@ class TestInputOutput(unittest.TestCase):
         self.assertFalse(result)
         self.assertEqual(mock_input.call_count, 2)
         self.assertNotIn(("Do you want to proceed?", None), io.never_prompts)
+
+    @patch('aider.io.FileHistory')
+    def test_add_to_input_history(self, mock_file_history):
+        # Setup
+        io = InputOutput(input_history_file='test_history.txt', fancy_input=True)
+        io.prompt_session = MagicMock()
+        io.prompt_session.history = InMemoryHistory()
+
+        # Test adding to history
+        test_input = "test input"
+        io.add_to_input_history(test_input)
+
+        # Assert that FileHistory.append_string was called
+        mock_file_history.return_value.append_string.assert_called_once_with(test_input)
+
+        # Assert that prompt_session.history.append_string was called
+        self.assertIn(test_input, io.prompt_session.history.get_strings())
+
+    def test_add_to_input_history_no_prompt_session(self):
+        # Setup
+        io = InputOutput(input_history_file='test_history.txt', fancy_input=False)
+
+        # Test adding to history
+        test_input = "test input"
+        io.add_to_input_history(test_input)
+
+        # Assert that the method doesn't raise an exception
+        # when prompt_session is not initialized
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Reworked imports for pygments MarkdownLexer to remove linter complaints

Reordered expections for two methods based on linter recommendations

Added new test cases to the tests/basic/test_io.py file to cover the add_to_input_history method of the InputOutput class. Specifically:

 1 We imported the InMemoryHistory from prompt_toolkit.history to use in our tests.
 2 We added two new test methods:
    • test_add_to_input_history: This test checks if the method correctly adds input to both the file history and the in-memory history when fancy_input is True.
    • test_add_to_input_history_no_prompt_session: This test ensures the method doesn't raise an exception when prompt_session is not initialized (when fancy_input is False).
 3 In the aider/io.py file, we updated the add_to_input_history method to use self.prompt_session instead of self.session, fixing a linting issue and making the code consistent with the rest of the class.
 4 All 11 tests in test_io.py are now passing, indicating that our changes are working as expected and haven't broken any existing functionality.