### PR TITLE
[fix for o3-mini formatting issue] Standardize `ask` and `architect` response formats to markdown

### DIFF
--- a/aider/coders/architect_prompts.py
+++ b/aider/coders/architect_prompts.py
@@ -4,7 +4,7 @@ from .base_prompts import CoderPrompts
 
 
 class ArchitectPrompts(CoderPrompts):
-    main_system = """Act as an expert architect engineer and provide direction to your editor engineer.
+    main_system = """{special_model_clause}Act as an expert architect engineer and provide direction to your editor engineer.
 Study the change request and the current code.
 Describe how to modify the code to complete the request.
 The editor engineer will rely solely on your instructions, so make them unambiguous and complete.

--- a/aider/coders/ask_prompts.py
+++ b/aider/coders/ask_prompts.py
@@ -4,7 +4,7 @@ from .base_prompts import CoderPrompts
 
 
 class AskPrompts(CoderPrompts):
-    main_system = """Act as an expert code analyst.
+    main_system = """{special_model_clause}Act as an expert code analyst.
 Answer questions about the supplied code.
 Always reply to the user in {language}.
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1055,6 +1055,12 @@ class Coder:
         else:
             language = "the same language they are using"
 
+        special_model_clause = ""
+        if self.main_model and hasattr(self.main_model, "name"):
+            name = self.main_model.name
+            if name.startswith("o1-") or name.startswith("/o1-") or name.startswith("o3-") or name.startswith("/o3-"):
+                special_model_clause = "Formatting re-enabled\n"
+
         prompt = prompt.format(
             fence=self.fence,
             lazy_prompt=lazy_prompt,
@@ -1062,6 +1068,7 @@ class Coder:
             shell_cmd_prompt=shell_cmd_prompt,
             shell_cmd_reminder=shell_cmd_reminder,
             language=language,
+            special_model_clause=special_model_clause,
         )
         return prompt
 


### PR DESCRIPTION
A few users in discord, including myself, have mentioned that `o3-mini` doesn't format code well in `ask` or `architect` mode [[1](https://discord.com/channels/1131200896827654144/1131200896827654149/1335546154368241726)] [[2](https://discord.com/channels/1131200896827654144/1335433322431774772/1335433322431774772)] [[3](https://discord.com/channels/1131200896827654144/1335691069412737085/1335691069412737085)].

I doubt this will negatively impact benchmark results as these are not editor prompts.