### PR TITLE
refactor: Reorder exception handling in file reading method

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -342,10 +342,6 @@ class InputOutput:
         try:
             with open(str(filename), "r", encoding=self.encoding) as f:
                 return f.read()
-        except OSError as err:
-            if not silent:
-                self.tool_error(f"{filename}: unable to read: {err}")
-            return
         except FileNotFoundError:
             if not silent:
                 self.tool_error(f"{filename}: file not found error")
@@ -353,6 +349,10 @@ class InputOutput:
         except IsADirectoryError:
             if not silent:
                 self.tool_error(f"{filename}: is a directory")
+            return
+        except OSError as err:
+            if not silent:
+                self.tool_error(f"{filename}: unable to read: {err}")
             return
         except UnicodeError as e:
             if not silent:


### PR DESCRIPTION
Fix exception handling order in InputOutput.read_text()

The method had unreachable exception handlers since `FileNotFoundError` and `IsADirectoryError` are subclasses of `OSError`. Reordered the exception handlers to catch specific exceptions first, followed by the more general `OSError`.

This change improves error reporting by providing more specific error messages when possible.