### PR TITLE
this enabled /read-only /path/to/sources.jar!/org/subdir/Component.java to be used.

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -13,9 +13,11 @@ import sys
 import threading
 import time
 import traceback
+import zipfile
 from collections import defaultdict
 from datetime import datetime
 from json.decoder import JSONDecodeError
+from os.path import expanduser
 from pathlib import Path
 from typing import List
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -364,14 +364,14 @@ class Coder:
                 self.io.tool_warning(f"Skipping {fname} that matches aiderignore spec.")
                 continue
 
-            if not fname.exists():
+            if not self.io.exists(fname):
                 if utils.touch_file(fname):
                     self.io.tool_output(f"Creating empty file {fname}")
                 else:
                     self.io.tool_warning(f"Can not create {fname}, skipping.")
                     continue
 
-            if not fname.is_file():
+            if not self.io.is_file(fname):
                 self.io.tool_warning(f"Skipping {fname} that is not a normal file.")
                 continue
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -213,7 +213,7 @@ class Commands:
         try:
             return cmd_method(args)
         except ANY_GIT_ERROR as err:
-            self.io.tool_error(f"Unable to complete {cmd_name}: {err}")
+            self.io.tool_error(f"Unable to complete1 {cmd_name}: {err}")
 
     def matching_commands(self, inp):
         words = inp.strip().split()
@@ -705,8 +705,8 @@ class Commands:
                 self.io.tool_warning(f"Skipping {fname} due to aiderignore or --subtree-only.")
                 continue
 
-            if self.io.exists(fname):
-                if self.io.is_file(fname):
+            if os.path.exists(fname):
+                if os.path.isfile(fname):
                     all_matched_files.add(str(fname))
                     continue
                 # an existing dir, escape any special chars so they won't be globs

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1189,14 +1189,10 @@ class Commands:
             
             # Check if this is a JAR path with internal file
             if '!' in expanded_pattern:
-                jar_path, internal_path = expanded_pattern.split('!', 1)
-                if internal_path.startswith('/'):
-                    internal_path = internal_path[1:]
-                jar_path = expanduser(jar_path)
-                if os.path.isfile(jar_path):
+                if self.io.exists(expanded_pattern):
                     all_paths.append(expanded_pattern)  # Keep the full JAR!internal_path
                 else:
-                    self.io.tool_error(f"JAR file not found: {jar_path}")
+                    self.io.tool_error(f"JAR file or internal file not found: {expanded_pattern}")
                 continue
 
             # Handle regular files and directories

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -705,8 +705,8 @@ class Commands:
                 self.io.tool_warning(f"Skipping {fname} due to aiderignore or --subtree-only.")
                 continue
 
-            if fname.exists():
-                if fname.is_file():
+            if self.io.exists(fname):
+                if self.io.is_file(fname):
                     all_matched_files.add(str(fname))
                     continue
                 # an existing dir, escape any special chars so they won't be globs

--- a/aider/io.py
+++ b/aider/io.py
@@ -330,7 +330,7 @@ class InputOutput:
                 internal_path = internal_path[1:]  # Remove leading slash
         
             # Check if JAR file exists and is valid
-            if not os.path.isfile(jar_path) or not self.is_jar_file(jar_path):
+            if not os.path.isfile(jar_path):
                 return False
         
             # Check if internal file exists in JAR

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -766,7 +766,7 @@ class TestCommands(TestCase):
                         self.fail(f"No matching read-only command found for {external_file_path}")
 
                 # Clear the current session
-                commands.cmd_recmd_reset("")
+                commands.cmd_reset("")
                 self.assertEqual(len(coder.abs_fnames), 0)
                 self.assertEqual(len(coder.abs_read_only_fnames), 0)
 

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -765,7 +765,7 @@ class TestCommands(TestCase):
                         self.fail(f"No matching read-only command found for {external_file_path}")
 
                 # Clear the current session
-                commands.cmd_reset("")
+                commands.cmd_recmd_reset("")
                 self.assertEqual(len(coder.abs_fnames), 0)
                 self.assertEqual(len(coder.abs_read_only_fnames), 0)
 

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -903,6 +903,33 @@ class TestCommands(TestCase):
                 )
             )
 
+    def test_cmd_read_only_with_jar_file(self):
+        with GitTemporaryDirectory() as repo_dir:
+            io = InputOutput(pretty=False, fancy_input=False, yes=False)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+
+            # Create a JAR file with a Markdown file inside
+            jar_path = Path(repo_dir) / "test_docs.jar"
+            with zipfile.ZipFile(jar_path, 'w') as jar:
+                jar.writestr('README.md', '# Test Documentation\n\nThis is a test markdown file.')
+
+            # Add the JAR file to read-only files
+            commands.cmd_read_only(str(jar_path) + '!README.md')
+
+            # Check if the internal file was added to read-only files
+            self.assertEqual(len(coder.abs_read_only_fnames), 1)
+            self.assertTrue(
+                any(
+                    str(jar_path) + '!README.md' in fname
+                    for fname in coder.abs_read_only_fnames
+                )
+            )
+
+            # Verify the content can be read
+            content = io.read_text(str(jar_path) + '!README.md')
+            self.assertEqual(content, '# Test Documentation\n\nThis is a test markdown file.')
+
     def test_cmd_read_only_with_glob_pattern(self):
         with GitTemporaryDirectory() as repo_dir:
             io = InputOutput(pretty=False, fancy_input=False, yes=False)

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -4,6 +4,7 @@ import re
 import shutil
 import sys
 import tempfile
+import zipfile
 from io import StringIO
 from pathlib import Path
 from unittest import TestCase, mock


### PR DESCRIPTION

To allow the passing of some Java API to LLM, it is convenient to paste some files from jars (java libraries / archives). They often come with sources in separate files, jar = zip.

Currently it is not possible to add content of file within zip file to context. This patch enables this in /read-only command.

Patch provides io.exists and io.is_file and io.read_text which are used in the code paths used for readonly files, which are compatible with original, but add jar support

Added test for this case.

Tests are passing.

