### PR TITLE
feat: add repomap support for ocaml/ocaml_interface

### DIFF
--- a/aider/queries/tree-sitter-language-pack/ocaml-tags.scm
+++ b/aider/queries/tree-sitter-language-pack/ocaml-tags.scm
@@ -1,0 +1,115 @@
+; Modules
+;--------
+
+(
+  (comment)? @doc .
+  (module_definition (module_binding (module_name) @name.definition.module) @definition.module)
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(module_path (module_name) @name.reference.module) @reference.module
+
+; Module types
+;--------------
+
+(
+  (comment)? @doc .
+  (module_type_definition (module_type_name) @name.definition.interface) @definition.interface
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(module_type_path (module_type_name) @name.reference.implementation) @reference.implementation
+
+; Functions
+;----------
+
+(
+  (comment)? @doc .
+  (value_definition
+    [
+      (let_binding
+        pattern: (value_name) @name.definition.function
+        (parameter))
+      (let_binding
+        pattern: (value_name) @name.definition.function
+        body: [(fun_expression) (function_expression)])
+    ] @definition.function
+  )
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(
+  (comment)? @doc .
+  (external (value_name) @name.definition.function) @definition.function
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(application_expression
+  function: (value_path (value_name) @name.reference.call)) @reference.call
+
+(infix_expression
+  left: (value_path (value_name) @name.reference.call)
+  operator: (concat_operator) @reference.call
+  (#eq? @reference.call "@@"))
+
+(infix_expression
+  operator: (rel_operator) @reference.call
+  right: (value_path (value_name) @name.reference.call)
+  (#eq? @reference.call "|>"))
+
+; Operator
+;---------
+
+(
+  (comment)? @doc .
+  (value_definition
+    (let_binding
+      pattern: (parenthesized_operator (_) @name.definition.function)) @definition.function)
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+[
+  (prefix_operator)
+  (sign_operator)
+  (pow_operator)
+  (mult_operator)
+  (add_operator)
+  (concat_operator)
+  (rel_operator)
+  (and_operator)
+  (or_operator)
+  (assign_operator)
+  (hash_operator)
+  (indexing_operator)
+  (let_operator)
+  (let_and_operator)
+  (match_operator)
+] @name.reference.call @reference.call
+
+; Classes
+;--------
+
+(
+  (comment)? @doc .
+  [
+    (class_definition (class_binding (class_name) @name.definition.class) @definition.class)
+    (class_type_definition (class_type_binding (class_type_name) @name.definition.class) @definition.class)
+  ]
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+[
+  (class_path (class_name) @name.reference.class)
+  (class_type_path (class_type_name) @name.reference.class)
+] @reference.class
+
+; Methods
+;--------
+
+(
+  (comment)? @doc .
+  (method_definition (method_name) @name.definition.method) @definition.method
+  (#strip! @doc "^\\(\\*\\*?\\s*|\\s\\*\\)$")
+)
+
+(method_invocation (method_name) @name.reference.call) @reference.call

--- a/aider/queries/tree-sitter-language-pack/ocaml_interface-tags.scm
+++ b/aider/queries/tree-sitter-language-pack/ocaml_interface-tags.scm
@@ -1,0 +1,98 @@
+; Modules
+;--------
+
+(
+  (comment)? @doc .
+  (module_definition
+    (module_binding (module_name) @name) @definition.module
+  )
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(module_path (module_name) @name) @reference.module
+(extended_module_path (module_name) @name) @reference.module
+
+(
+  (comment)? @doc .
+  (module_type_definition (module_type_name) @name) @definition.interface
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(module_type_path (module_type_name) @name) @reference.implementation
+
+
+; Classes
+;--------
+
+(
+  (comment)? @doc .
+  [
+    (class_definition
+      (class_binding (class_name) @name) @definition.class
+    )
+    (class_type_definition
+      (class_type_binding (class_type_name) @name) @definition.class
+    )
+  ]
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+[
+  (class_path (class_name) @name)
+  (class_type_path (class_type_name) @name)
+] @reference.class
+
+(
+  (comment)? @doc .
+  (method_definition (method_name) @name) @definition.method
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(method_invocation (method_name) @name) @reference.call
+
+
+; Types
+;------
+
+(
+  (comment)? @doc .
+  (type_definition
+    (type_binding
+      name: [
+        (type_constructor) @name
+        (type_constructor_path (type_constructor) @name)
+      ]
+    ) @definition.type
+  )
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(type_constructor_path (type_constructor) @name) @reference.type
+
+[
+  (constructor_declaration (constructor_name) @name)
+  (tag_specification (tag) @name)
+] @definition.enum_variant
+
+[
+  (constructor_path (constructor_name) @name)
+  (tag) @name
+] @reference.enum_variant
+
+(field_declaration (field_name) @name) @definition.field
+
+(field_path (field_name) @name) @reference.field
+
+(
+  (comment)? @doc .
+  (external (value_name) @name) @definition.function
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(
+  (comment)? @doc .
+  (value_specification
+    (value_name) @name.definition.function
+  ) @definition.function
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)

--- a/aider/queries/tree-sitter-languages/ocaml_interface-tags.scm
+++ b/aider/queries/tree-sitter-languages/ocaml_interface-tags.scm
@@ -1,0 +1,98 @@
+; Modules
+;--------
+
+(
+  (comment)? @doc .
+  (module_definition
+    (module_binding (module_name) @name) @definition.module
+  )
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(module_path (module_name) @name) @reference.module
+(extended_module_path (module_name) @name) @reference.module
+
+(
+  (comment)? @doc .
+  (module_type_definition (module_type_name) @name) @definition.interface
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(module_type_path (module_type_name) @name) @reference.implementation
+
+
+; Classes
+;--------
+
+(
+  (comment)? @doc .
+  [
+    (class_definition
+      (class_binding (class_name) @name) @definition.class
+    )
+    (class_type_definition
+      (class_type_binding (class_type_name) @name) @definition.class
+    )
+  ]
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+[
+  (class_path (class_name) @name)
+  (class_type_path (class_type_name) @name)
+] @reference.class
+
+(
+  (comment)? @doc .
+  (method_definition (method_name) @name) @definition.method
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(method_invocation (method_name) @name) @reference.call
+
+
+; Types
+;------
+
+(
+  (comment)? @doc .
+  (type_definition
+    (type_binding
+      name: [
+        (type_constructor) @name
+        (type_constructor_path (type_constructor) @name)
+      ]
+    ) @definition.type
+  )
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(type_constructor_path (type_constructor) @name) @reference.type
+
+[
+  (constructor_declaration (constructor_name) @name)
+  (tag_specification (tag) @name)
+] @definition.enum_variant
+
+[
+  (constructor_path (constructor_name) @name)
+  (tag) @name
+] @reference.enum_variant
+
+(field_declaration (field_name) @name) @definition.field
+
+(field_path (field_name) @name) @reference.field
+
+(
+  (comment)? @doc .
+  (external (value_name) @name) @definition.function
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)
+
+(
+  (comment)? @doc .
+  (value_specification
+    (value_name) @name.definition.function
+  ) @definition.function
+  (#strip! @doc "^\\(\\*+\\s*|\\s*\\*+\\)$")
+)

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -314,8 +314,6 @@ class TestRepoMapAllLanguages(unittest.TestCase):
     def test_language_lua(self):
         self._test_language_repo_map("lua", "lua", "greet")
 
-    # "ocaml": ("ml", "Greeter"), # not supported in tsl-pack (yet?)
-
     def test_language_php(self):
         self._test_language_repo_map("php", "php", "greet")
 
@@ -384,6 +382,12 @@ class TestRepoMapAllLanguages(unittest.TestCase):
     def test_language_scala(self):
         self._test_language_repo_map("scala", "scala", "Greeter")
 
+    def test_language_ocaml(self):
+        self._test_language_repo_map("ocaml", "ml", "Greeter")
+
+    def test_language_ocaml_interface(self):
+        self._test_language_repo_map("ocaml_interface", "mli", "Greeter")
+
     def _test_language_repo_map(self, lang, key, symbol):
         """Helper method to test repo map generation for a specific language."""
         # Get the fixture file path and name based on language
@@ -407,6 +411,7 @@ class TestRepoMapAllLanguages(unittest.TestCase):
             dump(lang)
             dump(result)
 
+            print(result)
             self.assertGreater(len(result.strip().splitlines()), 1)
 
             # Check if the result contains all the expected files and symbols

--- a/tests/fixtures/languages/ocaml_interface/test.mli
+++ b/tests/fixtures/languages/ocaml_interface/test.mli
@@ -1,0 +1,14 @@
+(* Module definition *)
+module Greeter : sig
+  type person = {
+    name: string;
+    age: int
+  }
+
+  val create_person : string -> int -> person
+
+  val greet : person -> unit
+end
+
+(* Outside the module *)
+val main : unit -> unit


### PR DESCRIPTION
Adds repo map support for .ml and .mli

Things I'm not sure about:

1. Should we have same tags files in both `queries/tree-sitter-language-pack`
   `queries/tree-sitter-languages`?

2. I think we should be smarter and only use tags from .mli files if they are
   present. E.g. if test.ml and test.mli are both present in the repo — get
   atgs only from test.mli as this is the external interface of the `Test`
   module.

Depends on:
- https://github.com/Goldziher/tree-sitter-language-pack/pull/25
- https://github.com/Aider-AI/grep-ast/pull/19

