### PR TITLE
Add ability to change the model from the browser

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -19,7 +19,7 @@ from PIL import Image
 from aider.dump import dump  # noqa: F401
 from aider.llm import litellm
 from aider.sendchat import ensure_alternating_roles, sanity_check_messages
-
+__all__ = [..., 'get_chat_models']
 RETRY_TIMEOUT = 60
 
 request_timeout = 600
@@ -775,9 +775,7 @@ def sanity_check_model(io, model):
     return show
 
 
-def fuzzy_match_models(name):
-    name = name.lower()
-
+def get_chat_models():
     chat_models = set()
     for orig_model, attrs in litellm.model_cost.items():
         model = orig_model.lower()
@@ -796,14 +794,11 @@ def fuzzy_match_models(name):
         chat_models.add(fq_model)
         chat_models.add(orig_model)
 
-    chat_models = sorted(chat_models)
-    # exactly matching model
-    # matching_models = [
-    #    (fq,m) for fq,m in chat_models
-    #    if name == fq or name == m
-    # ]
-    # if matching_models:
-    #    return matching_models
+    return sorted(chat_models)
+
+def fuzzy_match_models(name):
+    name = name.lower()
+    chat_models = get_chat_models()
 
     # Check for model names containing the name
     matching_models = [m for m in chat_models if name in m]


### PR DESCRIPTION
This adds the ability to change the model from the browser.     There are 3 methods shown here under `do_model_selector` (first two commented out).   I don't know aider I tried having aider do so it mostly generated the first solution.   The current implementation is closest to what I think happens on the command line but the command line really throws nearly everything away so it may not be doing that as well.

If the current implementation is best ill simplify this down to remove the code I didn't end up needing.   The second method self.get_coder which called cli_main again (and thus the force_model changes in cli_main) are the only reason cli_main has force_model so that would be removed if that method isn't used.

It works thats about all I can attest to.