### PR TITLE
Adding OpenRouter deepseek-chat:free (V3)

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,10 @@
 
 - Aider wrote 74% of the code in this release.
 
+### Aider v0.75.3
+
+- Support for V3 free on OpenRouter: `--model openrouter/deepseek/deepseek-chat:free`
+
 ### Aider v0.75.2
 
 - Added support for Claude 3.7 Sonnet models on OpenRouter, Bedrock and Vertex AI.

--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -47,6 +47,22 @@
         //"supports_tool_choice": true,
         "supports_prompt_caching": true
     },
+    "openrouter/deepseek/deepseek-chat:free": {
+        "max_tokens": 8192,
+        "max_input_tokens": 64000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.0,
+        "input_cost_per_token_cache_hit": 0.0,
+        "cache_read_input_token_cost": 0.00,
+        "cache_creation_input_token_cost": 0.0,
+        "output_cost_per_token": 0.0,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        //"supports_function_calling": true, 
+        "supports_assistant_prefill": true,
+        //"supports_tool_choice": true,
+        "supports_prompt_caching": true
+    },
     "fireworks_ai/accounts/fireworks/models/deepseek-r1": {
         "max_tokens": 160000,
         "max_input_tokens": 128000,

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -585,6 +585,18 @@
     max_tokens: 8192
   caches_by_default: true
 
+- name: openrouter/deepseek/deepseek-chat:free
+  edit_format: diff
+  weak_model_name: openrouter/deepseek/deepseek-chat:free
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+  caches_by_default: true
+  use_temperature: false
+  editor_model_name: openrouter/deepseek/deepseek-chat:free
+  editor_edit_format: editor-diff
+
 - name: deepseek/deepseek-coder
   edit_format: diff
   use_repo_map: true

--- a/aider/website/HISTORY.md
+++ b/aider/website/HISTORY.md
@@ -27,6 +27,10 @@ cog.out(text)
 
 - Aider wrote 74% of the code in this release.
 
+### Aider v0.75.3
+
+- Support for V3 free on OpenRouter: `--model openrouter/deepseek/deepseek-chat:free`
+
 ### Aider v0.75.2
 
 - Added support for Claude 3.7 Sonnet models on OpenRouter, Bedrock and Vertex AI.

--- a/aider/website/docs/config/adv-model-settings.md
+++ b/aider/website/docs/config/adv-model-settings.md
@@ -851,6 +851,19 @@ cog.out("```\n")
   use_repo_map: true
   reminder: sys
   examples_as_sys_msg: true
+  editor_edit_format: editor-diff
+
+- name: openrouter/deepseek/deepseek-chat:free
+  edit_format: diff
+  weak_model_name: openrouter/deepseek/deepseek-chat:free
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+  caches_by_default: true
+  use_temperature: false
+  editor_model_name: openrouter/deepseek/deepseek-chat:free
+  editor_edit_format: editor-diff
 
 - name: openrouter/deepseek/deepseek-coder
   edit_format: diff


### PR DESCRIPTION
Support for DeepSeek V3 (Free) via OpenRouter, see [https://openrouter.ai/deepseek/deepseek-chat:free](https://openrouter.ai/deepseek/deepseek-chat:free).