### PR TITLE
Fix Go installation and benchmark tests for Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ aider/_version.py
 .venv/
 .#*
 .gitattributes
+tmp.benchmarks/

--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -18,10 +18,18 @@ RUN apt-get update && apt-get install -y \
 # Make python3.11 the default python3
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.11 1
 
-# Install Go
-RUN curl -OL https://golang.org/dl/go1.21.5.linux-amd64.tar.gz && \
-    tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz && \
-    rm go1.21.5.linux-amd64.tar.gz
+# Install Go with architecture detection
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        GOARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        GOARCH="arm64"; \
+    else \
+        false; \
+    fi && \
+    curl -L "https://golang.org/dl/go1.21.5.linux-$GOARCH.tar.gz" -o go.tar.gz && \
+    tar -C /usr/local -xzf go.tar.gz && \
+    rm go.tar.gz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
 # Install Rust


### PR DESCRIPTION
## Description                                                                                                                                                                                                                                                                                  
 This PR addresses the Rosetta errors encountered when running Go benchmarks on Apple Silicon Macs. It modifies the benchmark Dockerfile to install the correct architecture-specific version of Go and adds tmp.benchmarks to .gitignore.                                                       
                                                                                                                                                                                                                                                                                                 
 ## Changes                                                                                                                                                                                                                                                                                      
 - Added architecture detection in Dockerfile to install correct Go binary:                                                                                                                                                                                                                      
   - Uses arm64 version on Apple Silicon/aarch64                                                                                                                                                                                                                                                 
   - Uses amd64 version on x86_64                                                                                                                                                                                                                                                                
 - Added tmp.benchmarks to .gitignore to avoid committing benchmark results                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                 
 ## Testing                                                                                                                                                                                                                                                                                      
 - Verified on Apple Silicon Mac:                                                                                                                                                                                                                                                                
   - Dockerfile now downloads correct arm64 Go binary                                                                                                                                                                                                                                            
   - Go tests run without Rosetta errors                                                                                                                                                                                                                                                         
   - Benchmarks complete successfully                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                 
 ## Problem                                                                                                                                                                                                                                                                                      
 Previously on Apple Silicon Macs, Go tests would fail with:                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                 

`rosetta error: Rosetta is only intended to run on Apple Silicon with a macOS host using Virtualization.framework with Rosetta mode enabled`                                                                                                                                                 

                                                                                                                                                                                                                                                                                                 
 This was because the wrong architecture (x86_64) Go binary was being installed.