### PR TITLE
fix: add build.gradle.kts to special.py

### DIFF
--- a/aider/special.py
+++ b/aider/special.py
@@ -41,6 +41,7 @@ ROOT_IMPORTANT_FILES = [
     "composer.lock",
     "pom.xml",
     "build.gradle",
+    "build.gradle.kts",
     "build.sbt",
     "go.mod",
     "go.sum",


### PR DESCRIPTION
Now that aider supports Kotlin syntax, this change will allow for indexing of kotlin-based gradle project files