### PR TITLE
Create tree-sitter-swift-tags.scm

### DIFF
--- a/aider/queries/tree-sitter-swift-tags.scm
+++ b/aider/queries/tree-sitter-swift-tags.scm
@@ -1,0 +1,51 @@
+(class_declaration
+  name: (type_identifier) @name) @definition.class
+
+(protocol_declaration
+  name: (type_identifier) @name) @definition.interface
+
+(class_declaration
+    (class_body
+        [
+            (function_declaration
+                name: (simple_identifier) @name
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name)
+            )
+            (init_declaration "init" @name)
+            (deinit_declaration "deinit" @name)
+        ]
+    )
+) @definition.method
+
+(protocol_declaration
+    (protocol_body
+        [
+            (protocol_function_declaration
+                name: (simple_identifier) @name
+            )
+            (subscript_declaration
+                (parameter (simple_identifier) @name)
+            )
+            (init_declaration "init" @name)
+        ]
+    )
+) @definition.method
+
+(class_declaration
+    (class_body
+        [
+            (property_declaration
+                (pattern (simple_identifier) @name)
+            )
+        ]
+    )
+) @definition.property
+
+(property_declaration
+    (pattern (simple_identifier) @name)
+) @definition.property
+
+(function_declaration
+    name: (simple_identifier) @name) @definition.function

--- a/aider/website/docs/languages.md
+++ b/aider/website/docs/languages.md
@@ -99,6 +99,7 @@ cog.out(get_supported_languages_md())
 | scala                | .scala               |          |   ✓    |
 | sql                  | .sql                 |          |   ✓    |
 | sqlite               | .sqlite              |          |   ✓    |
+| swift                | .swift               |    ✓     |        |
 | toml                 | .toml                |          |   ✓    |
 | tsq                  | .tsq                 |          |   ✓    |
 | typescript           | .ts                  |    ✓     |   ✓    |


### PR DESCRIPTION
from: https://github.com/alex-pinkus/tree-sitter-swift/blob/main/queries/tags.scm

Added swift lang support.
I want to make `--watch-files` work and i'm also going to make PR to grep-ast

error example i want to fix:
```bash
Added Sources/App/Jobs/EventStatusUpdateJob.swift to the chat

Processing your request...
Unknown language for Sources/App/Jobs/EventStatusUpdateJob.swift
Traceback (most recent call last):
  File ".pyenv/versions/3.12.1/lib/python3.12/site-packages/aider/io.py", line 490, in get_input
    cmd = self.file_watcher.process_changes()
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".pyenv/versions/3.12.1/lib/python3.12/site-packages/aider/watch.py", line 197, in process_changes
    context = TreeContext(
              ^^^^^^^^^^^^
  File ".pyenv/versions/3.12.1/lib/python3.12/site-packages/grep_ast/grep_ast.py", line 44, in __init__
    raise ValueError(f"Unknown language for {filename}")
ValueError: Unknown language for Sources/App/Jobs/EventStatusUpdateJob.swift

```