### PR TITLE
Adds .zsh filetypes to watch-files

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -28,7 +28,6 @@ def is_source_file(path: Path) -> bool:
         ".yaml",
         ".yml",
         ".zsh",
-        ".zshrc",
         # // style comments
         ".js",
         ".ts",

--- a/aider/watch.py
+++ b/aider/watch.py
@@ -27,6 +27,8 @@ def is_source_file(path: Path) -> bool:
         ".bash",
         ".yaml",
         ".yml",
+        ".zsh",
+        ".zshrc",
         # // style comments
         ".js",
         ".ts",


### PR DESCRIPTION
- This add aider's `--watch-file` functionality to `.zsh` file extensions.
- Partly fixes #2550 but won't work for `.zshrc`