### PR TITLE
fix: Handle EOFError gracefully in confirm_ask method

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -750,14 +750,17 @@ class InputOutput:
             self.user_input(f"{question}{res}", log_only=False)
         else:
             while True:
-                if self.prompt_session:
-                    res = self.prompt_session.prompt(
-                        question,
-                        style=style,
-                        complete_while_typing=False,
-                    )
-                else:
-                    res = input(question)
+                try:
+                    if self.prompt_session:
+                        res = self.prompt_session.prompt(
+                            question,
+                            style=style,
+                            complete_while_typing=False,
+                        )
+                    else:
+                        res = input(question)
+                except (EOFError, KeyboardInterrupt):
+                    return False
 
                 if not res:
                     res = default


### PR DESCRIPTION
Small change to not dump a traceback if Ctrl-D is hit instead of answering the question.