### PR TITLE
feat: Add line endings configuration option for file writing - fixes #1102

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -767,6 +767,12 @@ def get_parser(default_config_files, git_root):
         help="Specify the encoding for input and output (default: utf-8)",
     )
     group.add_argument(
+        "--line-endings",
+        choices=["platform", "lf", "crlf"],
+        default="platform",
+        help="Line endings to use when writing files (default: platform)",
+    )
+    group.add_argument(
         "-c",
         "--config",
         is_config_file=True,

--- a/aider/io.py
+++ b/aider/io.py
@@ -198,6 +198,7 @@ class InputOutput:
         completion_menu_current_bg_color=None,
         code_theme="default",
         encoding="utf-8",
+        line_endings="platform",
         dry_run=False,
         llm_history_file=None,
         editingmode=EditingMode.EMACS,
@@ -244,6 +245,8 @@ class InputOutput:
             self.chat_history_file = None
 
         self.encoding = encoding
+        self.newline = None if line_endings == "platform" \
+            else "\n" if line_endings == "lf" else "\r\n"
         self.dry_run = dry_run
 
         current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -375,7 +378,7 @@ class InputOutput:
         delay = initial_delay
         for attempt in range(max_retries):
             try:
-                with open(str(filename), "w", encoding=self.encoding) as f:
+                with open(str(filename), "w", encoding=self.encoding, newline=self.newline) as f:
                     f.write(content)
                 return  # Successfully wrote the file
             except PermissionError as err:

--- a/aider/main.py
+++ b/aider/main.py
@@ -552,6 +552,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             code_theme=args.code_theme,
             dry_run=args.dry_run,
             encoding=args.encoding,
+            line_endings=args.line_endings,
             llm_history_file=args.llm_history_file,
             editingmode=editing_mode,
             fancy_input=args.fancy_input,


### PR DESCRIPTION
Add configurable line endings for file writes
 
As discussed in: https://github.com/Aider-AI/aider/issues/1102 

 Previously, aider always wrote files with platform-specific line endings on Windows,
 which made it impossible for Windows users to maintain files with LF line endings.

 Added a new --line-endings argument that controls how files are written:
 - `platform` (default): Use system default (\n on Unix, \r\n on Windows)
 - `lf`: Always use \n
 - `crlf`: Always use \r\n

Comment:

- `InputOutput.read_text` always converts line endings to `\n` (LF) implicitly. I did not touch that behaviour.
- `InputOutput.write_text` previously always wrote platform dependent line endings (which can cause problems). The new `line_endings` configuration default (`platform`) preserves the original behavior, but it can now be explicitly set to "lf" or "clrf".