### PR TITLE
Switch Deepseek-R1 to not use system prompt

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -308,6 +308,11 @@ class Model(ModelSettings):
             self.use_temperature = False
             return  # <--
 
+        if model.startswith("deepseek-r1") or "/deepseek-r1" in model:
+            self.use_system_prompt = False
+            self.use_temperature = True
+            return  # <--
+        
         if (
             "qwen" in model
             and "coder" in model


### PR DESCRIPTION
Based on the R1 paper and the R1 repo: https://github.com/deepseek-ai/DeepSeek-R1

> Usage Recommendations
> 
> We recommend adhering to the following configurations when utilizing the DeepSeek-R1 series models, including benchmarking, to achieve the expected performance:
> 
> Set the temperature within the range of 0.5-0.7 (0.6 is recommended) to prevent endless repetitions or incoherent outputs.
> **Avoid adding a system prompt; all instructions should be contained within the user prompt.**
> For mathematical problems, it is advisable to include a directive in your prompt such as: "Please reason step by step, and put your final answer within \boxed{}."
> When evaluating model performance, it is recommended to conduct multiple tests and average the results.
> Additionally, we have observed that the DeepSeek-R1 series models tend to bypass thinking pattern (i.e., outputting "<think>\n\n</think>") when responding to certain queries, which can adversely affect the model's performance. To ensure that the model engages in thorough reasoning, we recommend enforcing the model to initiate its response with "<think>\n" at the beginning of every output.

Disabled system prompt have better performance when supplied directly as user.

---

I have also experimented with the temperature, and I have found a better architect results when using the recommended 0.6. That one would require your benchmarking based on your tests though, so I'm leaving it out of this simple PR.

Additonally, I'm testing remove_reasong with `think` and that also has impact on responses, althrough bit buggy with stream = True.