### PR TITLE
Ensure alternating roles for deepseek-reasoner

### DIFF
--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -42,6 +42,38 @@ def sanity_check_messages(messages):
     return last_non_system_role == "user"
 
 
+def ensure_alternating_roles(messages):
+    """
+    Ensure messages alternate between 'assistant' and 'user' roles.
+    Inserts empty messages of the opposite role when consecutive messages of the same role are found.
+
+    Args:
+        messages: List of message dictionaries with 'role' and 'content' keys.
+
+    Returns:
+        List of messages with alternating roles.
+    """
+    if not messages:
+        return messages
+
+    fixed_messages = []
+    prev_role = None
+
+    for msg in messages:
+        current_role = msg['role']
+
+        # If the current role is the same as the previous, insert an empty message of the opposite role
+        if current_role == prev_role:
+            if current_role == 'user':
+                fixed_messages.append({'role': 'assistant', 'content': ''})
+            else:
+                fixed_messages.append({'role': 'user', 'content': ''})
+
+        fixed_messages.append(msg)
+        prev_role = current_role
+
+    return fixed_messages
+
 def send_completion(
     model_name,
     messages,
@@ -56,6 +88,9 @@ def send_completion(
         sanity_check_messages(messages)
     #
     #
+
+    if model_name == 'deepseek/deepseek-reasoner':
+        messages = ensure_alternating_roles(messages)
 
     kwargs = dict(
         model=model_name,

--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -60,7 +60,7 @@ def ensure_alternating_roles(messages):
     prev_role = None
 
     for msg in messages:
-        current_role = msg['role']
+        current_role = msg.get('role')  # Get 'role', None if missing
 
         # If the current role is the same as the previous, insert an empty message of the opposite role
         if current_role == prev_role:


### PR DESCRIPTION
Currently, as of aider 0.72.2, if deepseek/deepseek-reasoner (aka 'r1') is selected as the model and ^C is used to cancel a request, then you may end up in a situation where you have two user requests in a row, and the model will refuse to process requests.  This short patch runs a check immediately before submission to ensure the messages alternate roles between 'user' and 'assistant', inserting a message of the appropriate role and an empty string for content to prevent the model from rejecting the request.  The assumption is that since submission is done infrequently, the expense is minimal to so on every request.

The error this patch resolves appears as follows:
```
litellm.BadRequestError: DeepseekException - Error code: 400 - {'error': {'message': 'deepseek-reasoner does not support 
successive user or assistant messages (messages[81] and messages[82] in your input). You should interleave the user/assistant 
messages in the message sequence.', 'type': 'invalid_request_error', 'param': None, 'code': 'invalid_request_error'}}
```
Once this error occurs, the only practical option right now is to clear the chat history.  This patch allows the session to continue.  I've tested the patch interactively by generating multiple consecutive user message by submitting one, hitting ^C, and entering another immediately after, and verifying that the messages list contains those consecutive user requests.  The deepseek/deepseek-reasoner model does not complain with this patch applied, allowing the session to continue.