### PR TITLE
Add clarifying instructions to LM Studio config

### DIFF
--- a/aider/website/docs/llms/lm-studio.md
+++ b/aider/website/docs/llms/lm-studio.md
@@ -10,16 +10,18 @@ To use LM Studio:
 ```
 python -m pip install -U aider-chat
 
+# Must set a value here even if its a dummy value
 export LM_STUDIO_API_KEY=<key> # Mac/Linux
 setx   LM_STUDIO_API_KEY <key> # Windows, restart shell after setx
 
+# LM Studio default server URL is http://localhost:1234/v1
 export LM_STUDIO_API_BASE=<url> # Mac/Linux
 setx   LM_STUDIO_API_BASE <url> # Windows, restart shell after setx
 
 aider --model lm_studio/<your-model-name>
 ```
 
-
+**Note:** Even though LM Studio doesn't require an API Key out of the box the `LM_STUDIO_API_KEY` must have a dummy value like `dummy-api-key` set or the client request will fail trying to send an empty `Bearer` token.
 
 See the [model warnings](warnings.html)
 section for information on warnings which will occur


### PR DESCRIPTION
There are a few small gotchas when configuring LM Studio to work with aider. This adds a few clarifying instructions to the documentation.