### PR TITLE
Retrieve the identity using git-config command

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -126,17 +126,8 @@ def setup_git(git_root, io):
     if not repo:
         return
 
-    user_name = None
-    user_email = None
-    with repo.config_reader() as config:
-        try:
-            user_name = config.get_value("user", "name", None)
-        except (configparser.NoSectionError, configparser.NoOptionError):
-            pass
-        try:
-            user_email = config.get_value("user", "email", None)
-        except (configparser.NoSectionError, configparser.NoOptionError):
-            pass
+    user_name = repo.git.config("--default", "", "--get", "user.name") or None
+    user_email = repo.git.config("--default", "", "--get", "user.email") or None
 
     if user_name and user_email:
         return repo.working_tree_dir

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -145,7 +145,7 @@ class GitRepo:
         else:
             cmd += ["-a"]
 
-        original_user_name = self.repo.config_reader().get_value("user", "name")
+        original_user_name = self.repo.git.config("--get", "user.name")
         original_committer_name_env = os.environ.get("GIT_COMMITTER_NAME")
         committer_name = f"{original_user_name} (aider)"
 


### PR DESCRIPTION
Fixes #2668 (and #1085). 

By using `git-config` command, both local and global git settings will be considered. 

I don't know what to do with the fallback identity. I have left it as it is. If either user or email is unavailable from any of the git configs, aider will still set the fake identity. 