### PR TITLE
Align markdown headings to the left

### DIFF
--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -85,7 +85,7 @@ class NoInsetMarkdown(Markdown):
         **Markdown.elements,
         "fence": NoInsetCodeBlock,
         "code_block": NoInsetCodeBlock,
-        "heading_open": LeftHeading,  # Use the correct token type key
+        "heading_open": LeftHeading,
     }
 
 

--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -85,12 +85,7 @@ class NoInsetMarkdown(Markdown):
         **Markdown.elements,
         "fence": NoInsetCodeBlock,
         "code_block": NoInsetCodeBlock,
-        "heading1": LeftHeading,
-        "heading2": LeftHeading,
-        "heading3": LeftHeading,
-        "heading4": LeftHeading,
-        "heading5": LeftHeading,
-        "heading6": LeftHeading,
+        "heading_open": LeftHeading,  # Use the correct token type key
     }
 
 

--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -5,7 +5,7 @@ import time
 
 from rich.console import Console
 from rich.live import Live
-from rich.markdown import CodeBlock, Markdown
+from rich.markdown import CodeBlock, Heading, Markdown
 from rich.syntax import Syntax
 from rich.text import Text
 
@@ -56,13 +56,28 @@ class NoInsetCodeBlock(CodeBlock):
         yield syntax
 
 
+class LeftHeading(Heading):
+    """A heading class that renders left-justified."""
+
+    def __rich_console__(self, console, options):
+        text = self.text
+        text.justify = "left"  # Override justification
+        yield text
+
+
 class NoInsetMarkdown(Markdown):
-    """Markdown with code blocks that have no padding."""
+    """Markdown with code blocks that have no padding and left-justified headings."""
 
     elements = {
         **Markdown.elements,
         "fence": NoInsetCodeBlock,
         "code_block": NoInsetCodeBlock,
+        "heading1": LeftHeading,
+        "heading2": LeftHeading,
+        "heading3": LeftHeading,
+        "heading4": LeftHeading,
+        "heading5": LeftHeading,
+        "heading6": LeftHeading,
     }
 
 

--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -3,9 +3,11 @@
 import io
 import time
 
+from rich import box
 from rich.console import Console
 from rich.live import Live
 from rich.markdown import CodeBlock, Heading, Markdown
+from rich.panel import Panel
 from rich.syntax import Syntax
 from rich.text import Text
 
@@ -62,7 +64,18 @@ class LeftHeading(Heading):
     def __rich_console__(self, console, options):
         text = self.text
         text.justify = "left"  # Override justification
-        yield text
+        if self.tag == "h1":
+            # Draw a border around h1s, but keep text left-aligned
+            yield Panel(
+                text,
+                box=box.HEAVY,
+                style="markdown.h1.border",
+            )
+        else:
+            # Styled text for h2 and beyond
+            if self.tag == "h2":
+                yield Text("")  # Keep the blank line before h2
+            yield text
 
 
 class NoInsetMarkdown(Markdown):


### PR DESCRIPTION
improves markdown header rendering for better reading flow.

before, center aligned:
![Screenshot 2025-03-27 at 14 05 36@2x](https://github.com/user-attachments/assets/5c569379-e322-4d41-9a3b-536f7df027d8)



after, left aligned:
![Screenshot 2025-03-27 at 14 06 12@2x](https://github.com/user-attachments/assets/ff2c0a01-7ea6-4e89-9d28-3c680254eb46)

references:
- https://discord.com/channels/1131200896827654144/1354844311216324711

