### PR TITLE
fix: wrap rel_fname in quote

### DIFF
--- a/aider/linter.py
+++ b/aider/linter.py
@@ -44,7 +44,7 @@ class Linter:
             return fname
 
     def run_cmd(self, cmd, rel_fname, code):
-        cmd += " " + rel_fname
+        cmd += " \"" + rel_fname + "\""
 
         returncode = 0
         stdout = ""


### PR DESCRIPTION
resolves: https://github.com/Aider-AI/aider/issues/3182

## Summary

Wraps `rel_fname` in double quotes (") for [linter.py](aider/linter.py) so that filepaths with `()[]` characters e.g. `src/(main)/product/[id]/page.tsx` is recognized as one argument instead of shell trying to parse it as glob paths.