### PR TITLE
fix: add uv as development dependency

### DIFF
--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -491,6 +491,8 @@ urllib3==2.3.0
     # via
     #   mixpanel
     #   requests
+uv==0.6.4
+    # via -r requirements/requirements-dev.in
 virtualenv==20.29.2
     # via pre-commit
 watchfiles==1.0.4

--- a/requirements/requirements-dev.in
+++ b/requirements/requirements-dev.in
@@ -10,3 +10,4 @@ pre-commit
 cogapp
 semver
 codespell
+uv

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -205,6 +205,10 @@ tzdata==2025.1
     # via
     #   -c requirements/common-constraints.txt
     #   pandas
+uv==0.6.4
+    # via
+    #   -c requirements/common-constraints.txt
+    #   -r requirements/requirements-dev.in
 virtualenv==20.29.2
     # via
     #   -c requirements/common-constraints.txt


### PR DESCRIPTION
`uv` is used in `pip-compile.sh`, so this PR adds it as a dev dependency.
