### PR TITLE
Frankenclaude: R1 thinking + Sonnet 

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -30,7 +30,7 @@ from aider.llm import litellm
 from aider.repo import ANY_GIT_ERROR, GitRepo
 from aider.repomap import RepoMap
 from aider.run_cmd import run_cmd
-from aider.sendchat import RETRY_TIMEOUT, send_completion
+from aider.sendchat import RETRY_TIMEOUT
 from aider.utils import format_content, format_messages, format_tokens, is_image_file
 
 from ..dump import dump  # noqa: F401
@@ -1577,13 +1577,11 @@ class Coder:
 
         completion = None
         try:
-            hash_object, completion = send_completion(
-                model.name,
+            hash_object, completion = model.send_completion(
                 messages,
                 functions,
                 self.stream,
                 temp,
-                extra_params=model.extra_params,
             )
             self.chat_completion_call_hashes.append(hash_object.hexdigest())
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -118,11 +118,7 @@ class Coder:
     ):
         import aider.coders as coders
 
-        if not main_model:
-            if from_coder:
-                main_model = from_coder.main_model
-            else:
-                main_model = models.Model(models.DEFAULT_MODEL_NAME)
+        main_model = models.FrankenClaude()
 
         if edit_format == "code":
             edit_format = None

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -118,15 +118,9 @@ class Coder:
     ):
         import aider.coders as coders
 
+        # FIXME hardcode FrankenClaude
         main_model = models.FrankenClaude()
-
-        if edit_format == "code":
-            edit_format = None
-        if edit_format is None:
-            if from_coder:
-                edit_format = from_coder.edit_format
-            else:
-                edit_format = main_model.edit_format
+        edit_format = "diff"
 
         if not io and from_coder:
             io = from_coder.io


### PR DESCRIPTION
I wanted to see what would happen if we combine R1's chain of thought with Sonnet's editing ability.

I hacked it into aider in the most disgusting fashion (although I think moving send_completion into Model is a good idea) using the native deepseek api since litellm doesn't expose R1 COT yet.

Here's the benchmark results.  (I'm not totally sure if the cost given is the R1 cost or the Sonnet cost, but it's not both.)

TLDR it about splits the difference between R1 and o1.  (56.9 < 59.1 < 61.7.)

Happy to try more experiments if anyone thinks they have a way to make it smarter.

```
- dirname: 2025-01-23-04-52-24--franken7
  test_cases: 225
  model: gpt-3.5-turbo
  edit_format: whole
  commit_hash: 57a1994-dirty
  pass_rate_1: 26.2
  pass_rate_2: 59.1
  pass_num_1: 59
  pass_num_2: 133
  percent_cases_well_formed: 99.1
  error_outputs: 3
  num_malformed_responses: 2
  num_with_malformed_responses: 2
  user_asks: 4
  lazy_comments: 0
  syntax_errors: 0
  indentation_errors: 0
  exhausted_context_windows: 0
  test_timeouts: 3
  total_tests: 225
  command: aider --model gpt-3.5-turbo
  date: 2025-01-23
  versions: 0.72.3.dev
  seconds_per_case: 206.9
  total_cost: 2.7148

costs: $0.0121/test-case, $2.71 total, $2.71 projected
```