### PR TITLE
allow editor to be set via config file

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -603,6 +603,12 @@ def get_parser(default_config_files, git_root):
         help="Specify the language to use in the chat (default: None, uses system settings)",
     )
     group.add_argument(
+        "--editor",
+        metavar="EDITOR_COMMAND",
+        default=None,
+        help="Specify the CLI command used to open an editor when using /editor",
+    )
+    group.add_argument(
         "--version",
         action="version",
         version=f"%(prog)s {__version__}",

--- a/aider/main.py
+++ b/aider/main.py
@@ -616,6 +616,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     is_first_run = is_first_run_of_new_version(io, verbose=args.verbose)
     check_and_load_imports(io, is_first_run, verbose=args.verbose)
 
+    if args.editor:
+        os.environ["AIDER_EDITOR"] = args.editor
+
     if args.anthropic_api_key:
         os.environ["ANTHROPIC_API_KEY"] = args.anthropic_api_key
 

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -302,6 +302,9 @@
 ## Use VI editing mode in the terminal (default: False)
 #vim: false
 
+## Specify the CLI command used to open an editor when using /editor
+#editor: xxx
+
 ## Specify the language to use in the chat (default: None, uses system settings)
 #chat-language: xxx
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -291,6 +291,9 @@
 ## Use VI editing mode in the terminal (default: False)
 #AIDER_VIM=false
 
+## Specify the CLI command used to open an editor when using /editor
+#AIDER_EDITOR=
+
 ## Specify the language to use in the chat (default: None, uses system settings)
 #AIDER_CHAT_LANGUAGE=
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -358,6 +358,9 @@ cog.outl("```")
 ## Use VI editing mode in the terminal (default: False)
 #vim: false
 
+## Specify the CLI command used to open an editor when using /editor
+#editor: xxx
+
 ## Specify the language to use in the chat (default: None, uses system settings)
 #chat-language: xxx
 

--- a/aider/website/docs/config/dotenv.md
+++ b/aider/website/docs/config/dotenv.md
@@ -333,6 +333,9 @@ cog.outl("```")
 ## Use VI editing mode in the terminal (default: False)
 #AIDER_VIM=false
 
+## Specify the CLI command used to open an editor when using /editor
+#AIDER_EDITOR=
+
 ## Specify the language to use in the chat (default: None, uses system settings)
 #AIDER_CHAT_LANGUAGE=
 

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -63,7 +63,7 @@ usage: aider [-h] [--openai-api-key] [--anthropic-api-key] [--model]
              [--auto-lint | --no-auto-lint] [--test-cmd]
              [--auto-test | --no-auto-test] [--test]
              [--analytics | --no-analytics] [--analytics-log]
-             [--analytics-disable] [--file] [--read] [--vim]
+             [--analytics-disable] [--file] [--read] [--vim] [--editor]
              [--chat-language] [--version] [--just-check-update]
              [--check-update | --no-check-update]
              [--show-release-notes | --no-show-release-notes]
@@ -540,6 +540,11 @@ Environment variable: `AIDER_READ`
 Use VI editing mode in the terminal (default: False)  
 Default: False  
 Environment variable: `AIDER_VIM`  
+
+### `--editor`
+Specify the CLI command used to open an editor when using `/editor`  
+Default: OS-dependant  
+Environment variable: `AIDER_EDITOR`  
 
 ### `--chat-language CHAT_LANGUAGE`
 Specify the language to use in the chat (default: None, uses system settings)  


### PR DESCRIPTION
Also adds editor doc to all sample configs.

Given that `editor.py` reads the `AIDER_EDITOR` environment variable directly, and I didn't see any mechanism to store the value of `args.editor` cleanly, I elected to simply set the `AIDER_EDITOR` environment variable manually in `main.py` to handle the setup. I tested this for all cases (CLI arg, env var, config file, nothing set), and it works properly in all cases.