### PR TITLE
Feature: Add current branch name substitution in commit prompt

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -178,6 +178,7 @@ class GitRepo:
             return os.path.relpath(self.repo.git_dir, os.getcwd())
         except (ValueError, OSError):
             return self.repo.git_dir
+
     def get_commit_message(self, diffs, context):
         diffs = "# Diffs:\n" + diffs
 
@@ -187,13 +188,13 @@ class GitRepo:
         content += diffs
 
         system_content = self.commit_prompt or prompts.commit_system
-        if system_content and '{{' in system_content:
+        if system_content and "{{" in system_content:
             try:
                 variables = {
-                    'branch_name': self.get_current_branch() or '',
+                    "branch_name": self.get_current_branch() or "",
                 }
                 for var_name, value in variables.items():
-                    template_var = '{{' + var_name + '}}'
+                    template_var = "{{" + var_name + "}}"
                     system_content = system_content.replace(template_var, value)
             except:
                 pass  # If template substitution fails, use original content

--- a/tests/basic/test_repo_prompt.py
+++ b/tests/basic/test_repo_prompt.py
@@ -1,6 +1,8 @@
 import unittest
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
+
 from aider.repo import GitRepo
+
 
 class TestGitRepoPrompt(unittest.TestCase):
     def setUp(self):
@@ -24,4 +26,4 @@ class TestGitRepoPrompt(unittest.TestCase):
         calls = mock_send.call_args_list
         self.assertEqual(len(calls), 1)
         messages = calls[0][0][1]
-        self.assertEqual(messages[0]['content'], "Generate commit for branch feature-123. Changes:")
+        self.assertEqual(messages[0]["content"], "Generate commit for branch feature-123. Changes:")

--- a/tests/basic/test_repo_prompt.py
+++ b/tests/basic/test_repo_prompt.py
@@ -1,0 +1,27 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from aider.repo import GitRepo
+
+class TestGitRepoPrompt(unittest.TestCase):
+    def setUp(self):
+        self.repo = GitRepo()
+        self.repo.repo = MagicMock()
+        self.repo.models = [MagicMock()]
+
+    @patch("aider.repo.simple_send_with_retries")
+    def test_commit_message_with_branch_template(self, mock_send):
+        # Setup
+        self.repo.repo.active_branch.name = "feature-123"
+        self.repo.commit_prompt = "Generate commit for branch {{branch_name}}. Changes:"
+        mock_send.return_value = "feat: add new feature"
+
+        # Test
+        result = self.repo.get_commit_message("some diff", "some context")
+
+        # Verify
+        self.assertEqual(result, "feat: add new feature")
+        # Verify the template was substituted in the system content
+        calls = mock_send.call_args_list
+        self.assertEqual(len(calls), 1)
+        messages = calls[0][0][1]
+        self.assertEqual(messages[0]['content'], "Generate commit for branch feature-123. Changes:")


### PR DESCRIPTION
This PR add current branch name substitution in commit message prompt template

Example of usage: 
```
  You are an expert software engineer that generates concise, \
  one-line Git commit messages based on the provided diffs.
  Review the provided context and diffs which are about to be committed to a git repo.
  Review the diffs carefully.
  Extract the task number from the branch name (e.g., from 'feature/san-8-XXXX' extract '8').
  Generate a one-line commit message for those changes.
  The commit message should be structured as follows: (<task_number>) <type>: <description>
  Use these for <type>: fix, feat, build, chore, ci, docs, style, refactor, perf, test

  Ensure the commit message:
  - Include task number in parentheses at the start (e.g., "(8)") from current branch name
  - Starts with the appropriate type prefix after the task number
  - Is in the imperative mood (e.g., "Add feature" not "Added feature" or "Adding feature")
  - Does not exceed 72 characters including the task number

  Reply only with the one-line commit message, without any additional text, explanations, \
  or line breaks.

  current branch name: {{branch_name}}
  ```