### PR TITLE
docs: update DeepSeek v2 Coder to v3 Chat

### DIFF
--- a/aider/website/docs/llms/deepseek.md
+++ b/aider/website/docs/llms/deepseek.md
@@ -6,7 +6,7 @@ nav_order: 500
 # DeepSeek
 
 Aider can connect to the DeepSeek.com API.
-The DeepSeek Coder V2 model has a top score on aider's code editing benchmark.
+The DeepSeek Chat V3 model has a top score on aider's code editing benchmark.
 
 ```
 python -m pip install -U aider-chat
@@ -14,7 +14,7 @@ python -m pip install -U aider-chat
 export DEEPSEEK_API_KEY=<key> # Mac/Linux
 setx   DEEPSEEK_API_KEY <key> # Windows, restart shell after setx
 
-# Use DeepSeek Coder V2
+# Use DeepSeek Chat v3
 aider --deepseek
 ```
 


### PR DESCRIPTION
This pull request includes a small update to the `aider/website/docs/llms/deepseek.md` file. The change updates the references to the DeepSeek model to reflect the latest version.

* Updated references from "DeepSeek Coder V2" to "DeepSeek Chat V3" to reflect the latest model in the documentation.


xref: https://aider.chat/docs/leaderboards/

![Screenshot from 2025-01-26 15-27-49](https://github.com/user-attachments/assets/47afd5c3-e64d-4754-b0c4-84fe83f12b28)
