### PR TITLE
Fix missing dotenv for requirements.in

### DIFF
--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -28,6 +28,7 @@ watchfiles
 socksio
 pip
 pillow
+dotenv
 
 # The proper dependency is networkx[default], but this brings
 # in matplotlib and a bunch of other deps


### PR DESCRIPTION
Request for upstream merge.

My front end tool aicode is reporting that this is a missing dependency when it launches aider.chat in an isolated environment.

I fixed it on my end by forcing dotenv to be included.