### PR TITLE
fix: set default voice language from args if not provided

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -67,10 +67,10 @@ class Commands:
         self.verbose = verbose
 
         self.verify_ssl = verify_ssl
+
         if voice_language == "auto":
             voice_language = None
-
-        self.voice_language = voice_language
+        self.voice_language = voice_language or (args.voice_language if args and hasattr(args, 'voice_language') else None)
 
         self.help = None
         self.editor = editor


### PR DESCRIPTION
when passing the voice-language arg from .aider.conf or an env variable it wasn't being used and is always set to None, so the whisper model would translate a voice with an accent to it's original language