### PR TITLE
Dedupe completion options for commands

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -171,7 +171,8 @@ class AutoCompleter(Completer):
 
         candidates = [word for word in candidates if partial in word.lower()]
         for candidate in sorted(candidates):
-            yield Completion(candidate, start_position=-len(words[-1]))
+            if candidate not in words:
+                yield Completion(candidate, start_position=-len(words[-1]))
 
     def get_completions(self, document, complete_event):
         self.tokenize()

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -102,6 +102,7 @@ class TestInputOutput(unittest.TestCase):
             ("/", ["/help", "/add", "/drop"]),
             ("/a", ["/add"]),
             ("/add f", ["file1.txt", "file2.txt"]),
+            ("/add file1.txt f", ["file2.txt"]),
         ]
 
         # Step 6: Iterate through test cases


### PR DESCRIPTION
## Changes                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                    
This PR improves the command completion functionality by filtering out options that have already been mentioned in the current command.                                                                                                             
                                                                                                                                                                                                                                                    
For example, when using the `/add` command with multiple files, once a file has been typed, it won't be suggested again in the same command. This makes the completion suggestions more relevant and reduces clutter.

Another example might be when you're adding a module and its test module. After you've added the first file, you then have to figure out which is the module/test file again to prevent adding the same file twice. If the file name is quite large, it can be quite difficult to distinguish between the module and the test file.

It's not a large thing but happens often enough for it to be inconvenient.
                                                                                                                                                                                                                                                    
## Testing                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                    
Added a test case that verifies this behavior works correctly when completing file names in commands like `/add file1.txt f` where `file2.txt` should be suggested but not `file1.txt` again.