### PR TITLE
feat: Add --map-root argument to configure repository map root directory

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -304,6 +304,12 @@ def get_parser(default_config_files, git_root):
         default=2,
         help="Multiplier for map tokens when no files are specified (default: 2)",
     )
+    group.add_argument(
+        "--map-root",
+        metavar="MAP_ROOT",
+        default=".",
+        help="Root directory for the repository map (default: current directory)",
+    )
 
     ##########
     group = parser.add_argument_group("History Files")

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -295,7 +295,11 @@ class Coder:
         ignore_mentions=None,
         file_watcher=None,
         auto_copy_context=False,
+        map_root='.',
     ):
+        # initialize from args.map_root
+        self.map_root = map_root
+        
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
 
@@ -442,7 +446,7 @@ class Coder:
         if use_repo_map and self.repo and has_map_prompt:
             self.repo_map = RepoMap(
                 map_tokens,
-                self.root,
+                self.map_root,
                 self.main_model,
                 io,
                 self.gpt_prompts.repo_content_prefix,

--- a/aider/main.py
+++ b/aider/main.py
@@ -886,6 +886,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             chat_language=args.chat_language,
             detect_urls=args.detect_urls,
             auto_copy_context=args.copy_paste,
+            map_root=args.map_root, # initialize from args.map_root
         )
     except UnknownEditFormat as err:
         io.tool_error(str(err))

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -78,6 +78,9 @@ class RepoMap:
             self.io.tool_output(
                 f"RepoMap initialized with map_mul_no_files: {self.map_mul_no_files}"
             )
+            self.io.tool_output(
+                f"RepoMap initialized with map_root: {self.root}"
+            )
 
     def token_count(self, text):
         len_text = len(text)


### PR DESCRIPTION
The patch makes the root directory for `.aider.tags.cache.v3` configurable through an additional argument `--map-root` or `AIDER_MAP_ROOT`environment variable.

This becomes important if your project lives on a CIFS mount and you encounter:

```
Tags cache error: database is locked
Unable to use tags cache at /mnt/.../.aider.tags.cache.v3, falling back to memory cache
Cache recreation error: [Errno 11] Resource temporarily unavailable: 'cache.db'
```

With the `--map-root` parameter, the cache directory can be moved to local device to avoid the problem.
