### PR TITLE
AIDER-1977: Add a new argument litellm-extra-headers

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -194,6 +194,12 @@ def get_parser(default_config_files, git_root):
         help="Specify a file with context window and costs for unknown models",
     )
     group.add_argument(
+        "--litellm-extra-headers",
+        metavar="LITELLM_EXTRA_HEADERS",
+        default=None,
+        help="Specify extra headers for litellm as a semicolon-separated list, e.g., 'Header1:Value1;Header2:Value2'",
+    )
+    group.add_argument(
         "--verify-ssl",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/aider/main.py
+++ b/aider/main.py
@@ -641,6 +641,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         weak_model=args.weak_model,
         editor_model=args.editor_model,
         editor_edit_format=args.editor_edit_format,
+        litellm_extra_headers=args.litellm_extra_headers,
     )
 
     if args.verbose:

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -86,6 +86,9 @@
 ## Specify a file with context window and costs for unknown models
 #model-metadata-file: .aider.model.metadata.json
 
+## Specify extra headers for litellm as a semicolon-separated list, e.g., 'Header1:Value1;Header2:Value2'
+#litellm-extra-headers: xxx
+
 ## Verify the SSL cert when connecting to models (default: True)
 #verify-ssl: true
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -90,6 +90,9 @@
 ## Specify a file with context window and costs for unknown models
 #AIDER_MODEL_METADATA_FILE=.aider.model.metadata.json
 
+## Specify extra headers for litellm as a semicolon-separated list, e.g., 'Header1:Value1;Header2:Value2'
+#AIDER_LITELLM_EXTRA_HEADERS=
+
 ## Verify the SSL cert when connecting to models (default: True)
 #AIDER_VERIFY_SSL=true
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -142,6 +142,9 @@ cog.outl("```")
 ## Specify a file with context window and costs for unknown models
 #model-metadata-file: .aider.model.metadata.json
 
+## Specify extra headers for litellm as a semicolon-separated list, e.g., 'Header1:Value1;Header2:Value2'
+#litellm-extra-headers: xxx
+
 ## Verify the SSL cert when connecting to models (default: True)
 #verify-ssl: true
 

--- a/aider/website/docs/config/dotenv.md
+++ b/aider/website/docs/config/dotenv.md
@@ -132,6 +132,9 @@ cog.outl("```")
 ## Specify a file with context window and costs for unknown models
 #AIDER_MODEL_METADATA_FILE=.aider.model.metadata.json
 
+## Specify extra headers for litellm as a semicolon-separated list, e.g., 'Header1:Value1;Header2:Value2'
+#AIDER_LITELLM_EXTRA_HEADERS=
+
 ## Verify the SSL cert when connecting to models (default: True)
 #AIDER_VERIFY_SSL=true
 

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -32,6 +32,7 @@ usage: aider [-h] [--openai-api-key] [--anthropic-api-key] [--model]
              [--openai-api-type] [--openai-api-version]
              [--openai-api-deployment-id] [--openai-organization-id]
              [--model-settings-file] [--model-metadata-file]
+             [--litellm-extra-headers]
              [--verify-ssl | --no-verify-ssl] [--edit-format]
              [--architect] [--weak-model] [--editor-model]
              [--editor-edit-format]
@@ -189,6 +190,10 @@ Environment variable: `AIDER_MODEL_SETTINGS_FILE`
 Specify a file with context window and costs for unknown models  
 Default: .aider.model.metadata.json  
 Environment variable: `AIDER_MODEL_METADATA_FILE`  
+
+### `--litellm-extra-headers LITELLM_EXTRA_HEADERS`
+Specify extra headers for litellm as a semicolon-separated list, e.g., 'Header1:Value1;Header2:Value2'  
+Environment variable: `AIDER_LITELLM_EXTRA_HEADERS`  
 
 ### `--verify-ssl`
 Verify the SSL cert when connecting to models (default: True)  


### PR DESCRIPTION
[Fixes issue 1977](https://github.com/Aider-AI/aider/issues/1977)

My company uses a centralized LLM proxy, so we need a way to provide global litellm headers that apply to all model requests.  Here's a simple new config option that takes in a list of headers to add for all models.