### PR TITLE
Avoid unnecessary duplicate call to expensive get_repo_map() method

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -722,13 +722,13 @@ class Coder:
 
         return readonly_messages
 
-    def get_chat_files_messages(self):
+    def get_chat_files_messages(self, repo_map_included):
         chat_files_messages = []
         if self.abs_fnames:
             files_content = self.gpt_prompts.files_content_prefix
             files_content += self.get_files_content()
             files_reply = self.gpt_prompts.files_content_assistant_reply
-        elif self.get_repo_map() and self.gpt_prompts.files_no_full_files_with_repo_map:
+        elif repo_map_included and self.gpt_prompts.files_no_full_files_with_repo_map:
             files_content = self.gpt_prompts.files_no_full_files_with_repo_map
             files_reply = self.gpt_prompts.files_no_full_files_with_repo_map_reply
         else:
@@ -1120,7 +1120,7 @@ class Coder:
 
         chunks.repo = self.get_repo_messages()
         chunks.readonly_files = self.get_readonly_files_messages()
-        chunks.chat_files = self.get_chat_files_messages()
+        chunks.chat_files = self.get_chat_files_messages(repo_map_included=bool(chunks.repo))
 
         if self.gpt_prompts.system_reminder:
             reminder_message = [


### PR DESCRIPTION
Coder calls `self.get_repo_map()` in `get_chat_files_messages()` just to determine whether the repo map is included in the prompt.
This is an expensive method and is already called immediately before `get_chat_files_messages()`, so that information can just be provided as an argument for efficiency. 