### PR TITLE
refactor: add ignore_permission_denied option to watch function

### DIFF
--- a/aider/watch.py
+++ b/aider/watch.py
@@ -140,7 +140,10 @@ class FileWatcher:
             roots_to_watch = self.get_roots_to_watch()
 
             for changes in watch(
-                *roots_to_watch, watch_filter=self.filter_func, stop_event=self.stop_event
+                *roots_to_watch,
+                watch_filter=self.filter_func,
+                stop_event=self.stop_event,
+                ignore_permission_denied=True,
             ):
                 if self.handle_changes(changes):
                     return


### PR DESCRIPTION
This PR addresses an issue where Aider fails to launch due to `PermissionError`.
In monorepos or complex repository configurations, permission errors can occur due to reasons such as Docker volume mounts.
In some cases, these errors are unavoidable, so this PR proposes that `PermissionError` can be safely ignored.