### PR TITLE
Fix autocomplete for /ask, /code, /architect

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -185,7 +185,7 @@ class AutoCompleter(Completer):
             # don't keep completing after a space
             return
 
-        if text[0] == "/":
+        if text[0] == "/" and len(text.split()) == 1:
             yield from self.get_command_completions(document, complete_event, text, words)
             return
 

--- a/aider/io.py
+++ b/aider/io.py
@@ -185,7 +185,11 @@ class AutoCompleter(Completer):
             # don't keep completing after a space
             return
 
-        if text[0] == "/" and len(text.split()) == 1:
+        # Let /ask, /code, /architect do code symbol completions.
+        if text.startswith("/ask") or text.startswith("/code") or text.startswith("/architect"):
+            pass
+        elif text[0] == "/":
+            # All other slash commands (incl /add) do normal command completions (no code symbols).
             yield from self.get_command_completions(document, complete_event, text, words)
             return
 


### PR DESCRIPTION
Auto-complete didn't work for /ask, /code and /architect, which was a minor annoyance for the way i use aider. This patch enables autocomplete for all the /cmds though... we might want to filter to only allow it for the above mentioned 3 commands?