### PR TITLE
Document that Pygments styles can be used for --code-theme

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -427,7 +427,8 @@ def get_parser(default_config_files, git_root):
         default="default",
         help=(
             "Set the markdown code theme (default: default, other options include monokai,"
-            " solarized-dark, solarized-light)"
+            " solarized-dark, solarized-light, or a Pygments builtin style,"
+            " see https://pygments.org/styles for available themes)"
         ),
     )
     group.add_argument(

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -381,7 +381,7 @@ Set the background color for the current item in the completion menu (default: t
 Environment variable: `AIDER_COMPLETION_MENU_CURRENT_BG_COLOR`  
 
 ### `--code-theme VALUE`
-Set the markdown code theme (default: default, other options include monokai, solarized-dark, solarized-light)  
+Set the markdown code theme (default: default, other options include monokai, solarized-dark, solarized-light, or a Pygments builtin style, see [https://pygments.org/styles](https://pygments.org/styles) for available themes)  
 Default: default  
 Environment variable: `AIDER_CODE_THEME`  
 


### PR DESCRIPTION
The `--code-theme` configuration option can accept any of the [Pygments builtin styles](https://pygments.org/styles/) (see [#49](https://github.com/Aider-AI/aider/pull/49)). I had to dig into the source to discover this, so this PR simply makes that better-documented for users.