### PR TITLE
Fix issue #1802: Handle UnicodeDecodeError in repo file paths

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -393,6 +393,12 @@ def sanity_check_repo(repo, io):
         if not repo.git_repo_error:
             return True
         error_msg = str(repo.git_repo_error)
+    except UnicodeDecodeError as exc:
+        error_msg = (
+            f"Failed to read the Git repository. This issue is likely caused by a path encoded "
+            f"in a format different from the expected encoding \"{sys.getfilesystemencoding()}\".\n"
+            f"Internal error: {str(exc)}"
+        )
     except ANY_GIT_ERROR as exc:
         error_msg = str(exc)
         bad_ver = "version in (1, 2)" in error_msg


### PR DESCRIPTION
Added error handling for UnicodeDecodeError when decoding paths in the Git repository. This issue arises when paths are encoded in formats other than the expected system encoding.

The error handler now provides a detailed error message, helping users identify potential encoding mismatches.

Closes #1802