### PR TITLE
feat: use copy-paste instead of api

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -585,6 +585,12 @@ def get_parser(default_config_files, git_root):
         help="Enable automatic copy/paste of chat between aider and web UI (default: False)",
     )
     group.add_argument(
+        "--copy-paste-no-api",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Use automatic copy/paste of chat between aider and web UI instead of API (default: False)",
+    )
+    group.add_argument(
         "--apply",
         metavar="FILE",
         help="Apply the changes from the given file instead of running the chat (debug)",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -201,6 +201,9 @@ class Coder:
         main_model = self.main_model
         weak_model = main_model.weak_model
 
+        if main_model.copy_paste_no_api:
+            lines.append("Running in copy-paste mode instead of using API")
+
         if weak_model is not main_model:
             prefix = "Main model"
         else:

--- a/aider/main.py
+++ b/aider/main.py
@@ -771,6 +771,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         weak_model=args.weak_model,
         editor_model=args.editor_model,
         editor_edit_format=args.editor_edit_format,
+        copy_paste_no_api=args.copy_paste_no_api,
+        io=io,
     )
 
     # Check if deprecated remove_reasoning is set
@@ -869,6 +871,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if args.cache_prompts and args.map_refresh == "auto":
         args.map_refresh = "files"
 
+    if args.copy_paste_no_api:
+        args.stream = False
+    
     if not main_model.streaming:
         if args.stream:
             io.tool_warning(


### PR DESCRIPTION
Thanks for your work on `aider`, it's a truly amazing open-source project!

See https://github.com/Aider-AI/aider/issues/3479

Inpired by aider's [copy-paste](https://aider.chat/docs/usage/copypaste.html) mode and Roo-Codes's [Human Relay](https://github.com/RooVetGit/Roo-Code/pull/1267) feature, I integrated a proof-of-concept `--copy-paste-no-api` mode into aider.

The `--copy-paste-no-api` mode allows using aider with a web ui **only** and **without** any api.

Why would anyone want to use this?

As already nicely explained in https://github.com/RooVetGit/Roo-Code/pull/1267
* aider works fully without api key
* very useful for using aider at e.g. work where
  * sending code to api / hosting local ollama model is not allowed/possible
  * but using web ui like GitHub copilot is allowed
* cost per token if often cheaper in web ui than in api
* equivalent to aider's `--copy-paste` mode this should not violate ToS

As this is just a quick proof-of-concept implementation, I appreciate feedback on how such a feature can fit best within aider's architecture. The code has some rough edges, e.g. passing `io` to `Models` class.

Also, I'm confident someone will find a better name for this than `--copy-paste-no-api`.

To test this, check out the PR's branch and run aider with:
```sh
aider --copy-paste-no-api --model claude-3-7-sonnet-20250219
```

Here is a short screen recording demonstrating this feature

https://github.com/user-attachments/assets/e83c1a81-b970-44c6-99ea-879589399ecb

