### PR TITLE
feat: support openai api compatible interface

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -239,6 +239,12 @@ def get_parser(default_config_files, git_root):
         ),
     )
     group.add_argument(
+        "--compatible-api",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Use openai api compatible interface (default: False)",
+    )
+    group.add_argument(
         "--editor-model",
         metavar="EDITOR_MODEL",
         default=None,

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -78,6 +78,7 @@ class Commands:
 
         model_name = args.strip()
         model = models.Model(model_name)
+        model.compatible_api = args.compatible_api 
         models.sanity_check_models(self.io, model)
         raise SwitchCoder(main_model=model)
 

--- a/aider/compatible_openai_api.py
+++ b/aider/compatible_openai_api.py
@@ -1,0 +1,59 @@
+import os
+import logging
+from openai import OpenAI
+from litellm.utils import ModelResponse
+
+class CompatibleOpenaiApi:
+    def __init__(self):
+        api_key = os.environ.get("COMPATIBLE_OPENAI_API_KEY")
+        api_base = os.environ.get("COMPATIBLE_OPENAI_API_BASE")
+        if not api_key or not api_base:
+            return
+
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=api_base
+        )
+
+    def chat_completion(self, model, messages, stream=False, temperature=0.7):
+        try:
+            response = self.client.chat.completions.create(
+                model=model,
+                messages=messages,
+                stream=stream,
+                temperature=temperature
+            )
+            if stream:
+                return convert_to_litellm_response(response)
+            else:
+                return ModelResponse(**response.model_dump())
+        except Exception as e:
+            return {"error": str(e)}
+
+def convert_to_litellm_response(response):
+    class ReusableStream:
+        def __init__(self, stream):
+            self.stream = stream
+            self._cached_chunks = []
+            self._finished = False
+            self.choices = []
+        
+        def __iter__(self):
+            if self._finished:
+                for chunk in self._cached_chunks:
+                    yield chunk
+                return
+            
+            try:
+                for chunk in self.stream:
+                    if hasattr(chunk, 'choices') and chunk.choices:
+                        self._cached_chunks.append(chunk)
+                        yield chunk
+                self._finished = True
+            except Exception as e:
+                print(str(e))
+                raise
+    
+    wrapped_stream = ReusableStream(response)
+    wrapped_stream.choices = []
+    return wrapped_stream

--- a/aider/main.py
+++ b/aider/main.py
@@ -730,6 +730,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         editor_model=args.editor_model,
         editor_edit_format=args.editor_edit_format,
     )
+    main_model.compatible_api = args.compatible_api
 
     if args.copy_paste and args.edit_format is None:
         if main_model.edit_format in ("diff", "whole"):
@@ -849,6 +850,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             chat_language=args.chat_language,
             detect_urls=args.detect_urls,
             auto_copy_context=args.copy_paste,
+            compatible_api=args.compatible_api,
         )
     except UnknownEditFormat as err:
         io.tool_error(str(err))

--- a/aider/models.py
+++ b/aider/models.py
@@ -862,6 +862,7 @@ class Model(ModelSettings):
         model = MODEL_ALIASES.get(model, model)
 
         self.name = model
+        self.compatible_api = False
 
         self.max_chat_history_tokens = 1024
         self.weak_model = None
@@ -1115,6 +1116,10 @@ class Model(ModelSettings):
             return dict(keys_in_environment=[var], missing_keys=[])
 
     def validate_environment(self):
+        # Check for compatible API mode first
+        if self.compatible_api:
+            return validate_variables(["COMPATIBLE_OPENAI_API_KEY", "COMPATIBLE_OPENAI_API_BASE"])
+
         res = self.fast_validate_environment()
         if res:
             return res

--- a/tests/basic/test_sendchat.py
+++ b/tests/basic/test_sendchat.py
@@ -49,7 +49,7 @@ class TestSendChat(unittest.TestCase):
 
         # Test basic send_completion
         hash_obj, response = send_completion(
-            self.mock_model, self.mock_messages, functions=None, stream=False
+            self.mock_model, self.mock_messages, functions=None, stream=False, compatible_api=False
         )
 
         assert response == mock_response
@@ -60,7 +60,7 @@ class TestSendChat(unittest.TestCase):
         mock_function = {"name": "test_function", "parameters": {"type": "object"}}
 
         hash_obj, response = send_completion(
-            self.mock_model, self.mock_messages, functions=[mock_function], stream=False
+            self.mock_model, self.mock_messages, functions=[mock_function], stream=False,  compatible_api=False
         )
 
         # Verify function was properly included in tools


### PR DESCRIPTION
hello,I encountered the following error when connecting to the Tencent Hunyuan model,
<img width="672" alt="截屏2024-12-22 00 02 05" src="https://github.com/user-attachments/assets/6d300ccb-07aa-4556-911e-2553f60b5be3" />

Then use inference endpoints according to the prompts, unfortunately, Model seems be too large for any available instance options.
<img width="910" alt="企业微信截图_6368e8f1-344e-4b5e-9d22-d0a156c9465b" src="https://github.com/user-attachments/assets/3e6f34f1-3b5a-44ff-aea7-6ce375ad0ae0" />
so, we can only use the openai api compatible interface method. Tencent Hunyuan official also recommends this method for access.

I believe that many other large models will also encounter such problems. aider needs to be able to support access directly through interface requests. I already support it. 

When using
`export COMPATIBLE_OPENAI_API_KEY="sk-xxxxxx"`
`export COMPATIBLE_OPENAI_API_BASE="https://xxxxxx"`
`aider --model="hunyuan-large"  --compatible-api`

Please evaluate it and help with code review. Thank you.

