### PR TITLE
remove empty default git config lookup

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -126,8 +126,8 @@ def setup_git(git_root, io):
     if not repo:
         return
 
-    user_name = repo.git.config("--default", "", "--get", "user.name") or None
-    user_email = repo.git.config("--default", "", "--get", "user.email") or None
+    user_name = repo.git.config("--get", "user.name") or None
+    user_email = repo.git.config("--get", "user.email") or None
 
     if user_name and user_email:
         return repo.working_tree_dir


### PR DESCRIPTION
this seems to fix #3497. it appears the change in question was introduced recently in #3423, which was unopinionated with respect to the fallback identity, and it seems a bug may have been introduced. This PR shouldn't do anything about the fallback case, but merely allows for forward progress in the happy path

testing:
tested locally following `CONTRIBUTING.md`, 
```
> aider --version
aider 0.76.2.dev0+g3cb6ec9.d20250311
> aider
```