### PR TITLE
fix: typo pytest filename

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -187,8 +187,8 @@ pytest
 You can also run specific test files or test cases by providing the file path or test name:
 
 ```
-pytest aider/tests/test_coder.py
-pytest aider/tests/test_coder.py::TestCoder::test_specific_case
+pytest tests/basic/test_coder.py
+pytest tests/basic/test_coder.py::TestCoder::test_specific_case
 ```
 
 #### Continuous Integration


### PR DESCRIPTION
I followed contribution file to run tests. I realized that some paths doesnt match current test files.
Here a patch to correct them