### PR TITLE
Add `fireworks_ai/deepseek` models

### DIFF
--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -47,4 +47,22 @@
         //"supports_tool_choice": true,
         "supports_prompt_caching": true
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-r1": {
+        "max_tokens": 160000,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 20480,
+        "litellm_provider": "fireworks_ai",
+        "input_cost_per_token": 0.000008,
+        "output_cost_per_token": 0.000008,
+        "mode": "chat",
+    },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v3": {
+        "max_tokens": 128000,
+        "max_input_tokens": 100000,
+        "max_output_tokens": 8192,
+        "litellm_provider": "fireworks_ai",
+        "input_cost_per_token": 0.0000009,
+        "output_cost_per_token": 0.0000009,
+        "mode": "chat",
+    },
 }

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -600,9 +600,13 @@
   editor_model_name: fireworks_ai/accounts/fireworks/models/deepseek-v3
   editor_edit_format: editor-diff
   remove_reasoning: false
+  extra_params:
+      max_tokens: 160000
 
 - name: fireworks_ai/accounts/fireworks/models/deepseek-v3
   edit_format: diff
   use_repo_map: true
   reminder: sys
   examples_as_sys_msg: true
+  extra_params:
+      max_tokens: 128000

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -590,3 +590,19 @@
   use_repo_map: true
   editor_model_name: openrouter/qwen/qwen-2.5-coder-32b-instruct
   editor_edit_format: editor-diff
+
+- name: fireworks_ai/accounts/fireworks/models/deepseek-r1
+  edit_format: diff
+  weak_model_name: fireworks_ai/accounts/fireworks/models/deepseek-v3
+  use_repo_map: true
+  use_temperature: false
+  streaming: true
+  editor_model_name: fireworks_ai/accounts/fireworks/models/deepseek-v3
+  editor_edit_format: editor-diff
+  remove_reasoning: false
+
+- name: fireworks_ai/accounts/fireworks/models/deepseek-v3
+  edit_format: diff
+  use_repo_map: true
+  reminder: sys
+  examples_as_sys_msg: true


### PR DESCRIPTION
Considering Deepseek's recently down, Fireworks has been the most reliable backup lately. Could be useful to those who want to keep using Deepseek.