### PR TITLE
Handle new path creation

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -756,6 +756,7 @@ class Commands:
 
             if self.io.confirm_ask(f"No files matched '{word}'. Do you want to create {fname}?"):
                 try:
+                    fname.parent.mkdir(parents=True, exist_ok=True)
                     fname.touch()
                     all_matched_files.add(str(fname))
                 except OSError as e:


### PR DESCRIPTION
To handle cases where a path, a file, or both need to be created, you can enhance the `fname.touch()` code as follows:

```python
try:
    # Create parent directories if they don't exist
    fname.parent.mkdir(parents=True, exist_ok=True)
    # Create the file
    fname.touch()
    all_matched_files.add(str(fname))
    self.io.tool_output(f"Created file: {fname}")
except OSError as e:
    self.io.tool_error(f"Error creating file {fname}: {e}")
```

This code ensures that any necessary parent directories are created before attempting to create the file itself.

(coPilot)