### PR TITLE
Remove `analytics-disable` option from sample.aider.conf.yml

### DIFF
--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -277,9 +277,6 @@
 ## Specify a file to log analytics events
 #analytics-log: xxx
 
-## Permanently disable analytics
-#analytics-disable: false
-
 #################
 # Other Settings:
 


### PR DESCRIPTION
Remove `analytics-disable` option from sample.aider.conf.yml

reason:
> `analytics-disable` no longer exits.

https://github.com/Aider-AI/aider/issues/2253#issuecomment-2457388490

#2253
