### PR TITLE
Don't add .env to gitignore when it doesn't exist.

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -173,7 +173,8 @@ def check_gitignore(git_root, io, ask=True):
             existing_lines = content.splitlines()
             for pat in patterns:
                 if pat not in existing_lines:
-                    patterns_to_add.append(pat)
+                    if '*' in pat or (Path(git_root) / pat).exists():
+                        patterns_to_add.append(pat)
         except OSError as e:
             io.tool_error(f"Error when trying to read {gitignore_file}: {e}")
             return


### PR DESCRIPTION
When I start up aider I get:
```
Add .env to .gitignore (recommended)? (Y)es/(N)o [Yes]:
```

This is despite me not actually having a `.env` to ignore. I have to click through this every time I start aider, and it's annoying. This prompts to add the file only if it exists.