### PR TITLE
benchmark: eases configuration of ollama and ENV variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+OPENAI_BASE_URL=http://host.docker.internal:11434/v1
+OPENAI_API_KEY=unused
+CHAT_MODEL=qwen2.5:3b

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -58,8 +58,8 @@ git clone https://github.com/Aider-AI/polyglot-benchmark tmp.benchmarks/polyglot
 
 ### Running the benchmark
 
-Launch the docker container and run the benchmark inside it:
-
+If your model requires ENV variables, such as `OPENAI_API_KEY`, add them to
+your `.env` file. Then, run a docker container and a benchmark inside it:
 ```
 # Launch the docker container
 ./benchmark/docker.sh

--- a/benchmark/docker.sh
+++ b/benchmark/docker.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
 
+# This runs docker with localhost mapped to the host-gateway for convenience.
+# This allows default ENV to work for configuration such as Ollama endponts.
 docker run \
        -it --rm \
        --memory=25g \
        --memory-swap=25g \
-       --add-host=host.docker.internal:host-gateway \
+       --env-file .env \
+       --add-host=localhost:host-gateway \
        -v `pwd`:/aider \
        -v `pwd`/tmp.benchmarks/.:/benchmarks \
-       -e OPENAI_API_KEY=$OPENAI_API_KEY \
        -e HISTFILE=/aider/.bash_history \
        -e PROMPT_COMMAND='history -a' \
        -e HISTCONTROL=ignoredups \


### PR DESCRIPTION
This switches docker so that it uses `--env-file .env` instead of cherry-picking certain LLM variables such as `OPENAI_API_KEY`.

It also maps the container's localhost to the host-gateway, which is a neat trick to make ollama or other local model providers work without any ENV (as you no longer need to say `host.docker.internal` since it defaults to `localhost`)