### PR TITLE
chore: remove redundant code

### DIFF
--- a/aider/onboarding.py
+++ b/aider/onboarding.py
@@ -13,7 +13,6 @@ import requests
 
 from aider import urls
 from aider.io import InputOutput
-from aider.utils import check_pip_install_extra
 
 
 def check_openrouter_tier(api_key):
@@ -214,10 +213,6 @@ def exchange_code_for_key(code, code_verifier, io):
 # Function to start the OAuth flow
 def start_openrouter_oauth_flow(io, analytics):
     """Initiates the OpenRouter OAuth PKCE flow using a local server."""
-
-    # Check for requests library
-    if not check_pip_install_extra(io, "requests", "OpenRouter OAuth", "aider[oauth]"):
-        return None
 
     port = find_available_port()
     if not port:


### PR DESCRIPTION
1. The module already imports `requests`, so by the time this check is called, the module is already loaded.

2. Even if the code path were taken, it would fail anyway, because the `aider[oauth]` extra was hallucinated and does not exist.

3. Downstream distributions usually have managed Python environments, where pip cannot be used at all.
    That means distros must patch out every such pip invocation ([example](https://aur.archlinux.org/cgit/aur.git/tree/archlinux-use-system.patch?h=aider-chat&id=7f8156946857215104bce151454ad0101ade4a48); full disclosure: I maintain this but other distros will eventually bump into the same issues).  
   Restricting at-runtime pip usage to the minimum necessary is friendlier to distro maintainers.
