### PR TITLE
Document boto3 install process with aider installed by uv or one-liner

### DIFF
--- a/aider/website/docs/llms/bedrock.md
+++ b/aider/website/docs/llms/bedrock.md
@@ -53,6 +53,12 @@ To use aider installed via `pipx` with AWS Bedrock, you must add the `boto3` dep
 pipx inject aider-chat boto3
 ```
 
+You must install `boto3` dependency to aider's virtual environment installed via one-liner or uv by running
+
+```bash
+uv tool run --from aider-chat pip install boto3
+```
+
 
 ## Running Aider with Bedrock
 


### PR DESCRIPTION
The solutions provided in the documentation for installing the missing `boto3` library do not work with a one-liner install script or UV. In this note, I propose additional information about the installation process.