### PR TITLE
use playwright if available when invoking scraper via cli

### DIFF
--- a/aider/gui.py
+++ b/aider/gui.py
@@ -11,7 +11,7 @@ from aider.coders import Coder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.main import main as cli_main
-from aider.scrape import Scraper
+from aider.scrape import Scraper, has_playwright
 
 
 class CaptureIO(InputOutput):
@@ -484,7 +484,7 @@ class GUI:
         url = self.web_content
 
         if not self.state.scraper:
-            self.scraper = Scraper(print_error=self.info)
+            self.scraper = Scraper(print_error=self.info, playwright_available=has_playwright())
 
         content = self.scraper.scrape(url) or ""
         if content.strip():

--- a/aider/scrape.py
+++ b/aider/scrape.py
@@ -14,7 +14,7 @@ aider_user_agent = f"Aider/{__version__} +{urls.website}"
 # platforms.
 
 
-def install_playwright(io):
+def check_env():
     try:
         from playwright.sync_api import sync_playwright
 
@@ -29,6 +29,16 @@ def install_playwright(io):
     except Exception:
         has_chromium = False
 
+    return has_pip, has_chromium
+
+
+def has_playwright():
+    has_pip, has_chromium = check_env()
+    return has_pip and has_chromium
+
+
+def install_playwright(io):
+    has_pip, has_chromium = check_env()
     if has_pip and has_chromium:
         return True
 
@@ -261,7 +271,7 @@ def slimdown_html(soup):
 
 
 def main(url):
-    scraper = Scraper()
+    scraper = Scraper(playwright_available=has_playwright())
     content = scraper.scrape(url)
     print(content)
 


### PR DESCRIPTION
I just discovered aider (it looks great so far!) and while exploring the installation / configuration options I ran into a problem with the scraper where it wasn't picking up any content from our SPA.

After some debugging of my playwright install I finally realized the sample command `python -m aider.scrape https://aider.chat/docs/usage/tips.html` I was referencing from [the docs ](https://aider.chat/docs/usage/images-urls.html#web-pages) would never utilize the playwright backend. This is an attempt to fix this behavior for the sample command in the docs and also for the experimental web GUI.