### PR TITLE
Configure o1 model settings to date-stamped versions

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -778,6 +778,11 @@ class Model(ModelSettings):
             self.examples_as_sys_msg = True
             self.reminder = "user"
 
+        if "o1-" in model:
+            self.use_system_prompt = False
+            self.use_temperature = False
+            self.streaming = False
+
         # use the defaults
         if self.edit_format == "diff":
             self.use_repo_map = True


### PR DESCRIPTION
## Motivation

This PR aims to

- Resolve #2179.

## Description of the changes

- Configured all models containing `o1-` to apply specific settings.

## Additional Notes

It is possible to address this issue by applying settings similar to those implemented at

https://github.com/Aider-AI/aider/blob/ed4ad45e3d7114d129eff32afcd260044ea07fdb/aider/models.py#L537-L632

for all currently available  o1 models, namely:
- azure/o1-mini,
- azure/o1-mini-2024-09-12,
- azure/o1-preview,
- azure/o1-preview-2024-09-12,
- o1-mini,
- o1-mini-2024-09-12,
- o1-preview,
- o1-preview-2024-09-12,
- openai/o1-mini,
- openai/o1-mini-2024-09-12,
- openai/o1-preview,
- openai/o1-preview-2024-09-12,
- openrouter/openai/o1-mini,
- openrouter/openai/o1-mini-2024-09-12,
- openrouter/openai/o1-preview, and
- openrouter/openai/o1-preview-2024-09-12.

However, this method involves configuring multiple settings, and any change to a new date version would require manual adjustments again.
