### PR TITLE
Added --no-auto-scraping flag 

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -664,6 +664,12 @@ def get_parser(default_config_files, git_root):
         default=False,
     )
     group.add_argument(
+        "--no-auto-scrape",
+        action="store_true",
+        help="Disable automatic web scraping when using --yes-always (default: False)",
+        default=False,
+    )
+    group.add_argument(
         "--show-repo-map",
         action="store_true",
         help="Print the repo map and exit (debug)",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -93,6 +93,7 @@ class Coder:
     suggest_shell_commands = True
     ignore_mentions = None
     chat_language = None
+    no_auto_scrape = None
 
     @classmethod
     def create(
@@ -267,12 +268,14 @@ class Coder:
         num_cache_warming_pings=0,
         suggest_shell_commands=True,
         chat_language=None,
+        no_auto_scrape=False,
     ):
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
 
         self.event = self.analytics.event
         self.chat_language = chat_language
+        self.no_auto_scrape = no_auto_scrape
         self.commit_before_message = []
         self.aider_commit_hashes = set()
         self.rejected_urls = set()
@@ -767,7 +770,9 @@ class Coder:
             return self.commands.run(inp)
 
         self.check_for_file_mentions(inp)
-        self.check_for_urls(inp)
+
+        if not (self.no_auto_scrape):
+            self.check_for_urls(inp)
 
         return inp
 
@@ -827,7 +832,6 @@ class Coder:
                     added_urls.append(url)
                 else:
                     self.rejected_urls.add(url)
-
         return added_urls
 
     def keyboard_interrupt(self):

--- a/aider/io.py
+++ b/aider/io.py
@@ -197,6 +197,7 @@ class InputOutput:
         llm_history_file=None,
         editingmode=EditingMode.EMACS,
         fancy_input=True,
+        no_auto_scrape=False,
     ):
         self.placeholder = None
         self.never_prompts = set()
@@ -225,6 +226,7 @@ class InputOutput:
             self.pretty = False
 
         self.yes = yes
+        self.no_auto_scrape = no_auto_scrape
 
         self.input_history_file = input_history_file
         self.llm_history_file = llm_history_file

--- a/aider/main.py
+++ b/aider/main.py
@@ -751,6 +751,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             num_cache_warming_pings=args.cache_keepalive_pings,
             suggest_shell_commands=args.suggest_shell_commands,
             chat_language=args.chat_language,
+            no_auto_scrape=args.no_auto_scrape,
         )
     except ValueError as err:
         io.tool_error(str(err))

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -502,6 +502,11 @@ Environment variable: `AIDER_AUTO_TEST`
 Aliases:
   - `--auto-test`
   - `--no-auto-test`
+  
+### `--no-auto-scrape`
+Disable automatic web scraping even when using --yes-always (default: False)
+Default: False
+Environment variable: `AIDER_NO_AUTO_SCRAPE`
 
 ### `--test`
 Run tests and fix problems found  


### PR DESCRIPTION
Added --no-auto-scraping flag, which disables auto web scraping, as users have indicated demand for:

Addresses: 
"Add option to disable external web scraping": https://github.com/Aider-AI/aider/issues/2187
and tangentially: "Extend aiders --yes option": https://github.com/Aider-AI/aider/issues/1375

Tested: 

Without flag:
<img width="1065" alt="Screenshot 2024-11-25 at 6 28 51 PM" src="https://github.com/user-attachments/assets/0e54e06b-7886-42d3-8067-bf0a0955aef8">

With flag:
<img width="1154" alt="Screenshot 2024-11-25 at 6 29 13 PM" src="https://github.com/user-attachments/assets/326bde12-46bc-4e18-aa50-7e84830aeac0">

Added to --help:
<img width="920" alt="Screenshot 2024-11-25 at 6 32 47 PM" src="https://github.com/user-attachments/assets/82499c54-4270-401c-8ad9-93ae98b3c0a0">



