### PR TITLE
feat: Add env_var and metavar to --editor argument in args.py

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -740,6 +740,8 @@ def get_parser(default_config_files, git_root):
     )
     group.add_argument(
         "--editor",
+        metavar="EDITOR",
+        env_var="AIDER_EDITOR",
         help="Specify which editor to use for the /editor command",
     )
 


### PR DESCRIPTION
Hello! On my Windows `/editor` command opens default editor, notepad, I want it to open vscode instead.

`aider --editor "C:/Users/popstas/AppData/Local/Programs/Microsoft VS Code/Code.exe"` - works, but I prefer to add this to config.