### PR TITLE
feat: Add configurable Whisper transcription API base URL

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -715,6 +715,10 @@ def get_parser(default_config_files, git_root):
         default=None,
         help="Specify the input device name for voice recording",
     )
+    group.add_argument(
+        "--openai-api-base-whisper",
+        help="Specify the api base url for Whisper transcriptions",
+    )
 
     ######
     group = parser.add_argument_group("Other settings")

--- a/aider/args.py
+++ b/aider/args.py
@@ -719,6 +719,10 @@ def get_parser(default_config_files, git_root):
         "--openai-api-base-whisper",
         help="Specify the api base url for Whisper transcriptions",
     )
+    group.add_argument(
+        "--openai-api-key-whisper",
+        help="Specify the OpenAI API key for Whisper transcriptions",
+    )
 
     ######
     group = parser.add_argument_group("Other settings")

--- a/aider/main.py
+++ b/aider/main.py
@@ -557,6 +557,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         os.environ["OPENAI_API_KEY"] = args.openai_api_key
     if args.openai_api_base:
         os.environ["OPENAI_API_BASE"] = args.openai_api_base
+    if args.openai_api_base_whisper:
+        os.environ["AIDER_OPENAI_API_BASE_WHISPER"] = args.openai_api_base_whisper
     if args.openai_api_version:
         io.tool_warning(
             "--openai-api-version is deprecated, use --set-env OPENAI_API_VERSION=<value>"

--- a/aider/main.py
+++ b/aider/main.py
@@ -559,6 +559,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         os.environ["OPENAI_API_BASE"] = args.openai_api_base
     if args.openai_api_base_whisper:
         os.environ["AIDER_OPENAI_API_BASE_WHISPER"] = args.openai_api_base_whisper
+    if args.openai_api_key_whisper:
+        os.environ["AIDER_OPENAI_API_KEY_WHISPER"] = args.openai_api_key_whisper
     if args.openai_api_version:
         io.tool_warning(
             "--openai-api-version is deprecated, use --set-env OPENAI_API_VERSION=<value>"

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -150,9 +150,24 @@ class Voice:
 
         with open(filename, "rb") as fh:
             try:
+                # Store original API base if it exists
+                original_api_base = os.environ.get('OPENAI_API_BASE')
+
+                # Set Whisper-specific API base if configured
+                whisper_api_base = os.environ.get('AIDER_OPENAI_API_BASE_WHISPER')
+                if whisper_api_base:
+                    os.environ['OPENAI_API_BASE'] = whisper_api_base
+
                 transcript = litellm.transcription(
                     model="whisper-1", file=fh, prompt=history, language=language
                 )
+
+                # Restore original API base (or remove if not previously set)
+                if original_api_base is not None:
+                    os.environ['OPENAI_API_BASE'] = original_api_base
+                else:
+                    os.environ.pop('OPENAI_API_BASE', None)
+
             except Exception as err:
                 print(f"Unable to transcribe {filename}: {err}")
                 return

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -150,23 +150,32 @@ class Voice:
 
         with open(filename, "rb") as fh:
             try:
-                # Store original API base if it exists
+                # Store original API settings if they exist
                 original_api_base = os.environ.get('OPENAI_API_BASE')
+                original_api_key = os.environ.get('OPENAI_API_KEY')
 
-                # Set Whisper-specific API base if configured
+                # Set Whisper-specific API settings if configured
                 whisper_api_base = os.environ.get('AIDER_OPENAI_API_BASE_WHISPER')
+                whisper_api_key = os.environ.get('AIDER_OPENAI_API_KEY_WHISPER')
                 if whisper_api_base:
                     os.environ['OPENAI_API_BASE'] = whisper_api_base
+                if whisper_api_key:
+                    os.environ['OPENAI_API_KEY'] = whisper_api_key
 
                 transcript = litellm.transcription(
                     model="whisper-1", file=fh, prompt=history, language=language
                 )
 
-                # Restore original API base (or remove if not previously set)
+                # Restore original API settings (or remove if not previously set)
                 if original_api_base is not None:
                     os.environ['OPENAI_API_BASE'] = original_api_base
                 else:
                     os.environ.pop('OPENAI_API_BASE', None)
+                    
+                if original_api_key is not None:
+                    os.environ['OPENAI_API_KEY'] = original_api_key
+                else:
+                    os.environ.pop('OPENAI_API_KEY', None)
 
             except Exception as err:
                 print(f"Unable to transcribe {filename}: {err}")

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -72,6 +72,9 @@
 ## Specify the api base url for OpenAI's Whisper API
 #AIDER_OPENAI_API_BASE_WHISPER=
 
+## Specify the OpenAI API key for Whisper
+#AIDER_OPENAI_API_KEY_WHISPER=
+
 ## (deprecated, use --set-env OPENAI_API_TYPE=<value>)
 #AIDER_OPENAI_API_TYPE=
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -69,6 +69,9 @@
 ## Specify the api base url
 #AIDER_OPENAI_API_BASE=
 
+## Specify the api base url for OpenAI's Whisper API
+#AIDER_OPENAI_API_BASE_WHISPER=
+
 ## (deprecated, use --set-env OPENAI_API_TYPE=<value>)
 #AIDER_OPENAI_API_TYPE=
 


### PR DESCRIPTION
Enable sending voice transcriptions to alternative Whisper API endpoints (including self hosted).

This change adds support for:

`--openai-api-base-whisper`
`--openai-api-key-whisper`

If provided, causes voice.py to temporarily set OPENAI_API_BASE to the provided value when sending voice recording for transcription.

Whisper is open source and runs well on a range of hardware. If you have a Mac with Apple Silicon you can make use of the unified memory shared between GPU and CPU.

Feel free to test with this Whisper.cpp API I installed on my M4 Mac Mini (no API key required currently):

  $ aider --openai-api-base-whisper https://api.ailocal.org

  $ AIDER_OPENAI_API_BASE_WHISPER=https://api.ailocal.org aider