### PR TITLE
docs(infinite-output): add bedrock/ prefix

### DIFF
--- a/aider/website/docs/more/infinite-output.md
+++ b/aider/website/docs/more/infinite-output.md
@@ -68,8 +68,8 @@ cog.out(model_list)
 - deepseek/deepseek-chat
 - deepseek/deepseek-coder
 - deepseek/deepseek-reasoner
-- eu.anthropic.claude-3-5-haiku-20241022-v1:0
-- eu.anthropic.claude-3-5-sonnet-20241022-v2:0
+- bedrock/eu.anthropic.claude-3-5-haiku-20241022-v1:0
+- bedrock/eu.anthropic.claude-3-5-sonnet-20241022-v2:0
 - mistral/codestral-2405
 - mistral/codestral-latest
 - mistral/codestral-mamba-latest
@@ -94,8 +94,8 @@ cog.out(model_list)
 - mistral/pixtral-large-latest
 - openrouter/anthropic/claude-3.5-sonnet
 - openrouter/deepseek/deepseek-r1
-- us.anthropic.claude-3-5-haiku-20241022-v1:0
-- us.anthropic.claude-3-5-sonnet-20241022-v2:0
+- bedrock/us.anthropic.claude-3-5-haiku-20241022-v1:0
+- bedrock/us.anthropic.claude-3-5-sonnet-20241022-v2:0
 - vertex_ai/claude-3-5-haiku
 - vertex_ai/claude-3-5-haiku@20241022
 - vertex_ai/claude-3-5-sonnet


### PR DESCRIPTION
Adding the missing `bedrock/` prefix in the infinite output documentation for AWS Bedrock models. 