### PR TITLE
Add support for infinite output model fallback

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -251,6 +251,12 @@ def get_parser(default_config_files, git_root):
         help="Specify the edit format for the editor model (default: depends on editor model)",
     )
     group.add_argument(
+        "--infinite-output-model",
+        metavar="INFINITE_OUTPUT_MODEL",
+        default=None,
+        help="Specify the model to use for continuing long responses (default depends on --model)",
+    )
+    group.add_argument(
         "--show-model-warnings",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/aider/args.py
+++ b/aider/args.py
@@ -254,7 +254,7 @@ def get_parser(default_config_files, git_root):
         "--infinite-output-model",
         metavar="INFINITE_OUTPUT_MODEL",
         default=None,
-        help="Specify the model to use for continuing long responses (default depends on --model)",
+        help="Specify the model to use for continuing long responses (default: None)",
     )
     group.add_argument(
         "--show-model-warnings",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1284,7 +1284,7 @@ class Coder:
                         use_model = self.main_model
                     else:
                         # Try to get an infinite output model
-                        use_model = self.main_model.get_infinite_output_model()
+                        use_model = self.main_model.infinite_output_model
                         if not use_model or not use_model.info.get("supports_assistant_prefill"):
                             exhausted = True
                             break

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -211,7 +211,7 @@ class Coder:
             output = f"Weak model: {weak_model.name}"
             lines.append(output)
 
-        if infinite_output_model is not main_model:
+        if infinite_output_model and infinite_output_model is not main_model:
             output = f"Infinite output model: {infinite_output_model.name}"
             lines.append(output)
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -186,6 +186,7 @@ class Coder:
         # Model
         main_model = self.main_model
         weak_model = main_model.weak_model
+        infinite_output_model = main_model.infinite_output_model
 
         if weak_model is not main_model:
             prefix = "Main model"
@@ -208,6 +209,10 @@ class Coder:
 
         if weak_model is not main_model:
             output = f"Weak model: {weak_model.name}"
+            lines.append(output)
+
+        if infinite_output_model is not main_model:
+            output = f"Infinite output model: {infinite_output_model.name}"
             lines.append(output)
 
         # Repo

--- a/aider/main.py
+++ b/aider/main.py
@@ -717,6 +717,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         weak_model=args.weak_model,
         editor_model=args.editor_model,
         editor_edit_format=args.editor_edit_format,
+        infinite_output_model=args.infinite_output_model,
     )
 
     if args.copy_paste and args.edit_format is None:

--- a/aider/models.py
+++ b/aider/models.py
@@ -112,7 +112,6 @@ MODEL_SETTINGS = [
         "gpt-3.5-turbo",
         "whole",
         weak_model_name="gpt-4o-mini",
-        infinite_output_model_name="claude-3-5-sonnet-20241022",
         reminder="sys",
     ),
     ModelSettings(

--- a/aider/models.py
+++ b/aider/models.py
@@ -858,7 +858,7 @@ model_info_manager = ModelInfoManager()
 
 
 class Model(ModelSettings):
-    def __init__(self, model, weak_model=None, editor_model=None, editor_edit_format=None):
+    def __init__(self, model, weak_model=None, editor_model=None, editor_edit_format=None, infinite_output_model=None):
         # Map any alias to its canonical name
         model = MODEL_ALIASES.get(model, model)
 
@@ -897,6 +897,11 @@ class Model(ModelSettings):
             self.editor_model_name = None
         else:
             self.get_editor_model(editor_model, editor_edit_format)
+
+        if infinite_output_model is False:
+            self.infinite_output_model_name = None
+        else:
+            self.get_infinite_output_model(infinite_output_model)
 
     def get_model_info(self, model):
         return model_info_manager.get_model_info(model)
@@ -1017,7 +1022,11 @@ class Model(ModelSettings):
     def commit_message_models(self):
         return [self.weak_model, self]
 
-    def get_infinite_output_model(self):
+    def get_infinite_output_model(self, provided_infinite_output_model_name):
+        # If infinite_output_model_name is provided, override the model settings
+        if provided_infinite_output_model_name:
+            self.infinite_output_model_name = provided_infinite_output_model_name
+
         if not self.infinite_output_model_name:
             return None
             

--- a/aider/models.py
+++ b/aider/models.py
@@ -86,6 +86,7 @@ class ModelSettings:
     name: str
     edit_format: str = "whole"
     weak_model_name: Optional[str] = None
+    infinite_output_model_name: Optional[str] = None
     use_repo_map: bool = False
     send_undo_reply: bool = False
     lazy: bool = False
@@ -111,6 +112,7 @@ MODEL_SETTINGS = [
         "gpt-3.5-turbo",
         "whole",
         weak_model_name="gpt-4o-mini",
+        infinite_output_model_name="claude-3-5-sonnet-20241022",
         reminder="sys",
     ),
     ModelSettings(
@@ -866,6 +868,7 @@ class Model(ModelSettings):
         self.max_chat_history_tokens = 1024
         self.weak_model = None
         self.editor_model = None
+        self.infinite_output_model = None
 
         # Find the extra settings
         self.extra_model_settings = next(
@@ -1014,6 +1017,20 @@ class Model(ModelSettings):
 
     def commit_message_models(self):
         return [self.weak_model, self]
+
+    def get_infinite_output_model(self):
+        if not self.infinite_output_model_name:
+            return None
+            
+        if self.infinite_output_model_name == self.name:
+            return self
+            
+        self.infinite_output_model = Model(
+            self.infinite_output_model_name,
+            weak_model=False,
+            editor_model=False,
+        )
+        return self.infinite_output_model
 
     def get_editor_model(self, provided_editor_model_name, editor_edit_format):
         # If editor_model_name is provided, override the model settings


### PR DESCRIPTION
When a response exceeds its length limit and the model doesn't support assistant prefill, we currently throw an error. This PR adds support for falling back to a dedicated "infinite output" model in such cases.

## Changes

- Added `--infinite-output-model` CLI argument
- Added `infinite_output_model` support to Model class
- Modified response handling to check for and use infinite output model before giving up
- Updated status display to show infinite output model when configured

## Implementation Notes

The flow is now:
1. If main model hits length limit, check if it supports prefill
2. If not, check for infinite output model
3. If found and it supports prefill, switch to it
4. Otherwise throw error as before

I haven't added any default infinite output model configurations. The current convention is that default models (main/weak/editor) come from the same provider. Since the whole point of infinite output models is to fall back to a different provider when the main one doesn't support it, this would break that convention.

We could add defaults (e.g. falling back to Claude for Gemini users), but I kept this PR focused on just the mechanism. Happy to add defaults if desired.