### PR TITLE
Add Fireworks AI model 'deepseek-v3-0324'

### DIFF
--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -108,6 +108,15 @@
         "output_cost_per_token": 0.0000009,
         "mode": "chat",
     },
+    "fireworks_ai/accounts/fireworks/models/deepseek-v3-0324": {
+        "max_tokens": 160000,
+        "max_input_tokens": 100000,
+        "max_output_tokens": 8192,
+        "litellm_provider": "fireworks_ai",
+        "input_cost_per_token": 0.0000009,
+        "output_cost_per_token": 0.0000009,
+        "mode": "chat",
+    },
     "o3-mini": {
         "max_tokens": 100000,
         "max_input_tokens": 200000,

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -817,7 +817,7 @@
   use_temperature: false
   editor_model_name: openrouter/deepseek/deepseek-chat
   editor_edit_format: editor-diff
-  
+
 - name: fireworks_ai/accounts/fireworks/models/deepseek-r1
   edit_format: diff
   weak_model_name: fireworks_ai/accounts/fireworks/models/deepseek-v3
@@ -838,6 +838,14 @@
   extra_params:
       max_tokens: 128000
 
+- name: fireworks_ai/accounts/fireworks/models/deepseek-v3-0324
+  edit_format: diff
+  use_repo_map: true
+  reminder: sys
+  examples_as_sys_msg: true
+  extra_params:
+      max_tokens: 160000
+
 - name: openai/o3-mini
   edit_format: diff
   weak_model_name: gpt-4o-mini
@@ -847,7 +855,7 @@
   editor_edit_format: editor-diff
   system_prompt_prefix: "Formatting re-enabled. "
   accepts_settings: ["reasoning_effort"]
-  
+
 - name: o3-mini
   edit_format: diff
   weak_model_name: gpt-4o-mini
@@ -897,7 +905,7 @@
   examples_as_sys_msg: true
   editor_model_name: gpt-4o
   editor_edit_format: editor-diff
-  
+
 - name: openai/gpt-4.5-preview
   edit_format: diff
   weak_model_name: gpt-4o-mini
@@ -942,10 +950,10 @@
 
 - name: gemini/gemma-3-27b-it
   use_system_prompt: false
-  
+
 - name: openrouter/google/gemma-3-27b-it:free
   use_system_prompt: false
-  
+
 - name: openrouter/google/gemma-3-27b-it
   use_system_prompt: false
 


### PR DESCRIPTION
Fireworks supports the recently released `deepseek-v3-0324` model.

https://fireworks.ai/models/fireworks/deepseek-v3-0324

<img width="373" alt="Screenshot 2025-04-05 at 16 46 48" src="https://github.com/user-attachments/assets/c5dc14c5-266d-455c-8b6c-8764dff24f83" />

**Note:** I couldn't verify the `max_input_tokens` and `max_output_tokens` values, as this information isn't available on their homepage. I assume these values remain the same as those for the existing `deepseek-v3` model.