### PR TITLE
Make `confirm_ask` behavior consistent with explicit confirmation handling

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -847,8 +847,8 @@ class InputOutput:
 
         style = self._get_style()
 
-        if self.yes is True:
-            res = "n" if explicit_yes_required else "y"
+        if self.yes is True and not explicit_yes_required:
+            res = "y"
         elif self.yes is False:
             res = "n"
         elif group and group.preference:

--- a/aider/io.py
+++ b/aider/io.py
@@ -847,11 +847,6 @@ class InputOutput:
 
         style = self._get_style()
 
-        def is_valid_response(text):
-            if not text:
-                return True
-            return text.lower() in valid_responses
-
         if self.yes is True:
             res = "n" if explicit_yes_required else "y"
         elif self.yes is False:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -178,9 +178,13 @@ class TestInputOutput(unittest.TestCase):
 
         # Test case 1: explicit_yes_required=True, self.yes=True
         io.yes = True
+        mock_input.return_value = "n"
         result = io.confirm_ask("Are you sure?", explicit_yes_required=True)
         self.assertFalse(result)
-        mock_input.assert_not_called()
+        mock_input.assert_called_once()
+
+        # Reset mock_input
+        mock_input.reset_mock()
 
         # Test case 2: explicit_yes_required=True, self.yes=False
         io.yes = False


### PR DESCRIPTION
This PR refactors the confirm_ask function to ensure consistent behavior when handling the explicit_yes_required parameter. The changes include:

Improved Logic: The function now handles cases where self.yes is True, False, or None more predictably, ensuring that user confirmation is appropriately prompted or bypassed based on the context.
Removed Unused Code: The unused valid_responses logic has been removed, simplifying the code and improving maintainability.
Enhanced Use Case Support: This update is particularly useful in scenarios where commands suggested by an LLM require manual confirmation even when --yes-always flag is set. It ensures that users are prompted for confirmation when necessary, rather than skipping the confirmation step unintentionally.
These changes improve the clarity, reliability, and usability of the confirm_ask function.