### PR TITLE
Install ca-certificates before openjdk-21 to resolve cacerts error

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     python3.11-venv \
     python3.11-dev \
     python3-pip \
+    ca-certificates-java \
     openjdk-21-jdk \
     libtbb-dev \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Fixes an issue where the cacerts directory isn't created before openjdk-21-jdk is installed in the benchmarks docker container.

Ran into this while following the benchmark instructions at https://github.com/Aider-AI/aider/blob/main/benchmark/README.md.

My setup was a fresh install of Docker with Rosetta 2 on macOS and a fresh clone of aider.

<details>
```shell
124.4 Setting up ca-certificates-java (20190909ubuntu1.2) ...
124.4 head: cannot open '/etc/ssl/certs/java/cacerts' for reading: No such file or directory
124.4 #
124.4 # A fatal error has been detected by the Java Runtime Environment:
124.4 #
124.4 #  SIGILL (0x4) at pc=0x0000ffff97c67c5c, pid=3573, tid=3574
124.4 #
124.4 # JRE version:  (21.0.5+11) (build )
124.4 # Java VM: OpenJDK 64-Bit Server VM (21.0.5+11-Ubuntu-1ubuntu122.04, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
124.4 # Problematic frame:
124.4 # j  java.lang.System.registerNatives()V+0 java.base@21.0.5
124.4 #
124.4 # No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
124.4 #
124.4 # An error report file with more information is saved as:
124.4 # //hs_err_pid3573.log
124.4 [0.013s][warning][os] Loading hsdis library failed
124.4 #
124.4 # The crash happened outside the Java Virtual Machine in native code.
124.4 # See problematic frame for where to report the bug.
124.4 #
124.4 /var/lib/dpkg/info/ca-certificates-java.postinst: line 87:  3572 Done                    echo -e "-diginotar_root_ca\n-diginotar_root_ca_pem"
124.4       3573 Aborted                 | java -Xmx64m -jar $JAR -storepass "$storepass"
124.4 dpkg: error processing package ca-certificates-java (--configure):
124.4  installed ca-certificates-java package post-installation script subprocess returned error exit status 134
124.4 dpkg: dependency problems prevent configuration of openjdk-21-jre-headless:arm64:
124.4  openjdk-21-jre-headless:arm64 depends on ca-certificates-java (>= 20190405~); however:
124.4   Package ca-certificates-java is not configured yet.
124.4
124.4 dpkg: error processing package openjdk-21-jre-headless:arm64 (--configure):
124.4  dependency problems - leaving unconfigured
124.4 dpkg: dependency problems prevent configuration of openjdk-21-jre:arm64:
124.4  openjdk-21-jre:arm64 depends on openjdk-21-jre-headless (= 21.0.5+11-1ubuntu1~22.04); however:
124.4   Package openjdk-21-jre-headless:arm64 is not configured yet.
124.4
124.4 dpkg: error processing package openjdk-21-jre:arm64 (--configure):
124.4  dependency problems - leaving unconfigured
124.4 Setting up humanity-icon-theme (0.6.16) ...
124.5 dpkg: dependency problems prevent configuration of openjdk-21-jdk-headless:arm64:
124.5  openjdk-21-jdk-headless:arm64 depends on openjdk-21-jre-headless (= 21.0.5+11-1ubuntu1~22.04); however:
124.5   Package openjdk-21-jre-headless:arm64 is not configured yet.
124.5
124.5 dpkg: error processing package openjdk-21-jdk-headless:arm64 (--configure):
124.5  dependency problems - leaving unconfigured
124.5 Setting up ubuntu-mono (20.10-0ubuntu2) ...
124.5 dpkg: dependency problems prevent configuration of openjdk-21-jdk:arm64:
124.5  openjdk-21-jdk:arm64 depends on openjdk-21-jre (= 21.0.5+11-1ubuntu1~22.04); however:
124.5   Package openjdk-21-jre:arm64 is not configured yet.
124.5  openjdk-21-jdk:arm64 depends on openjdk-21-jdk-headless (= 21.0.5+11-1ubuntu1~22.04); however:
124.5   Package openjdk-21-jdk-headless:arm64 is not configured yet.
124.5
124.5 dpkg: error processing package openjdk-21-jdk:arm64 (--configure):
124.5  dependency problems - leaving unconfigured
124.5 Processing triggers for ca-certificates (20240203~22.04.1) ...
124.5 Updating certificates in /etc/ssl/certs...
124.6 0 added, 0 removed; done.
124.6 Running hooks in /etc/ca-certificates/update.d...
124.6
124.7 #
124.7 # A fatal error has been detected by the Java Runtime Environment:
124.7 #
124.7 #  SIGILL (0x4) at pc=0x0000ffff8fc67c5c, pid=4358, tid=4359
124.7 #
124.7 # JRE version:  (21.0.5+11) (build )
124.7 # Java VM: OpenJDK 64-Bit Server VM (21.0.5+11-Ubuntu-1ubuntu122.04, mixed mode, sharing, tiered, compressed oops, compressed class ptrs, g1 gc, linux-aarch64)
124.7 # Problematic frame:
124.7 # j  java.lang.System.registerNatives()V+0 java.base@21.0.5
124.7 #
124.7 # No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
124.7 #
124.7 # An error report file with more information is saved as:
124.7 # /etc/ssl/certs/hs_err_pid4358.log
124.7 [0.008s][warning][os] Loading hsdis library failed
124.7 #
124.7 # The crash happened outside the Java Virtual Machine in native code.
124.7 # See problematic frame for where to report the bug.
124.7 #
124.7 Aborted
124.7 E: /etc/ca-certificates/update.d/jks-keystore exited with code 1.
124.7 done.
124.7 Processing triggers for fontconfig (2.13.1-4.2ubuntu5) ...
124.7 Processing triggers for hicolor-icon-theme (0.17-2) ...
124.7 Processing triggers for libglib2.0-0:arm64 (2.72.4-0ubuntu2.3) ...
124.7 Setting up libgtk-3-0:arm64 (3.24.33-1ubuntu2.2) ...
124.7 Processing triggers for libc-bin (2.35-0ubuntu3.8) ...
124.7 Setting up libgtk-3-bin (3.24.33-1ubuntu2.2) ...
124.7 Setting up at-spi2-core (2.44.0-3) ...
124.7 Errors were encountered while processing:
124.7  ca-certificates-java
124.7  openjdk-21-jre-headless:arm64
124.7  openjdk-21-jre:arm64
124.7  openjdk-21-jdk-headless:arm64
124.7  openjdk-21-jdk:arm64
124.7 E: Sub-process /usr/bin/dpkg returned an error code (1)
------
Dockerfile:4
--------------------
   3 |     # Install Python 3.11
   4 | >>> RUN apt-get update && apt-get install -y \
   5 | >>>     software-properties-common \
   6 | >>>     cmake \
   7 | >>>     && add-apt-repository ppa:deadsnakes/ppa \
   8 | >>>     && apt-get update \
   9 | >>>     && apt-get install -y \
  10 | >>>     python3.11 \
  11 | >>>     python3.11-venv \
  12 | >>>     python3.11-dev \
  13 | >>>     python3-pip \
  14 | >>>     openjdk-21-jdk \
  15 | >>>     libtbb-dev \
  16 | >>>     && rm -rf /var/lib/apt/lists/*
  17 |
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get install -y     software-properties-common     cmake     && add-apt-repository ppa:deadsnakes/ppa     && apt-get update     && apt-get install -y     python3.11     python3.11-venv     python3.11-dev     python3-pip     openjdk-21-jdk     libtbb-dev     && rm -rf /var/lib/apt/lists/*" did not complete successfully: exit code: 100
```
</details>