### PR TITLE
Add support for customized tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <!-- Edit README.md, not index.md -->
 
 # Aider is AI pair programming in your terminal
@@ -88,7 +87,7 @@ Pair program with AI.
 - [Add images to the chat](https://aider.chat/docs/usage/images-urls.html) (GPT-4o, Claude 3.5 Sonnet, etc).
 - [Add URLs to the chat](https://aider.chat/docs/usage/images-urls.html) and aider will read their content.
 - [Code with your voice](https://aider.chat/docs/usage/voice.html).
-
+- Create and integrate custom tools with Aider using the `--custom-tool` argument.
 
 ## Top tier performance
 
@@ -134,3 +133,51 @@ projects like django, scikitlearn, matplotlib, etc.
 - *Hands down, this is the best AI coding assistant tool so far.* -- [IndyDevDan](https://www.youtube.com/watch?v=MPYFPvxfGZs)
 - *[Aider] changed my daily coding workflows. It's mind-blowing how a single Python application can change your life.* -- [maledorak](https://discord.com/channels/1131200896827654144/1131200896827654149/1258453375620747264)
 - *Best agent for actual dev work in existing codebases.* -- [Nick Dobos](https://twitter.com/NickADobos/status/1690408967963652097?s=20)
+
+## Creating and Integrating Custom Tools
+
+Aider allows users to create and integrate custom tools to enhance its functionality. This can be done using the `--custom-tool` argument.
+
+### Example: Web Search Integration
+
+To create a custom tool for web search integration, follow these steps:
+
+1. Create a Python file for your custom tool, e.g., `web_search_tool.py`:
+
+```python
+from aider.coders.custom_tool import CustomTool
+
+class WebSearchTool(CustomTool):
+    def execute(self, query):
+        # Implement your web search logic here
+        return f"Results for query: {query}"
+```
+
+2. Use the `--custom-tool` argument to specify your custom tool when running Aider:
+
+```sh
+aider --custom-tool web_search_tool.WebSearchTool
+```
+
+### Example: Code Repository Search
+
+To create a custom tool for code repository search, follow these steps:
+
+1. Create a Python file for your custom tool, e.g., `repo_search_tool.py`:
+
+```python
+from aider.coders.custom_tool import CustomTool
+
+class RepoSearchTool(CustomTool):
+    def execute(self, query):
+        # Implement your code repository search logic here
+        return f"Results for repository query: {query}"
+```
+
+2. Use the `--custom-tool` argument to specify your custom tool when running Aider:
+
+```sh
+aider --custom-tool repo_search_tool.RepoSearchTool
+```
+
+These examples demonstrate how you can extend Aider's functionality by creating and integrating custom tools tailored to your specific needs.

--- a/aider/args.py
+++ b/aider/args.py
@@ -805,6 +805,13 @@ def get_parser(default_config_files, git_root):
         "--editor",
         help="Specify which editor to use for the /editor command",
     )
+    group.add_argument(
+        "--custom-tool",
+        action="append",
+        metavar="TOOL",
+        help="Specify a custom tool to integrate with Aider (can be used multiple times)",
+        default=[],
+    )
 
     return parser
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -35,6 +35,7 @@ from aider.utils import format_content, format_messages, format_tokens, is_image
 
 from ..dump import dump  # noqa: F401
 from .chat_chunks import ChatChunks
+from .custom_tool import CustomTool
 
 
 class UnknownEditFormat(ValueError):
@@ -104,6 +105,7 @@ class Coder:
     ignore_mentions = None
     chat_language = None
     file_watcher = None
+    custom_tools = []
 
     @classmethod
     def create(
@@ -156,6 +158,7 @@ class Coder:
                 total_cost=from_coder.total_cost,
                 ignore_mentions=from_coder.ignore_mentions,
                 file_watcher=from_coder.file_watcher,
+                custom_tools=from_coder.custom_tools,  # Copy custom tools
             )
             use_kwargs.update(update)  # override to complete the switch
             use_kwargs.update(kwargs)  # override passed kwargs
@@ -287,6 +290,7 @@ class Coder:
         ignore_mentions=None,
         file_watcher=None,
         auto_copy_context=False,
+        custom_tools=None,
     ):
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
@@ -475,6 +479,11 @@ class Coder:
             if self.verbose:
                 self.io.tool_output("JSON Schema:")
                 self.io.tool_output(json.dumps(self.functions, indent=4))
+
+        # Initialize custom tools
+        self.custom_tools = custom_tools or []
+        for tool in self.custom_tools:
+            tool.initialize(self)
 
     def setup_lint_cmds(self, lint_cmds):
         if not lint_cmds:

--- a/aider/coders/custom_tool.py
+++ b/aider/coders/custom_tool.py
@@ -1,0 +1,16 @@
+class CustomTool:
+    def __init__(self, name, config):
+        self.name = name
+        self.config = config
+
+    def initialize(self, coder):
+        """
+        Initialize the custom tool with the given coder instance.
+        """
+        self.coder = coder
+
+    def execute(self, *args, **kwargs):
+        """
+        Execute the custom tool with the provided arguments.
+        """
+        raise NotImplementedError("Custom tools must implement the execute method.")


### PR DESCRIPTION
Related to #2075

Add support for customized tools in Aider.

* **Command-line Argument:**
  - Add `--custom-tool` argument in `aider/args.py` to specify custom tools.

* **Custom Tool Integration:**
  - Introduce `CustomTool` class in `aider/coders/custom_tool.py` to handle user-defined tools.
  - Implement methods for tool initialization and execution in `CustomTool` class.

* **Base Coder Updates:**
  - Import `CustomTool` in `aider/coders/base_coder.py`.
  - Add `custom_tools` attribute to the base coder class.
  - Initialize custom tools in the base coder class.

* **Documentation:**
  - Update `README.md` to guide users on creating and integrating custom tools.
  - Provide examples of custom tool configurations for web search and code repository search.

