### PR TITLE
fix: Use shlex.quote() to enable linting filepaths containing shell metacharacters

### DIFF
--- a/aider/linter.py
+++ b/aider/linter.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import traceback
 import warnings
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -44,7 +45,7 @@ class Linter:
             return fname
 
     def run_cmd(self, cmd, rel_fname, code):
-        cmd += " " + rel_fname
+        cmd += " " + shlex.quote(rel_fname)
 
         returncode = 0
         stdout = ""


### PR DESCRIPTION
In, for example, Next.js projects, certain paths must contain components with filenames containing shell metacharacters, such as app/(auth)/login.ts for example.  These paths must be quoted for the shell to do the right thing and interpret those characters literally.  

Without this tiny patch, try to run the linter on such files results in an errror.  With this patch, it invokes the command with the files correctly.

This is a general issue, and shlex.quote implements a solution designed to be portable across shells.  It may be possible to craft a malicious filename to circumvent it on non-Unix hosts, according to the docs, but quoting it at all seems to be a step in the right direction -- this does not add to that class of vulnerability.