### PR TITLE
refactor: Sort files by token count in cmd_tokens

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -404,6 +404,7 @@ class Commands:
 
         fence = "`" * 3
 
+        file_res = []
         # files
         for fname in self.coder.abs_fnames:
             relative_fname = self.coder.get_rel_fname(fname)
@@ -414,7 +415,7 @@ class Commands:
                 # approximate
                 content = f"{relative_fname}\n{fence}\n" + content + "{fence}\n"
                 tokens = self.coder.main_model.token_count(content)
-            res.append((tokens, f"{relative_fname}", "/drop to remove"))
+            file_res.append((tokens, f"{relative_fname}", "/drop to remove"))
 
         # read-only files
         for fname in self.coder.abs_read_only_fnames:
@@ -424,7 +425,10 @@ class Commands:
                 # approximate
                 content = f"{relative_fname}\n{fence}\n" + content + "{fence}\n"
                 tokens = self.coder.main_model.token_count(content)
-                res.append((tokens, f"{relative_fname} (read-only)", "/drop to remove"))
+                file_res.append((tokens, f"{relative_fname} (read-only)", "/drop to remove"))
+
+        file_res.sort()
+        res.extend(file_res)
 
         self.io.tool_output(
             f"Approximate context window usage for {self.coder.main_model.name}, in tokens:"


### PR DESCRIPTION
```
Approximate context window usage for openrouter/anthropic/claude-3.5-sonnet, in tokens:

$ 0.0059    1,976 system messages          
$ 0.0108    3,597 repository map           use --map-tokens to resize
$ 0.0001       30 aider/__main__.py        /drop to remove
$ 0.0003       92 aider/help_pats.py       /drop to remove
$ 0.0004      135 aider/__init__.py        /drop to remove
$ 0.0004      136 aider/watch_prompts.py   /drop to remove
$ 0.0006      193 aider/dump.py            /drop to remove
$ 0.0008      274 aider/format_settings.py /drop to remove
$ 0.0009      285 aider/llm.py             /drop to remove
$ 0.0009      313 aider/urls.py            /drop to remove
$ 0.0012      413 aider/copypaste.py       /drop to remove
$ 0.0016      533 aider/prompts.py         /drop to remove
$ 0.0020      672 aider/versioncheck.py    /drop to remove
$ 0.0020      677 aider/exceptions.py      /drop to remove
$ 0.0024      800 aider/diffs.py           /drop to remove
$ 0.0027      897 aider/run_cmd.py         /drop to remove
$ 0.0029      975 aider/editor.py          /drop to remove
$ 0.0030    1,001 aider/help.py            /drop to remove
$ 0.0030    1,010 aider/history.py         /drop to remove
$ 0.0031    1,025 aider/sendchat.py        /drop to remove
$ 0.0037    1,219 aider/special.py         /drop to remove
$ 0.0040    1,317 aider/mdstream.py        /drop to remove
$ 0.0040    1,324 aider/args_formatter.py  /drop to remove
$ 0.0041    1,369 aider/report.py          /drop to remove
$ 0.0041    1,372 aider/voice.py           /drop to remove
$ 0.0048    1,612 aider/analytics.py       /drop to remove
$ 0.0052    1,733 aider/scrape.py          /drop to remove
$ 0.0056    1,867 aider/linter.py          /drop to remove
$ 0.0059    1,953 aider/watch.py           /drop to remove
$ 0.0071    2,368 aider/utils.py           /drop to remove
$ 0.0088    2,935 aider/repo.py            /drop to remove
$ 0.0110    3,669 aider/gui.py             /drop to remove
$ 0.0153    5,116 aider/repomap.py         /drop to remove
$ 0.0156    5,202 aider/models.py          /drop to remove
$ 0.0177    5,888 aider/args.py            /drop to remove
$ 0.0207    6,916 aider/io.py              /drop to remove
$ 0.0254    8,475 aider/main.py            /drop to remove
$ 0.0331   11,023 aider/commands.py        /drop to remove
==================
$ 0.2412   80,392 tokens total
          119,608 tokens remaining in context window
          200,000 tokens max context window size
```