### PR TITLE
Fixed /chat-mode architect no description

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -103,6 +103,7 @@ class Commands:
                 ("help", "Get help about using aider (usage, config, troubleshoot)."),
                 ("ask", "Ask questions about your code without making any changes."),
                 ("code", "Ask for changes to your code (using the best edit format)."),
+                ("architect", "Discuss high-level design and architecture."),
             ]
         )
 


### PR DESCRIPTION
Fixed my own issue #2566

Output after change:
```
Aider v0.67.1.dev+less
Main model: gpt-4o-2024-08-06 with diff edit format
Weak model: gpt-4o-mini
Git repo: .git with 406 files
Repo-map: using 1024 tokens, auto refresh
───────────────────────────────────────────────────────
> /chat-mode                                           

Chat mode should be one of these:

- help         : Get help about using aider (usage, 
config, troubleshoot).
- ask          : Ask questions about your code without 
making any changes.
- code         : Ask for changes to your code (using 
the best edit format).
- architect    : Discuss high-level design and 
architecture.

Or a valid edit format:

- diff         : A coder that uses search/replace 
blocks for code modifications.
- diff-fenced  : A coder that uses fenced 
search/replace blocks for code modifications.
- editor-diff  : No description
- editor-whole : No description
- udiff        : A coder that uses unified diff format 
for code modifications.
- whole        : A coder that operates on entire files 
for code modifications.
```