### PR TITLE
Add '?' to set of punctuations to strip for file mentions

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1471,7 +1471,7 @@ class Coder:
         words = set(word for word in content.split())
 
         # drop sentence punctuation from the end
-        words = set(word.rstrip(",.!;:") for word in words)
+        words = set(word.rstrip(",.!;:?") for word in words)
 
         # strip away all kinds of quotes
         quotes = "".join(['"', "'", "`"])


### PR DESCRIPTION
Currently if aider outputs something like `Shall we look at the contents of 'workers/routes.ts'?`, it does not ask if we want to add the file to the chat because it ends with a question mark. This fixes that.