### PR TITLE
Add support for Gemini API key in command line and config file

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -45,6 +45,12 @@ def get_parser(default_config_files, git_root):
         help="Specify the Anthropic API key",
     )
     group.add_argument(
+        "--gemini-api-key",
+        metavar="GEMINI_API_KEY",
+        env_var="GEMINI_API_KEY",
+        help="Specify the Google Gemini API key",
+    )
+    group.add_argument(
         "--model",
         metavar="MODEL",
         default=None,

--- a/aider/main.py
+++ b/aider/main.py
@@ -649,6 +649,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if args.anthropic_api_key:
         os.environ["ANTHROPIC_API_KEY"] = args.anthropic_api_key
 
+    if args.gemini_api_key:
+        os.environ["GEMINI_API_KEY"] = args.gemini_api_key
+
     if args.openai_api_key:
         os.environ["OPENAI_API_KEY"] = args.openai_api_key
     if args.openai_api_base:


### PR DESCRIPTION
This allows users to use Gemini models by passing their API key via the `--gemini-api-key` command line argument, or by setting it in the `.aider.conf.yml`