### PR TITLE
feat: create .aider.working when ai! comment is detected (closes #2562)

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -30,7 +30,7 @@ from rich.text import Text
 from aider.mdstream import MarkdownStream
 
 from .dump import dump  # noqa: F401
-from .utils import is_image_file
+from .utils import is_image_file, get_canary_path
 
 
 @dataclass
@@ -404,6 +404,14 @@ class InputOutput:
         edit_format=None,
     ):
         self.rule()
+
+        canary_path=get_canary_path(root)
+        try: # remove canary file if it exists, so wait-for-aider.sh can continue
+            if os.path.exists(canary_path):
+                os.remove(canary_path)
+        except:
+            pass # yes we don't care if it fails
+
 
         rel_fnames = list(rel_fnames)
         show = ""

--- a/aider/utils.py
+++ b/aider/utils.py
@@ -81,6 +81,17 @@ def make_repo(path=None):
 
     return repo
 
+def get_canary_path(from_path=None):
+    """used by scripts/wait-for-aider.sh"""
+    return Path(get_repo_root(from_path or os.getcwd())) / ".aider.working"
+
+def get_repo_root(path):
+    """Get the repository root directory for the given path."""
+    try:
+        repo = git.Repo(path, search_parent_directories=True)
+        return repo.git.rev_parse("--show-toplevel")
+    except:
+        return path
 
 def is_image_file(file_name):
     """

--- a/aider/watch.py
+++ b/aider/watch.py
@@ -9,6 +9,7 @@ from pathspec.patterns import GitWildMatchPattern
 from watchfiles import watch
 
 from aider.dump import dump  # noqa
+from aider.utils import get_canary_path
 from aider.watch_prompts import watch_ask_prompt, watch_code_prompt
 
 
@@ -161,6 +162,9 @@ class FileWatcher:
 
         if not has_action:
             return ""
+
+        with open(get_canary_path(self.root), 'w') as file:
+            file.write("this is a canary file for wait-for-aider.sh which will be deleted after Aider finishes processing changes")
 
         if self.analytics:
             self.analytics.event("ai-comments execute")

--- a/scripts/wait-for-aider.sh
+++ b/scripts/wait-for-aider.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# usage: pycharm preferences > tools > file watchers > add
+#
+# - Files to watch > File type > Any;
+# - Tool to run on changes: wait-for-aider.sh
+# - Output paths to refresh: $Projectpath$
+# - [x] autosave, [-] trigger on external, [x] trigger regardless of syntax errors, [-] create output from stdout
+
+repo_root=$(git rev-parse --show-toplevel)
+# created in FileWatcher.process_changes, removed in InputOutput.get_input
+filename="$repo_root/.aider.working"
+
+has_one_second_passed() {
+    local current_time=$(date +%s)
+    local time_diff=$((current_time - start_time))
+    [ $time_diff -ge 1 ]
+}
+
+start_time=$(date +%s)
+
+# wait while the file exists and at least one second has passed so we don't exit immediately
+echo "waiting for $filename to be deleted..."
+
+while [ -e "$filename" ] || ! has_one_second_passed; do
+    sleep 0.1
+done
+
+echo "exiting."


### PR DESCRIPTION
usage: preferences > tools > file watchers > add

- Files to watch > File type > Any; 
- Tool to run on changes: wait-for-aider.sh
- Output paths to refresh: $Projectpath$
- [x] autosave, [-] trigger on external, [x] trigger regardless of syntax errors, [-] create output from stdout
