### PR TITLE
fix: follow conventional commits examples by going all lowercase

### DIFF
--- a/aider/prompts.py
+++ b/aider/prompts.py
@@ -10,12 +10,13 @@ one-line Git commit messages based on the provided diffs.
 Review the provided context and diffs which are about to be committed to a git repo.
 Review the diffs carefully.
 Generate a one-line commit message for those changes.
+The commit message should be entirely lowercase.
 The commit message should be structured as follows: <type>: <description>
 Use these for <type>: fix, feat, build, chore, ci, docs, style, refactor, perf, test
 
 Ensure the commit message:
 - Starts with the appropriate prefix.
-- Is in the imperative mood (e.g., \"Add feature\" not \"Added feature\" or \"Adding feature\").
+- Is in the imperative mood (e.g., \"add feature\" not \"added feature\" or \"adding feature\").
 - Does not exceed 72 characters.
 
 Reply only with the one-line commit message, without any additional text, explanations, \


### PR DESCRIPTION
Super tiny change, but I recently tried out Aider and I love it. However, when it auto generates commit messages it does so with capital letters, which does not follow any of the examples provided by the [specification](https://www.conventionalcommits.org/en/v1.0.0/#specification). All of them are completely in lowercase.

Even though the casing does not matter that much (and according to the specification, it is not a must), I would love to be able to stay as close as possible to the actual examples provided whenever I use Aider.

I basically just updated the prompt by removing capital letters in the example, and adding a new line stating it should always be lowercase. 

If this is not viable, a flag perhaps is the better way if you still want it to be "backwards" compatible. Something like `--lowercase-commits` or similar. 