### PR TITLE
fix: Correct typo in base_coder by removing duplicate 'in'

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -962,7 +962,7 @@ class Coder:
         if self.chat_language:
             language = self.chat_language
         else:
-            language = "in the same language they are using"
+            language = "the same language they are using"
 
         prompt = prompt.format(
             fence=self.fence,


### PR DESCRIPTION
This corrects a grammatical error in the system prompt within `base_coder.py`. The `language` variable was previously set as:

    language = "in the same language they are using"

Which resulted in the prompt:

    "Always reply to the user IN IN the same language they are using."