### PR TITLE
add documentation for /editor configuration

### DIFF
--- a/aider/website/_includes/multi-line.md
+++ b/aider/website/_includes/multi-line.md
@@ -4,7 +4,7 @@ You can send long, multi-line messages in the chat in a few ways:
   - Enter `{tag` (where "tag" is any sequence of letters/numbers) and end with `tag}`. This is useful when you need to include closing braces `}` in your message.
   - Use Meta-ENTER to start a new line without sending the message (Esc+ENTER in some environments).
   - Use `/paste` to paste text from the clipboard into the chat.
-  - Use the `/editor` command to open your editor to create the next chat message.
+  - Use the `/editor` command to open your editor to create the next chat message. *(see [Editor configuration](/docs/config/editor.html)) to customize the editor*
 
 Example with a tag:
 ```

--- a/aider/website/docs/config/editor.md
+++ b/aider/website/docs/config/editor.md
@@ -1,0 +1,121 @@
+---
+parent: Configuration
+nav_order: 15
+description: How to configure a custom editor for aider's /editor command
+---
+
+# Editor configuration
+
+Aider allows you to configure your preferred text editor for use with the `/editor` command. The editor must be capable of running in "blocking mode", meaning the command line will wait until you close the editor before proceeding.
+
+## Environment variables
+
+Aider checks the following environment variables in order to determine which editor to use:
+
+1. `AIDER_EDITOR`
+2. `VISUAL`
+3. `EDITOR`
+
+## Default behavior
+
+If no editor is configured, aider will use these platform-specific defaults:
+
+- Windows: `notepad`
+- macOS: `vim`
+- Linux/Unix: `vi`
+
+## Using a custom editor
+
+You can set your preferred editor in your shell's configuration file (e.g., `.bashrc`, `.zshrc`):
+
+```bash
+export AIDER_EDITOR=vim
+```
+
+## Popular Editors by Platform
+
+### macOS
+
+1. **vim**
+   ```bash
+   export AIDER_EDITOR=vim
+   ```
+
+2. **Emacs**
+   ```bash
+   export AIDER_EDITOR=emacs
+   ```
+
+3. **VSCode**
+   ```bash
+   export AIDER_EDITOR="code --wait"
+   ```
+
+4. **Sublime Text**
+   ```bash
+   export AIDER_EDITOR="subl --wait"
+   ```
+
+5. **BBEdit**
+   ```bash
+   export AIDER_EDITOR="bbedit --wait"
+   ```
+
+### Linux
+
+1. **vim**
+   ```bash
+   export AIDER_EDITOR=vim
+   ```
+
+2. **Emacs**
+   ```bash
+   export AIDER_EDITOR=emacs
+   ```
+
+3. **nano**
+   ```bash
+   export AIDER_EDITOR=nano
+   ```
+
+4. **VSCode**
+   ```bash
+   export AIDER_EDITOR="code --wait"
+   ```
+
+5. **Sublime Text**
+   ```bash
+   export AIDER_EDITOR="subl --wait"
+   ```
+
+### Windows
+
+1. **Notepad**
+   ```bat
+   set AIDER_EDITOR=notepad
+   ```
+
+2. **VSCode**
+   ```bat
+   set AIDER_EDITOR="code --wait"
+   ```
+
+3. **Notepad++**
+   ```bat
+   set AIDER_EDITOR="notepad++ -multiInst -notabbar -nosession -noPlugin -waitForClose"
+   ```
+
+## Editor command arguments
+
+Some editors require specific command-line arguments to operate in blocking mode. The `--wait` flag (or equivalent) is commonly used to make the editor block until the file is closed.
+
+## Troubleshooting
+
+If you encounter issues with your editor not blocking (returning to the prompt immediately), verify that:
+
+1. Your editor supports blocking mode
+2. You've included the necessary command-line arguments for blocking mode
+3. The editor command is properly quoted if it contains spaces or special characters, e.g.:
+   ```bash
+   export AIDER_EDITOR="code --wait"
+   ```

--- a/aider/website/docs/usage/commands.md
+++ b/aider/website/docs/usage/commands.md
@@ -24,7 +24,7 @@ cog.out(get_help_md())
 | **/copy** | Copy the last assistant message to the clipboard |
 | **/diff** | Display the diff of changes since the last message |
 | **/drop** | Remove files from the chat session to free up context space |
-| **/editor** | Open an editor to write a prompt |
+| **/editor** | Open an editor to write a prompt *(see [Editor configuration](/docs/config/editor.html)) to customize the editor* |
 | **/exit** | Exit the application |
 | **/git** | Run a git command (output excluded from chat) |
 | **/help** | Ask questions about aider |


### PR DESCRIPTION
I put the new doc under the `config` section in the docs -- seemed like the most sensible place, then linked it in a few places.

I should add that I did *not* test all the example commands with the various editors -- I did run them through Perplexity for verification, I'm guessing they are correct.