### PR TITLE
Fix test for `get_environment_editor()`

### DIFF
--- a/tests/basic/test_editor.py
+++ b/tests/basic/test_editor.py
@@ -21,7 +21,7 @@ def test_get_environment_editor():
         assert get_environment_editor("default") == "default"
 
     # Test EDITOR precedence
-    with patch.dict(os.environ, {"EDITOR": "vim"}):
+    with patch.dict(os.environ, {"EDITOR": "vim"}, clear=True):
         assert get_environment_editor() == "vim"
 
     # Test VISUAL overrides EDITOR


### PR DESCRIPTION
The test for `EDITOR` preference failed to clean up any existing value of `VISUAL` which may be present in the environment pytest is run in.

For example, on my laptop I have `VISUAL` set to `nano`, and the test would fail with:
```python
    def test_get_environment_editor():
        # Test with no environment variables set
        with patch.dict(os.environ, {}, clear=True):
            assert get_environment_editor("default") == "default"
    
        # Test EDITOR precedence
        with patch.dict(os.environ, {"EDITOR": "vim"}):
>           assert get_environment_editor() == "vim"
E           AssertionError: assert 'nano' == 'vim'
E             
E             - vim
E             + nano

tests/basic/test_editor.py:25: AssertionError
```