### PR TITLE
add new `map-tags-cache-dir` config option

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -309,6 +309,18 @@ def get_parser(default_config_files, git_root):
         default=2,
         help="Multiplier for map tokens when no files are specified (default: 2)",
     )
+    default_map_tags_cache_dir = (
+        os.path.join(git_root, ".aider.tags.cache") if git_root else ".aider.tags.cache"
+    )
+    group.add_argument(
+        "--map-tags-cache-dir",
+        metavar="MAP_TAGS_CACHE_DIR",
+        default=default_map_tags_cache_dir,
+        help=(
+            "Specify the directory for the repo map tags cache (default:"
+            f" {default_map_tags_cache_dir})"
+        ),
+    )
 
     ##########
     group = parser.add_argument_group("History Files")

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -304,6 +304,7 @@ class Coder:
         ignore_mentions=None,
         file_watcher=None,
         auto_copy_context=False,
+        map_tags_cache_dir=None,
     ):
         # Fill in a dummy Analytics if needed, but it is never .enable()'d
         self.analytics = analytics if analytics is not None else Analytics()
@@ -459,6 +460,7 @@ class Coder:
                 max_inp_tokens,
                 map_mul_no_files=map_mul_no_files,
                 refresh=map_refresh,
+                tags_cache_dir=map_tags_cache_dir,
             )
 
         self.summarizer = summarizer or ChatSummary(

--- a/aider/main.py
+++ b/aider/main.py
@@ -926,6 +926,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             chat_language=args.chat_language,
             detect_urls=args.detect_urls,
             auto_copy_context=args.copy_paste,
+            map_tags_cache_dir=args.map_tags_cache_dir,
         )
     except UnknownEditFormat as err:
         io.tool_error(str(err))

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -37,7 +37,7 @@ if USING_TSL_PACK:
 
 
 class RepoMap:
-    TAGS_CACHE_DIR = f".aider.tags.cache.v{CACHE_VERSION}"
+    TAGS_CACHE_DIR = ".aider.tags.cache"
 
     warned_files = set()
 
@@ -52,6 +52,7 @@ class RepoMap:
         max_context_window=None,
         map_mul_no_files=8,
         refresh="auto",
+        tags_cache_dir=None,
     ):
         self.io = io
         self.verbose = verbose
@@ -60,6 +61,8 @@ class RepoMap:
         if not root:
             root = os.getcwd()
         self.root = root
+
+        self.TAGS_CACHE_DIR = f"{tags_cache_dir or self.TAGS_CACHE_DIR}.v{CACHE_VERSION}"
 
         self.load_tags_cache()
         self.cache_threshold = 0.95

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -164,6 +164,9 @@
 ## Multiplier for map tokens when no files are specified (default: 2)
 #map-multiplier-no-files: true
 
+## Specify the directory for the repo map tags cache (default: .aider.tags.cache)
+#map-tags-cache-dir: .aider.tags.cache
+
 ################
 # History Files:
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -153,6 +153,9 @@
 ## Multiplier for map tokens when no files are specified (default: 2)
 #AIDER_MAP_MULTIPLIER_NO_FILES=true
 
+## Specify the directory for the repo map tags cache (default: .aider.tags.cache)
+#AIDER_MAP_TAGS_CACHE_DIR=.aider.tags.cache
+
 ################
 # History Files:
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -218,6 +218,9 @@ cog.outl("```")
 ## Multiplier for map tokens when no files are specified (default: 2)
 #map-multiplier-no-files: true
 
+## Specify the directory for the repo map tags cache (default: .aider.tags.cache)
+#map-tags-cache-dir: .aider.tags.cache
+
 ################
 # History Files:
 

--- a/aider/website/docs/config/dotenv.md
+++ b/aider/website/docs/config/dotenv.md
@@ -193,6 +193,9 @@ cog.outl("```")
 ## Multiplier for map tokens when no files are specified (default: 2)
 #AIDER_MAP_MULTIPLIER_NO_FILES=true
 
+## Specify the directory for the repo map tags cache (default: .aider.tags.cache)
+#AIDER_MAP_TAGS_CACHE_DIR=.aider.tags.cache
+
 ################
 # History Files:
 

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -294,6 +294,11 @@ Multiplier for map tokens when no files are specified (default: 2)
 Default: 2  
 Environment variable: `AIDER_MAP_MULTIPLIER_NO_FILES`  
 
+### `--map-tags-cache-dir TAGS_CACHE_DIR`
+Specify the directory for the repo map tags cache (default: .aider.tags.cache)
+Default: .aider.tags.cache
+Environment variable: `AIDER_MAP_TAGS_CACHE_DIR`
+
 ## History Files:
 
 ### `--input-history-file INPUT_HISTORY_FILE`


### PR DESCRIPTION
I'm new to aider and I noticed quite a few new ignored files / directories being created in my projects. While looking for config options to organize various `.aider*` files into a single directory I wasn't able to find a way control the location of the `.aider.tags.cache.*` directory. This PR just adds a new config option to address that.