### PR TITLE
Add ability for aider to review PRs or current status

### DIFF
--- a/aider/coders/__init__.py
+++ b/aider/coders/__init__.py
@@ -6,8 +6,10 @@ from .editblock_fenced_coder import EditBlockFencedCoder
 from .editor_editblock_coder import EditorEditBlockCoder
 from .editor_whole_coder import EditorWholeFileCoder
 from .help_coder import HelpCoder
+from .review_coder import ReviewCoder
 from .udiff_coder import UnifiedDiffCoder
 from .wholefile_coder import WholeFileCoder
+
 
 # from .single_wholefile_func_coder import SingleWholeFileFunctionCoder
 
@@ -23,4 +25,5 @@ __all__ = [
     ArchitectCoder,
     EditorEditBlockCoder,
     EditorWholeFileCoder,
+    ReviewCoder,
 ]

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -56,6 +56,10 @@ class ReviewCoder(Coder):
             if not self.head_branch:
                 self.head_branch = pr.head.ref
 
+        except Exception as e:
+            self.io.tool_error(f"Error fetching PR information: {str(e)}")
+            return []
+
         # Get the diff between branches
         diff = repo.git.diff(f"{self.base_branch}...{self.head_branch}", "--name-status")
 

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -17,13 +17,11 @@ class FileChange:
     new_content: str
     change_type: str  # 'added', 'modified', 'deleted'
 
-
 class ReviewComment(NamedTuple):
     file: str
     line: int
     type: str
     content: str
-
 
 class ReviewCoder(Coder):
     edit_format = "review"  # Unique identifier for this coder

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -188,9 +188,10 @@ class ReviewCoder(Coder):
             {"role": "user", "content": prompt}
         ]
 
-        # Send directly to model without chat history
+        # Send directly to model without chat history and output chunks
         try:
             for chunk in simple_send_with_retries(self.main_model, messages):
+                self.io.tool_output(chunk, log_only=False)
                 yield chunk
         except Exception as e:
             self.io.tool_error(f"Unable to complete review: {str(e)}")

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -8,7 +8,12 @@ import re
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
-from rich.progress import Progress, SpinnerColumn, TextColumn, ProgressColumn
+from rich.progress import (
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    ProgressColumn,
+)
 
 from .review_prompts import ReviewPrompts
 from .base_coder import Coder

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -187,29 +187,6 @@ class ReviewCoder(Coder):
             
         return comments
 
-    def display_comments(self, comments: List[ReviewComment]):
-        """Display parsed comments in a formatted way"""
-        console = Console()
-        
-        for comment in comments:
-            # Create styled text based on comment type
-            title = Text()
-            title.append(f"{comment.file}:{comment.line} ", style="bold")
-            
-            type_styles = {
-                "issue": "red",
-                "suggestion": "yellow",
-                "security": "red bold",
-                "performance": "blue"
-            }
-            title.append(f"[{comment.type}]", style=type_styles.get(comment.type, "white"))
-            
-            panel = Panel(
-                Text(comment.content),
-                title=title,
-                border_style=type_styles.get(comment.type, "white")
-            )
-            console.print(panel)
 
     def review_pr(self, pr_number_or_branch: str, base_branch: str = None):
         """Main method to review a PR or branch changes"""
@@ -263,7 +240,7 @@ class ReviewCoder(Coder):
         comments = self.parse_comments(full_response)
         if comments:
             self.io.tool_output("\nDetailed Review Comments:")
-            self.display_comments(comments)
+            self.io.display_review_comments(comments)
 
     def get_edits(self):
         """ReviewCoder doesn't make edits"""

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -195,33 +195,14 @@ class ReviewCoder(Coder):
             assessment_match = re.search(r'<assessment>(.*?)</assessment>', review_text, re.DOTALL)
             assessment = assessment_match.group(1).strip() if assessment_match else ""
 
-            # If no XML tags found, raise exception
-            if not (summary or comments or assessment):
-                raise ValueError("No valid XML tags found in review")
+            # If no XML tags found or missing required sections, raise exception
+            if not (summary and assessment):  # Allow empty comments
+                raise ValueError("Missing required XML tags in review")
 
             return summary, comments, assessment
 
         except Exception as e:
-            # If parsing fails, create a basic review from the raw text
-            self.io.tool_warning(f"Failed to parse review in XML format: {str(e)}")
-            self.io.tool_warning("Falling back to raw text format")
-            
-            # Use the first line as summary if possible
-            lines = review_text.strip().split('\n')
-            summary = lines[0] if lines else "Review parsing failed"
-            
-            # Create a generic comment with the full text
-            comments = [ReviewComment(
-                file="unknown",
-                line=1,
-                type="issue",
-                content=review_text.strip()
-            )]
-            
-            # Use a standard assessment message
-            assessment = "Review was provided in non-standard format"
-            
-            return summary, comments, assessment
+            raise ValueError(f"Failed to parse review in XML format: {str(e)}")
 
     def review_pr(self, pr_number_or_branch: str, base_branch: str = None):
         """Main method to review a PR or branch changes"""

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -5,6 +5,7 @@ import git
 from github import Github
 import os
 
+from .review_prompts import ReviewPrompts
 from .base_coder import Coder
 
 
@@ -18,6 +19,7 @@ class FileChange:
 
 class ReviewCoder(Coder):
     edit_format = "review"  # Unique identifier for this coder
+    gpt_prompts = ReviewPrompts()
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -73,7 +75,6 @@ class ReviewCoder(Coder):
         self.io.tool_output(f"Diff:\n{diff}")
 
         for line in diff.splitlines():
-            self.io.debug(line)
             status, filename = line.split('\t')
 
             if status.startswith('A'):  # Added
@@ -144,6 +145,8 @@ class ReviewCoder(Coder):
             return
 
         prompt = self.format_review_prompt(changes)
+
+        self.io.tool_output(f"Reviewing changes:")
 
         # Send to LLM for review
         messages = self.format_messages()

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -67,9 +67,6 @@ class ReviewCoder(Coder):
                 else:
                     repo_name = remote_url.split('github.com/')[-1].replace('.git', '')
 
-                self.io.tool_output(f"Fetching PR information for {repo_name} from {remote_url}")
-                self.io.tool_output(f"PR number: {self.pr_number}")
-
                 gh_repo = g.get_repo(repo_name)
 
                 # Get the PR
@@ -77,17 +74,17 @@ class ReviewCoder(Coder):
 
                 # Update base and head branches from PR if not explicitly set
                 if not self.base_branch:
-                    self.base_branch = pr.base.ref
+                    self.base_branch = pr.head.ref
                 if not self.main_branch:
-                    self.main_branch = pr.head.ref
+                    self.main_branch = pr.base.ref
 
             except Exception as e:
                 self.io.tool_error(f"Error fetching PR information: {str(e)}")
                 return []
 
-        self.io.tool_output(
-            f"Reviewing {self.pr_number}, {self.base_branch} against {self.main_branch}")
-        if self.pr_number:
+            self.io.tool_output(
+                f"Reviewing PR {self.pr_number} - {self.base_branch} against {self.main_branch}")
+
             # Get changes from GitHub PR
             pr = gh_repo.get_pull(int(self.pr_number))
             files = pr.get_files()
@@ -122,7 +119,10 @@ class ReviewCoder(Coder):
                     f"Must be on base branch ({self.base_branch}) to review local changes")
                 return []
 
-            diff = repo.git.diff(f"{self.base_branch}...{self.main_branch}", "--name-status")
+            self.io.tool_output(
+                f"Reviewing {self.base_branch} against {self.main_branch}")
+            
+            diff = repo.git.diff(f"{self.main_branch}...{self.base_branch}", "--name-status")
             self.io.tool_output(f"Diff:\n{diff}")
 
             for line in diff.splitlines():

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -42,7 +42,11 @@ class ReviewCoder(Coder):
                 # Get the GitHub repository
                 g = Github(github_token) if github_token else Github()
                 remote_url = repo.remotes.origin.url
-                repo_name = remote_url.split('github.com/')[-1].replace('.git', '')
+                # Handle both HTTPS and SSH URLs
+                if 'git@github.com:' in remote_url:
+                    repo_name = remote_url.split('git@github.com:')[-1].replace('.git', '')
+                else:
+                    repo_name = remote_url.split('github.com/')[-1].replace('.git', '')
 
                 self.io.tool_output(f"Fetching PR information for {repo_name} from {remote_url}")
                 self.io.tool_output(f"PR number: {self.pr_number}")

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -188,7 +188,7 @@ class ReviewCoder(Coder):
             {"role": "user", "content": prompt}
         ]
         
-        response = send_completion(
+        hash_obj, response = send_completion(
             self.main_model.name,
             messages,
             None,
@@ -199,8 +199,10 @@ class ReviewCoder(Coder):
 
         # Display the streamed response
         for chunk in response:
-            if chunk:
-                self.io.tool_output(chunk, log_only=False)
+            if hasattr(chunk, 'choices') and chunk.choices:
+                delta = chunk.choices[0].delta
+                if hasattr(delta, 'content') and delta.content:
+                    self.io.tool_output(delta.content, log_only=False)
 
     def get_edits(self):
         """ReviewCoder doesn't make edits"""

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -153,9 +153,6 @@ class ReviewCoder(Coder):
     def format_review_prompt(self, changes: List[FileChange]) -> str:
         """Format the changes into a prompt for the LLM"""
         prompt = "Please review the following changes and provide:\n"
-        prompt += "1. A summary of each file's changes\n"
-        prompt += "2. Potential issues or improvements\n"
-        prompt += "3. Overall assessment of the changes\n\n"
 
         for change in changes:
             prompt += f"\nFile: {change.filename}\n"

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -8,7 +8,7 @@ import re
 from rich.console import Console
 from rich.panel import Panel
 from rich.text import Text
-from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.progress import Progress, SpinnerColumn, TextColumn, ProgressColumn
 
 from .review_prompts import ReviewPrompts
 from .base_coder import Coder
@@ -232,12 +232,7 @@ class ReviewCoder(Coder):
 
         # Collect the full response with progress indicator
         full_response = ""
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            console=Console(),
-            transient=True,
-        ) as progress:
+        with self.io.create_progress_context("Analyzing changes...") as progress:
             review_task = progress.add_task("Analyzing changes...", total=None)
             
             for chunk in response:

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -153,8 +153,17 @@ class ReviewCoder(Coder):
         messages.append({"role": "user", "content": prompt})
 
         # Stream the review response
-        for chunk in self.send_message(prompt):
-            yield chunk
+        try:
+            response = ""
+            for chunk in self.send_message(prompt):
+                if isinstance(chunk, dict) and "content" in chunk:
+                    response += chunk["content"]
+                    yield chunk["content"]
+                elif isinstance(chunk, str):
+                    response += chunk
+                    yield chunk
+        except Exception as e:
+            self.io.tool_error(f"Unable to complete review: {str(e)}")
 
     def get_edits(self):
         """ReviewCoder doesn't make edits"""

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -1,0 +1,118 @@
+from typing import List, Optional
+from dataclasses import dataclass
+from pathlib import Path
+import git
+
+from .base_coder import Coder
+
+
+@dataclass
+class FileChange:
+    filename: str
+    old_content: Optional[str]
+    new_content: str
+    change_type: str  # 'added', 'modified', 'deleted'
+
+
+class ReviewCoder(Coder):
+    edit_format = "review"  # Unique identifier for this coder
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pr_number = None
+        self.base_branch = None
+        self.head_branch = None
+
+    def get_pr_changes(self) -> List[FileChange]:
+        """Get all file changes in the PR"""
+        if not self.repo:
+            self.io.tool_error("No git repository found")
+            return []
+
+        changes = []
+        repo = git.Repo(self.repo.root)
+
+        # Get the diff between branches
+        diff = repo.git.diff(f"{self.base_branch}...{self.head_branch}", "--name-status")
+
+        for line in diff.splitlines():
+            self.io.debug(line)
+            status, filename = line.split('\t')
+
+            if status.startswith('A'):  # Added
+                new_content = self.io.read_text(filename)
+                changes.append(FileChange(
+                    filename=filename,
+                    old_content=None,
+                    new_content=new_content,
+                    change_type='added'
+                ))
+            elif status.startswith('M'):  # Modified
+                old_content = repo.git.show(f"{self.base_branch}:{filename}")
+                new_content = self.io.read_text(filename)
+                changes.append(FileChange(
+                    filename=filename,
+                    old_content=old_content,
+                    new_content=new_content,
+                    change_type='modified'
+                ))
+            elif status.startswith('D'):  # Deleted
+                old_content = repo.git.show(f"{self.base_branch}:{filename}")
+                changes.append(FileChange(
+                    filename=filename,
+                    old_content=old_content,
+                    new_content=None,
+                    change_type='deleted'
+                ))
+
+        return changes
+
+    def format_review_prompt(self, changes: List[FileChange]) -> str:
+        """Format the changes into a prompt for the LLM"""
+        prompt = "Please review the following changes and provide:\n"
+        prompt += "1. A summary of each file's changes\n"
+        prompt += "2. Potential issues or improvements\n"
+        prompt += "3. Overall assessment of the changes\n\n"
+
+        for change in changes:
+            prompt += f"\nFile: {change.filename}\n"
+            prompt += f"Change type: {change.change_type}\n"
+
+            if change.change_type == 'modified':
+                prompt += f"Previous content:\n{self.fence[0]}\n{change.old_content}\n{self.fence[1]}\n"
+                prompt += f"New content:\n{self.fence[0]}\n{change.new_content}\n{self.fence[1]}\n"
+            elif change.change_type == 'added':
+                prompt += f"New content:\n{self.fence[0]}\n{change.new_content}\n{self.fence[1]}\n"
+            elif change.change_type == 'deleted':
+                prompt += f"Deleted content:\n{self.fence[0]}\n{change.old_content}\n{self.fence[1]}\n"
+
+        return prompt
+
+    def review_pr(self, pr_number: str, base: str, head: str):
+        """Main method to review a PR"""
+        self.pr_number = pr_number
+        self.base_branch = base
+        self.head_branch = head
+
+        changes = self.get_pr_changes()
+        if not changes:
+            self.io.tool_error("No changes found in PR")
+            return
+
+        prompt = self.format_review_prompt(changes)
+
+        # Send to LLM for review
+        messages = self.format_messages()
+        messages.append({"role": "user", "content": prompt})
+
+        # Stream the review response
+        for chunk in self.send_message(prompt):
+            yield chunk
+
+    def get_edits(self):
+        """ReviewCoder doesn't make edits"""
+        return []
+
+    def apply_edits(self, edits):
+        """ReviewCoder doesn't apply edits"""
+        pass

--- a/aider/coders/review_coder.py
+++ b/aider/coders/review_coder.py
@@ -120,7 +120,7 @@ class ReviewCoder(Coder):
                 return []
 
             self.io.tool_output(
-                f"Reviewing {self.base_branch} against {self.main_branch}")
+                f"Reviewing {self.base_branch} branch against {self.main_branch} branch")
 
             diff = repo.git.diff(f"{self.main_branch}...{self.base_branch}", "--name-status")
             self.io.tool_output(f"Diff:\n{diff}")
@@ -218,12 +218,13 @@ class ReviewCoder(Coder):
 
         prompt = self.format_review_prompt(changes)
 
-        self.io.tool_output(f"Reviewing changes:")
-
         messages = [
             {"role": "system", "content": self.gpt_prompts.main_system},
             {"role": "user", "content": prompt}
         ]
+
+        progress = self.io.create_progress_context("Analyzing changes...")
+        progress.start()
 
         hash_obj, response = send_completion(
             self.main_model.name,
@@ -236,8 +237,7 @@ class ReviewCoder(Coder):
 
         # Collect the full response with progress updates
         full_response = ""
-        progress = self.io.create_progress_context("Analyzing changes...")
-        progress.start()
+        progress.update(description="Processing response...")
 
         try:
             for chunk in response:

--- a/aider/coders/review_prompts.py
+++ b/aider/coders/review_prompts.py
@@ -4,17 +4,22 @@ class ReviewPrompts(CoderPrompts):
 
     main_system = """You are an expert code reviewer. Analyze code changes and provide:
 1. A clear summary of the changes
-2. Potential issues, bugs, or security concerns
-3. Suggestions for improvements in:
-- Code quality
-- Performance
-- Maintainability
-- Security
-4. Best practices that could be applied
-5. Overall assessment of the changes
+2. Specific comments on code issues using this XML format:
+   <comment file="filename" line="line_number" type="issue|suggestion|security|performance">
+   Your detailed comment here
+   </comment>
+
+Comment types:
+- issue: Potential bugs or problems
+- suggestion: Code quality improvements
+- security: Security concerns
+- performance: Performance improvements
+
+3. Overall assessment of the changes
 
 Use {language} in your responses.
 Format your review to be clear and constructive.
+Each specific comment MUST use the XML format with correct file and line numbers.
 {platform}
 """
 

--- a/aider/coders/review_prompts.py
+++ b/aider/coders/review_prompts.py
@@ -3,7 +3,10 @@ from .base_prompts import CoderPrompts
 class ReviewPrompts(CoderPrompts):
 
     main_system = """You are an expert code reviewer. Analyze code changes and provide:
-1. A clear summary of the changes
+1. A clear summary of the changes using this XML format:
+    <summary>
+    Your summary here
+    </summary>
 2. Specific comments on code issues using this XML format:
    <comment file="filename" line="line_number" type="issue|suggestion|security|performance">
    Your detailed comment here
@@ -15,48 +18,16 @@ Comment types:
 - security: Security concerns
 - performance: Performance improvements
 
-3. Overall assessment of the changes
+3. Overall assessment of the changes using this XML format:
+    <assessment>
+    Your assessment here
+    </assessment>
 
 Use {language} in your responses.
 Format your review to be clear and constructive.
+The summary and assetmet MUST use the XML format.
 Each specific comment MUST use the XML format with correct file and line numbers.
 {platform}
 """
 
-    example_messages = ["""
-USER: Please review the following changes and provide:
-1. A summary of each file's changes
-2. Potential issues or improvements
-3. Overall assessment of the changes
-                        
-File: utils.py
-Change type: modified
-Previous content:
-def process_data(data):
-    return data.strip()
-
-New content:
-def process_data(data):
-    if not isinstance(data, str):
-        raise TypeError("Expected string input")
-    return data.strip()
-
-ASSISTANT: Here's my review of the changes to utils.py:
-
-Summary:
-- Added input type validation to process_data() function
-- Now raises TypeError for non-string inputs
-
-Positive aspects:
-+ Improved input validation improves robustness
-+ Clear error message helps with debugging
-+ Maintains existing functionality for valid inputs
-
-Suggestions:
-1. Consider adding docstring to document the new behavior
-2. Could add return type hint -> str
-3. May want to handle None input specifically
-
-Overall: Good defensive programming change that improves reliability.
-"""
-]
+    example_messages = []

--- a/aider/coders/review_prompts.py
+++ b/aider/coders/review_prompts.py
@@ -25,7 +25,7 @@ Comment types:
 
 Use {language} in your responses.
 Format your review to be clear and constructive.
-The summary and assetmet MUST use the XML format.
+The summary and assessment MUST use the XML format.
 Each specific comment MUST use the XML format with correct file and line numbers.
 {platform}
 """

--- a/aider/coders/review_prompts.py
+++ b/aider/coders/review_prompts.py
@@ -1,0 +1,57 @@
+from .base_prompts import CoderPrompts
+
+class ReviewPrompts(CoderPrompts):
+
+    main_system = """You are an expert code reviewer. Analyze code changes and provide:
+1. A clear summary of the changes
+2. Potential issues, bugs, or security concerns
+3. Suggestions for improvements in:
+- Code quality
+- Performance
+- Maintainability
+- Security
+4. Best practices that could be applied
+5. Overall assessment of the changes
+
+Use {language} in your responses.
+Format your review to be clear and constructive.
+{platform}
+"""
+
+    example_messages = ["""
+USER: Please review the following changes and provide:
+1. A summary of each file's changes
+2. Potential issues or improvements
+3. Overall assessment of the changes
+                        
+File: utils.py
+Change type: modified
+Previous content:
+def process_data(data):
+    return data.strip()
+
+New content:
+def process_data(data):
+    if not isinstance(data, str):
+        raise TypeError("Expected string input")
+    return data.strip()
+
+ASSISTANT: Here's my review of the changes to utils.py:
+
+Summary:
+- Added input type validation to process_data() function
+- Now raises TypeError for non-string inputs
+
+Positive aspects:
++ Improved input validation improves robustness
++ Clear error message helps with debugging
++ Maintains existing functionality for valid inputs
+
+Suggestions:
+1. Consider adding docstring to document the new behavior
+2. Could add return type hint -> str
+3. May want to handle None input specifically
+
+Overall: Good defensive programming change that improves reliability.
+"""
+]

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1399,22 +1399,29 @@ class Commands:
 
         report_github_issue(issue_text, title=title, confirm=False)
     
-    def cmd_review(self, pr_number=None, base="main", head=None):
-        """Review a pull request
-        Usage: /review <pr_number> [base_branch] [head_branch]
+    def cmd_review(self, args=""):
+        """Review a pull request or branch changes
+        Usage: 
+          /review <pr_number> [base_branch] [head_branch]
+          /review <branch> [base_branch]
         """
-        if not pr_number:
-            self.io.tool_error("Please provide a PR number")
+        args = args.strip().split()
+        if not args:
+            self.io.tool_error("Please provide a PR number or branch name")
             return
 
-        if not head:
+        pr_number_or_branch = args[0]
+        base = args[1] if len(args) > 1 else None
+        head = args[2] if len(args) > 2 else None
+
+        if not head and not pr_number_or_branch.isdigit():
             head = self.coder.repo.repo.active_branch.name
 
         # Create a new ReviewCoder
         review_coder = self.coder.clone(edit_format="review")
 
         # Stream the review
-        for chunk in review_coder.review_pr(pr_number, base, head):
+        for chunk in review_coder.review_pr(pr_number_or_branch, base, head):
             pass  # The streaming is handled by the coder
 
     def cmd_editor(self, initial_content=""):

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1071,7 +1071,7 @@ class Commands:
     def cmd_architect(self, args):
         """Enter architect/editor mode using 2 different models. If no prompt provided, switches to architect/editor mode."""  # noqa
         return self._generic_chat_command(args, "architect")
-
+    
     def _generic_chat_command(self, args, edit_format):
         if not args.strip():
             # Switch to the corresponding chat mode if no args provided
@@ -1398,6 +1398,24 @@ class Commands:
             title = None
 
         report_github_issue(issue_text, title=title, confirm=False)
+    
+    def cmd_review(self, pr_number=None, base="main", head=None):
+        """Review a pull request
+        Usage: /review <pr_number> [base_branch] [head_branch]
+        """
+        if not pr_number:
+            self.io.tool_error("Please provide a PR number")
+            return
+
+        if not head:
+            head = self.coder.repo.repo.active_branch.name
+
+        # Create a new ReviewCoder
+        review_coder = self.coder.clone(edit_format="review")
+
+        # Stream the review
+        for chunk in review_coder.review_pr(pr_number, base, head):
+            pass  # The streaming is handled by the coder
 
     def cmd_editor(self, initial_content=""):
         "Open an editor to write a prompt"

--- a/aider/io.py
+++ b/aider/io.py
@@ -28,6 +28,10 @@ from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.style import Style as RichStyle
 from rich.text import Text
+from rich.progress import Progress
+from rich.progress import SpinnerColumn
+from rich.progress import TextColumn
+from rich.progress import ProgressColumn
 
 from aider.mdstream import MarkdownStream
 
@@ -177,11 +181,11 @@ class AutoCompleter(Completer):
 
 class InputOutput:
     num_error_outputs = 0
-    Progress = _Progress
-    SpinnerColumn = _SpinnerColumn
-    TextColumn = _TextColumn
     num_user_asks = 0
     clipboard_watcher = None
+    progress = Progress
+    spinner_column = SpinnerColumn
+    text_column = TextColumn
 
     def __init__(
         self,
@@ -907,9 +911,9 @@ class InputOutput:
 
     def create_progress_context(self, initial_status="Processing..."):
         """Create and return a progress context with a dynamic status message"""
-        progress = self.Progress(
-            self.SpinnerColumn(),
-            self.TextColumn("[progress.description]{task.description}"),
+        progress = self.progress(
+            self.spinner_column(),
+            self.text_column("[progress.description]{task.description}"),
             console=self.console,
             transient=True,
         )

--- a/aider/io.py
+++ b/aider/io.py
@@ -911,13 +911,33 @@ class InputOutput:
 
     def create_progress_context(self, initial_status="Processing..."):
         """Create and return a progress context with a dynamic status message"""
-        progress = self.progress(
-            self.spinner_column(),
-            self.text_column("[progress.description]{task.description}"),
-            console=self.console,
-            transient=True,
-        )
-        return progress
+        class ProgressContext:
+            def __init__(self, progress, console):
+                self.progress = progress
+                self.console = console
+                self.task_id = None
+                self.initial_status = initial_status
+
+            def start(self):
+                with self.progress(
+                    SpinnerColumn(),
+                    TextColumn("[progress.description]{task.description}"),
+                    console=self.console,
+                    transient=True,
+                ) as progress:
+                    self.task_id = progress.add_task(self.initial_status, total=None)
+                    self._progress = progress
+
+            def update(self, description=None):
+                if description and self.task_id is not None:
+                    self._progress.update(self.task_id, description=description)
+
+            def stop(self):
+                if self.task_id is not None:
+                    self._progress.stop()
+                    self.task_id = None
+
+        return ProgressContext(self.progress, self.console)
 
     def display_review(self, summary: str, comments: list, assessment: str):
         """Display a complete code review including summary, comments and assessment"""

--- a/aider/io.py
+++ b/aider/io.py
@@ -25,6 +25,7 @@ from pygments.token import Token
 from rich.columns import Columns
 from rich.console import Console
 from rich.markdown import Markdown
+from rich.panel import Panel
 from rich.style import Style as RichStyle
 from rich.text import Text
 
@@ -900,6 +901,28 @@ class InputOutput:
             self.tool_output(
                 "Multiline mode: Disabled. Alt-Enter inserts newline, Enter submits text"
             )
+
+    def display_review_comments(self, comments):
+        """Display code review comments in a formatted way"""
+        for comment in comments:
+            # Create styled text based on comment type
+            title = Text()
+            title.append(f"{comment.file}:{comment.line} ", style="bold")
+            
+            type_styles = {
+                "issue": "red",
+                "suggestion": "yellow", 
+                "security": "red bold",
+                "performance": "blue"
+            }
+            title.append(f"[{comment.type}]", style=type_styles.get(comment.type, "white"))
+            
+            panel = Panel(
+                Text(comment.content),
+                title=title,
+                border_style=type_styles.get(comment.type, "white")
+            )
+            self.console.print(panel)
 
     def append_chat_history(self, text, linebreak=False, blockquote=False, strip=True):
         if blockquote:

--- a/aider/io.py
+++ b/aider/io.py
@@ -182,15 +182,14 @@ class AutoCompleter(Completer):
 class ProgressContext:
     """A context manager for displaying progress with dynamic status messages."""
     
-    def __init__(self, progress, console, initial_status="Processing..."):
-        self.progress = progress
+    def __init__(self, console, initial_status="Processing..."):
         self.console = console
         self.task_id = None
         self.initial_status = initial_status
         self._progress = None
 
     def start(self):
-        progress = self.progress(
+        progress = Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
             console=self.console,
@@ -215,9 +214,6 @@ class InputOutput:
     num_error_outputs = 0
     num_user_asks = 0
     clipboard_watcher = None
-    progress = lambda *args, **kwargs: Progress(*args, **kwargs)
-    spinner_column = SpinnerColumn
-    text_column = TextColumn
 
     def __init__(
         self,
@@ -943,11 +939,7 @@ class InputOutput:
 
     def create_progress_context(self, initial_status="Processing..."):
         """Create and return a progress context with a dynamic status message"""
-        return ProgressContext(
-            lambda *args, **kwargs: Progress(*args, **kwargs),
-            self.console,
-            initial_status
-        )
+        return ProgressContext(self.console, initial_status)
 
     def display_review(self, summary: str, comments: list, assessment: str):
         """Display a complete code review including summary, comments and assessment"""

--- a/aider/io.py
+++ b/aider/io.py
@@ -177,9 +177,9 @@ class AutoCompleter(Completer):
 
 class InputOutput:
     num_error_outputs = 0
-    Progress = Progress
-    SpinnerColumn = SpinnerColumn
-    TextColumn = TextColumn
+    Progress = _Progress
+    SpinnerColumn = _SpinnerColumn
+    TextColumn = _TextColumn
     num_user_asks = 0
     clipboard_watcher = None
 

--- a/aider/io.py
+++ b/aider/io.py
@@ -902,6 +902,16 @@ class InputOutput:
                 "Multiline mode: Disabled. Alt-Enter inserts newline, Enter submits text"
             )
 
+    def create_progress_context(self, initial_status="Processing..."):
+        """Create and return a progress context with a dynamic status message"""
+        progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            console=self.console,
+            transient=True,
+        )
+        return progress
+
     def display_review(self, summary: str, comments: list, assessment: str):
         """Display a complete code review including summary, comments and assessment"""
         # Display Summary

--- a/aider/io.py
+++ b/aider/io.py
@@ -902,27 +902,49 @@ class InputOutput:
                 "Multiline mode: Disabled. Alt-Enter inserts newline, Enter submits text"
             )
 
-    def display_review_comments(self, comments):
-        """Display code review comments in a formatted way"""
-        for comment in comments:
-            # Create styled text based on comment type
-            title = Text()
-            title.append(f"{comment.file}:{comment.line} ", style="bold")
-            
+    def display_review(self, summary: str, comments: list, assessment: str):
+        """Display a complete code review including summary, comments and assessment"""
+        # Display Summary
+        if summary:
+            summary_panel = Panel(
+                Text(summary),
+                title="Summary",
+                border_style="cyan"
+            )
+            self.console.print(summary_panel)
+            self.console.print()
+
+        # Display Comments
+        if comments:
+            self.console.print("[bold]Detailed Review Comments:[/bold]")
             type_styles = {
                 "issue": "red",
-                "suggestion": "yellow", 
+                "suggestion": "yellow",
                 "security": "red bold",
                 "performance": "blue"
             }
-            title.append(f"[{comment.type}]", style=type_styles.get(comment.type, "white"))
             
-            panel = Panel(
-                Text(comment.content),
-                title=title,
-                border_style=type_styles.get(comment.type, "white")
+            for comment in comments:
+                title = Text()
+                title.append(f"{comment.file}:{comment.line} ", style="bold")
+                title.append(f"[{comment.type}]", style=type_styles.get(comment.type, "white"))
+                
+                panel = Panel(
+                    Text(comment.content),
+                    title=title,
+                    border_style=type_styles.get(comment.type, "white")
+                )
+                self.console.print(panel)
+            self.console.print()
+
+        # Display Assessment
+        if assessment:
+            assessment_panel = Panel(
+                Text(assessment),
+                title="Overall Assessment",
+                border_style="green"
             )
-            self.console.print(panel)
+            self.console.print(assessment_panel)
 
     def append_chat_history(self, text, linebreak=False, blockquote=False, strip=True):
         if blockquote:

--- a/aider/io.py
+++ b/aider/io.py
@@ -177,6 +177,9 @@ class AutoCompleter(Completer):
 
 class InputOutput:
     num_error_outputs = 0
+    Progress = Progress
+    SpinnerColumn = SpinnerColumn
+    TextColumn = TextColumn
     num_user_asks = 0
     clipboard_watcher = None
 
@@ -904,9 +907,9 @@ class InputOutput:
 
     def create_progress_context(self, initial_status="Processing..."):
         """Create and return a progress context with a dynamic status message"""
-        progress = Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
+        progress = self.Progress(
+            self.SpinnerColumn(),
+            self.TextColumn("[progress.description]{task.description}"),
             console=self.console,
             transient=True,
         )

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -30,6 +30,7 @@ json5
 psutil
 watchfiles
 pip
+PyGithub
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -76,15 +76,6 @@ def test_format_review_prompt():
     assert "Change type: added" in prompt
     assert "print('hello')" in prompt
 
-def test_review_prompts():
-    """Test review prompt templates"""
-    prompts = ReviewPrompts()
-    
-    assert "<summary>" in prompts.main_system
-    assert "<comment" in prompts.main_system
-    assert "<assessment>" in prompts.main_system
-    assert "issue|suggestion|security|performance" in prompts.main_system
-
 @pytest.mark.asyncio
 async def test_review_pr_local():
     """Test reviewing local branch changes"""

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -1,0 +1,108 @@
+import pytest
+from pathlib import Path
+from unittest.mock import Mock, patch
+from aider.coders.review_coder import ReviewCoder, ReviewComment, FileChange
+from aider.coders.review_prompts import ReviewPrompts
+
+def test_parse_review():
+    """Test parsing of review responses"""
+    coder = ReviewCoder(None)
+    
+    review_text = """
+    <summary>
+    Added error handling and input validation
+    </summary>
+    <comment file="test.py" line="15" type="suggestion">
+    Consider adding type hints to improve code clarity
+    </comment>
+    <comment file="main.py" line="42" type="security">
+    Potential SQL injection vulnerability
+    </comment>
+    <assessment>
+    Code changes look good overall but needs some minor improvements
+    </assessment>
+    """
+    
+    summary, comments, assessment = coder.parse_review(review_text)
+    
+    assert summary == "Added error handling and input validation"
+    assert len(comments) == 2
+    assert comments[0] == ReviewComment(
+        file="test.py",
+        line=15,
+        type="suggestion",
+        content="Consider adding type hints to improve code clarity"
+    )
+    assert comments[1] == ReviewComment(
+        file="main.py",
+        line=42,
+        type="security",
+        content="Potential SQL injection vulnerability"
+    )
+    assert assessment == "Code changes look good overall but needs some minor improvements"
+
+def test_format_review_prompt():
+    """Test formatting of review prompts"""
+    coder = ReviewCoder(None)
+    coder.fence = ('```', '```')
+    
+    changes = [
+        FileChange(
+            filename="test.py",
+            old_content="def old_func():\n    pass",
+            new_content="def new_func():\n    return True",
+            change_type="modified"
+        ),
+        FileChange(
+            filename="new.py",
+            old_content=None,
+            new_content="print('hello')",
+            change_type="added"
+        )
+    ]
+    
+    prompt = coder.format_review_prompt(changes)
+    
+    assert "File: test.py" in prompt
+    assert "Change type: modified" in prompt
+    assert "def old_func():" in prompt
+    assert "def new_func():" in prompt
+    assert "File: new.py" in prompt
+    assert "Change type: added" in prompt
+    assert "print('hello')" in prompt
+
+def test_review_prompts():
+    """Test review prompt templates"""
+    prompts = ReviewPrompts()
+    
+    assert "<summary>" in prompts.main_system
+    assert "<comment" in prompts.main_system
+    assert "<assessment>" in prompts.main_system
+    assert "issue|suggestion|security|performance" in prompts.main_system
+
+@pytest.mark.asyncio
+async def test_review_pr_local():
+    """Test reviewing local branch changes"""
+    mock_io = Mock()
+    mock_repo = Mock()
+    mock_repo.root = "/fake/path"
+    
+    with patch('git.Repo') as mock_git:
+        mock_git.return_value.git.diff.return_value = "M\ttest.py"
+        mock_git.return_value.git.show.return_value = "old content"
+        
+        coder = ReviewCoder(None)
+        coder.io = mock_io
+        coder.repo = mock_repo
+        
+        # Mock file reading
+        def mock_read_text(filename):
+            return "new content"
+        mock_io.read_text = mock_read_text
+        
+        # Test local branch review
+        coder.review_pr("main", "feature")
+        
+        # Verify git commands were called
+        mock_git.return_value.git.diff.assert_called_once()
+        mock_git.return_value.git.show.assert_called_once()

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -6,7 +6,8 @@ from aider.coders.review_prompts import ReviewPrompts
 
 def test_parse_review():
     """Test parsing of review responses"""
-    coder = ReviewCoder(None)
+    mock_io = Mock()
+    coder = ReviewCoder(mock_io)
     
     review_text = """
     <summary>
@@ -43,7 +44,8 @@ def test_parse_review():
 
 def test_format_review_prompt():
     """Test formatting of review prompts"""
-    coder = ReviewCoder(None)
+    mock_io = Mock()
+    coder = ReviewCoder(mock_io)
     coder.fence = ('```', '```')
     
     changes = [
@@ -91,7 +93,7 @@ async def test_review_pr_local():
         mock_git.return_value.git.diff.return_value = "M\ttest.py"
         mock_git.return_value.git.show.return_value = "old content"
         
-        coder = ReviewCoder(None)
+        coder = ReviewCoder(mock_io)
         coder.io = mock_io
         coder.repo = mock_repo
         

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -104,9 +104,9 @@ async def test_review_retry_on_bad_format():
         good_response = Mock()
         good_chunk = Mock()
         good_chunk.choices = [Mock()]
-        good_chunk.choices[0].delta.content = "<summary>Test summary</summar            good_chunk.choices[0].delta.content = """<summary>Test summary</summary>
-        good_chunk.choices[0].delta.content = "<summary>Test summary</summar<comment file="test.py" line="1" type="suggestion">Test comment</comment>
-        good_chunk.choices[0].delta.content = "<summary>Test summary</summar<assessment>Test assessment</assessment>"""
+        good_chunk.choices[0].delta.content = """<summary>Test summary</summary>
+<comment file="test.py" line="1" type="suggestion">Test comment</comment>
+<assessment>Test assessment</assessment>"""
         good_response.__iter__ = Mock(return_value=iter([good_chunk]))
 
         coder = ReviewCoder(mock_model, mock_io)

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -8,6 +8,7 @@ def test_parse_review():
     """Test parsing of review responses"""
     mock_io = Mock()
     mock_model = Mock()
+    mock_model.extra_params = {}  # Mock extra_params as empty dict
     coder = ReviewCoder(mock_model, mock_io)
     
     review_text = """

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -92,22 +92,24 @@ async def test_review_pr_local():
     mock_repo.root = "/fake/path"
     
     with patch('git.Repo') as mock_git:
+        # Setup mock repo with active branch
+        mock_git.return_value.active_branch.name = "feature"
         mock_git.return_value.git.diff.return_value = "M\ttest.py"
         mock_git.return_value.git.show.return_value = "old content"
-        
+
         mock_model = Mock()
         coder = ReviewCoder(mock_model, mock_io)
         coder.io = mock_io
         coder.repo = mock_repo
-        
+
         # Mock file reading
         def mock_read_text(filename):
             return "new content"
         mock_io.read_text = mock_read_text
-        
+
         # Test local branch review
         coder.review_pr("main", "feature")
-        
+
         # Verify git commands were called
-        mock_git.return_value.git.diff.assert_called_once()
+        mock_git.return_value.git.diff.assert_called_once_with("main...feature", "--name-status")
         mock_git.return_value.git.show.assert_called_once()

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -7,7 +7,8 @@ from aider.coders.review_prompts import ReviewPrompts
 def test_parse_review():
     """Test parsing of review responses"""
     mock_io = Mock()
-    coder = ReviewCoder(mock_io)
+    mock_model = Mock()
+    coder = ReviewCoder(mock_model, mock_io)
     
     review_text = """
     <summary>
@@ -45,7 +46,8 @@ def test_parse_review():
 def test_format_review_prompt():
     """Test formatting of review prompts"""
     mock_io = Mock()
-    coder = ReviewCoder(mock_io)
+    mock_model = Mock()
+    coder = ReviewCoder(mock_model, mock_io)
     coder.fence = ('```', '```')
     
     changes = [
@@ -93,7 +95,8 @@ async def test_review_pr_local():
         mock_git.return_value.git.diff.return_value = "M\ttest.py"
         mock_git.return_value.git.show.return_value = "old content"
         
-        coder = ReviewCoder(mock_io)
+        mock_model = Mock()
+        coder = ReviewCoder(mock_model, mock_io)
         coder.io = mock_io
         coder.repo = mock_repo
         

--- a/tests/basic/test_review.py
+++ b/tests/basic/test_review.py
@@ -104,7 +104,9 @@ async def test_review_retry_on_bad_format():
         good_response = Mock()
         good_chunk = Mock()
         good_chunk.choices = [Mock()]
-        good_chunk.choices[0].delta.content = "<summary>Test summary</summary>"
+        good_chunk.choices[0].delta.content = "<summary>Test summary</summar            good_chunk.choices[0].delta.content = """<summary>Test summary</summary>
+        good_chunk.choices[0].delta.content = "<summary>Test summary</summar<comment file="test.py" line="1" type="suggestion">Test comment</comment>
+        good_chunk.choices[0].delta.content = "<summary>Test summary</summar<assessment>Test assessment</assessment>"""
         good_response.__iter__ = Mock(return_value=iter([good_chunk]))
 
         coder = ReviewCoder(mock_model, mock_io)


### PR DESCRIPTION
Added new command
/review [main_branch('main')] [modified_branch('current`)]
/review {pr number}

Just using `/review` will get a diff of the current state of the repo vs the 'main' branch and provide a review, otherwise you can identify the branch you want to compare to and or the branch you want compared (if not the current head you are on).
Providing `/review` a number will fetch the review information from github via PyGithub and generate the review.

Reviews look like this
![image](https://github.com/user-attachments/assets/2c2690d5-96d8-4b70-ac52-9261ea5d795e)
