### PR TITLE
Fix docs regarding extra_body

### DIFF
--- a/aider/website/docs/config/adv-model-settings.md
+++ b/aider/website/docs/config/adv-model-settings.md
@@ -125,7 +125,6 @@ entry in the list below and adding the above `extra_params` entry:
   lazy: false
   reminder: user
   examples_as_sys_msg: false
-  extra_params: null
   cache_control: false
   caches_by_default: false
   use_system_prompt: true

--- a/aider/website/docs/config/adv-model-settings.md
+++ b/aider/website/docs/config/adv-model-settings.md
@@ -108,12 +108,13 @@ These settings will be merged with any model-specific settings, with the
 You need this chunk of yaml:
 
 ```
-  extra_body:
-    reasoning_effort: high
+  extra_params:
+    extra_body:
+      reasoning_effort: high
 ```
 
 This is a full entry for o1 with that setting, obtained by finding the default
-entry in the list below and adding the above `extra_body` entry:
+entry in the list below and adding the above `extra_params` entry:
 
 ```
 - name: o1
@@ -132,8 +133,9 @@ entry in the list below and adding the above `extra_body` entry:
   streaming: false
   editor_model_name: gpt-4o
   editor_edit_format: editor-diff
-  extra_body:
-    reasoning_effort: high
+  extra_params:
+    extra_body:
+      reasoning_effort: high
 ```
 
 ### Default model settings


### PR DESCRIPTION
Setting the `extra_body` as suggested by the doc gives me the following error:
```
Error loading aider model settings: Error loading model settings from /home/zhyu/.aider/aider.model.settings.yml: ModelSettings.__init__() got an unexpected keyword
argument 'extra_body'
```

Setting `extra_body` as a key of `extra_params` fixed the issue for me. And I confirmed that the behavior changed accordingly after I set the reasoning effort for o1 in this way.

It also matches another `extra_body` usage in this [doc](https://aider.chat/docs/llms/openrouter.html#controlling-provider-selection).