### PR TITLE
fix: return combined output of failed test to trigger fix

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -945,6 +945,7 @@ class Commands:
 
             if add and exit_status != 0:
                 self.io.placeholder = "What's wrong? Fix"
+                return combined_output
 
     def cmd_exit(self, args):
         "Exit the application"


### PR DESCRIPTION
Fixes #3140 by returning the combined output of a failed test, which is the same as how failed lint commands work.

This section of base coder is expecting failed tests to return errors to trigger the prompt:
```python
        if edited and self.auto_test:
            test_errors = self.commands.cmd_test(self.test_cmd)
            self.test_outcome = not test_errors
            if test_errors:
                ok = self.io.confirm_ask("Attempt to fix test errors?")
                if ok:
                    self.reflected_message = test_errors
                    return
```