### PR TITLE
feat: vi-like behavior when pressing enter in multiline-mode

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -18,6 +18,7 @@ from prompt_toolkit.enums import EditingMode
 from prompt_toolkit.filters import Condition, is_searching
 from prompt_toolkit.history import FileHistory
 from prompt_toolkit.key_binding import KeyBindings
+from prompt_toolkit.key_binding.vi_state import InputMode
 from prompt_toolkit.keys import Keys
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.output.vt100 import is_dumb_terminal
@@ -543,8 +544,8 @@ class InputOutput:
         @kb.add("enter", eager=True, filter=~is_searching)
         def _(event):
             "Handle Enter key press"
-            if self.multiline_mode:
-                # In multiline mode, Enter adds a newline
+            if self.multiline_mode and not (self.editingmode == EditingMode.VI and event.app.vi_state.input_mode == InputMode.NAVIGATION):
+                # In multiline mode and if not in vi-mode or vi navigation/normal mode, Enter adds a newline
                 event.current_buffer.insert_text("\n")
             else:
                 # In normal mode, Enter submits


### PR DESCRIPTION
When vi-mode is enabled, there are two modes as usual in vi:
- Insert mode where text can be entered. 
- Normal mode where text can be edited (for example delete word under cursor) but not inserted unless switching to insert-mode. 

When multiline-mode is enabled, currently pressing enter while in normal mode also results in entering a new line. This is unusual behavior in vi-mode. Usually, in such a case the command is sent, which makes sense considering the context where this happens.

I think most vi-users would prefer if in multiline-mode a new line is only added in insert-mode, and in normal-mode the command is sent. This PR fixes this.