### PR TITLE
feat: Add various HTTP Client settings

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -215,6 +215,21 @@ def get_parser(default_config_files, git_root):
         help="Verify the SSL cert when connecting to models (default: True)",
     )
     group.add_argument(
+        "--client-cert",
+        type=str,
+        help="Specify the client certificate file for TLS connections",
+    )
+    group.add_argument(
+        "--client-cert-key",
+        type=str,
+        help="Specify the client certificate key file for TLS connections",
+    )
+    group.add_argument(
+        "--auth-cookie",
+        type=str,
+        help="A cookie that will be sent with all HTTP requests (e.g. for authentication)",
+    )
+    group.add_argument(
         "--timeout",
         type=float,
         default=None,

--- a/aider/main.py
+++ b/aider/main.py
@@ -2,12 +2,14 @@ import configparser
 import json
 import os
 import re
+import ssl
 import sys
 import threading
 import traceback
 import webbrowser
 from dataclasses import fields
 from pathlib import Path
+import httpx
 
 try:
     import git
@@ -512,14 +514,36 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         analytics = Analytics(permanently_disable=True)
         print("Analytics have been permanently disabled.")
 
+    litellm._load_litellm()
+    http_client = httpx.Client()
+    async_client = httpx.AsyncClient()
+    
     if not args.verify_ssl:
-        import httpx
-
         os.environ["SSL_VERIFY"] = ""
-        litellm._load_litellm()
-        litellm._lazy_module.client_session = httpx.Client(verify=False)
-        litellm._lazy_module.aclient_session = httpx.AsyncClient(verify=False)
+        http_client = httpx.Client(verify=False)
+        async_client = httpx.AsyncClient(verify=False)
 
+    if args.client_cert:
+        if not args.client_cert_key:
+            print("Expected both --client-cert and --client-cert-key.")
+            return False
+        context = ssl.create_default_context()
+        context.load_cert_chain(certfile=args.client_cert, keyfile=args.client_cert_key)
+
+        http_client = httpx.Client(verify=context)
+        async_client = httpx.AsyncClient(verify=context)
+
+    if args.auth_cookie:
+        try:
+            cookie_name, cookie_value = args.auth_cookie.split("=", 1)
+            http_client.cookies = httpx.Cookies({cookie_name: cookie_value})
+        except ValueError:
+            print("Invalid format for --auth-cookie. Expected format: name=value")
+            return False
+
+    litellm._lazy_module.client_session = http_client
+    litellm._lazy_module.aclient_session = async_client
+    
     if args.timeout:
         models.request_timeout = args.timeout
 


### PR DESCRIPTION
Options to load a TLS Client certificate.
An option to set an authentication cookie.

These are necessary for talking to certain configurations of backends.