### PR TITLE
Add a link to mermaid.live render for mermaid markdown

### DIFF
--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -2,6 +2,10 @@
 
 import io
 import time
+import base64
+import json
+import zlib
+import re
 
 from rich.console import Console
 from rich.live import Live
@@ -53,6 +57,35 @@ class MarkdownStream:
             self.mdargs = mdargs
         else:
             self.mdargs = dict()
+            
+        self.mermaid_pattern = re.compile(r'```mermaid\n(.*?)\n```', re.DOTALL)
+
+    def _generate_mermaid_link(self, graph_markdown):
+        """Generate a mermaid.live link for the given graph markdown"""
+        def js_string_to_byte(data):
+            return bytes(data, 'ascii')
+
+        def js_bytes_to_string(data):
+            return data.decode('ascii')
+
+        def js_btoa(data):
+            return base64.b64encode(data)
+
+        def pako_deflate(data):
+            compress = zlib.compressobj(9, zlib.DEFLATED, 15, 8, zlib.Z_DEFAULT_STRATEGY)
+            compressed_data = compress.compress(data)
+            compressed_data += compress.flush()
+            return compressed_data
+
+        j_graph = {
+            "code": graph_markdown,
+            "mermaid": {"theme": "default"}
+        }
+        byte_str = js_string_to_byte(json.dumps(j_graph))
+        deflated = pako_deflate(byte_str)
+        d_encode = js_btoa(deflated)
+        link = 'http://mermaid.live/view#pako:' + js_bytes_to_string(d_encode)
+        return link
 
         self.live = Live(Text(""), refresh_per_second=1.0 / self.min_delay)
         self.live.start()
@@ -70,10 +103,23 @@ class MarkdownStream:
             return
         self.when = now
 
+        # Process mermaid diagrams
+        processed_text = text
+        for match in self.mermaid_pattern.finditer(text):
+            mermaid_code = match.group(1)
+            link = self._generate_mermaid_link(mermaid_code)
+            # Add the link after the mermaid block
+            diagram_end = match.end()
+            processed_text = (
+                processed_text[:diagram_end] + 
+                f"\n\n[View diagram]({link})\n" +
+                processed_text[diagram_end:]
+            )
+
         string_io = io.StringIO()
         console = Console(file=string_io, force_terminal=True)
 
-        markdown = Markdown(text, **self.mdargs)
+        markdown = Markdown(processed_text, **self.mdargs)
 
         console.print(markdown)
         output = string_io.getvalue()

--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -59,6 +59,8 @@ class MarkdownStream:
             self.mdargs = dict()
             
         self.mermaid_pattern = re.compile(r'```mermaid\n(.*?)\n```', re.DOTALL)
+        self.live = Live(Text(""), refresh_per_second=1.0 / self.min_delay)
+        self.live.start()
 
     def _generate_mermaid_link(self, graph_markdown):
         """Generate a mermaid.live link for the given graph markdown"""
@@ -86,9 +88,6 @@ class MarkdownStream:
         d_encode = js_btoa(deflated)
         link = 'http://mermaid.live/view#pako:' + js_bytes_to_string(d_encode)
         return link
-
-        self.live = Live(Text(""), refresh_per_second=1.0 / self.min_delay)
-        self.live.start()
 
     def __del__(self):
         if self.live:


### PR DESCRIPTION
When you ask the model to generate a diagram:

<img width="562" alt="Screenshot 2024-11-25 at 2 35 23 PM" src="https://github.com/user-attachments/assets/87aed51f-f66f-4e39-a300-4a911341caa4">

It will generate a link you can CMD-Click in iTerm to view it in the browser:

<img width="1354" alt="Screenshot 2024-11-25 at 2 35 46 PM" src="https://github.com/user-attachments/assets/fe4cfeb5-c6a4-42ba-ae47-9c7b18dc5143">
