### PR TITLE
Polyglot Qwen2.5-Coder-32B-Instruct Results [Whole]

### DIFF
--- a/aider/website/_data/polyglot_leaderboard.yml
+++ b/aider/website/_data/polyglot_leaderboard.yml
@@ -283,3 +283,29 @@
   versions: 0.69.2.dev
   seconds_per_case: 34.8
   total_cost: 0.3369
+
+- dirname: 2024-12-26-00-55-20--Qwen2.5-Coder-32B-Instruct
+  test_cases: 225
+  model: openai/Qwen2.5-Coder-32B-Instruct
+  edit_format: whole
+  commit_hash: b51768b0
+  pass_rate_1: 4.9
+  pass_rate_2: 16.4
+  pass_num_1: 11
+  pass_num_2: 37
+  percent_cases_well_formed: 99.6
+  error_outputs: 1
+  num_malformed_responses: 1
+  num_with_malformed_responses: 1
+  user_asks: 33
+  lazy_comments: 0
+  syntax_errors: 0
+  indentation_errors: 0
+  exhausted_context_windows: 0
+  test_timeouts: 6
+  total_tests: 225
+  command: aider --model openai/Qwen2.5-Coder-32B-Instruct
+  date: 2024-12-26
+  versions: 0.69.2.dev
+  seconds_per_case: 42.0
+  total_cost: 0.0000


### PR DESCRIPTION
This commit adds the evaluation results of `Qwen2.5-Coder-32B-Instruct` on the Polyglot benchmark with the `whole` edit format.