### PR TITLE
Make `confirm_ask` behavior consistent with explicit confirmation handling

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -847,8 +847,8 @@ class InputOutput:
 
         style = self._get_style()
 
-        if self.yes is True:
-            res = "n" if explicit_yes_required else "y"
+        if self.yes is True and not explicit_yes_required:
+            res = "y"
         elif self.yes is False:
             res = "n"
         elif group and group.preference:

--- a/aider/io.py
+++ b/aider/io.py
@@ -847,11 +847,6 @@ class InputOutput:
 
         style = self._get_style()
 
-        def is_valid_response(text):
-            if not text:
-                return True
-            return text.lower() in valid_responses
-
         if self.yes is True:
             res = "n" if explicit_yes_required else "y"
         elif self.yes is False:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -204,7 +204,23 @@ class TestInputOutput(unittest.TestCase):
         mock_input.assert_called_once()
         mock_input.reset_mock()
 
-        # Test case 4: Test group behavior with explicit_yes_required=True 
+        # Test case 4: When self.yes=None and user is prompted
+        # User denies with 'n'
+        io.yes = None
+        mock_input.return_value = "n"
+        result = io.confirm_ask("Are you sure?", explicit_yes_required=True)
+        self.assertFalse(result)
+        mock_input.assert_called_once()
+        mock_input.reset_mock()
+
+        # User approves with 'y'
+        mock_input.return_value = "y"
+        result = io.confirm_ask("Are you sure?", explicit_yes_required=True)
+        self.assertTrue(result)
+        mock_input.assert_called_once()
+        mock_input.reset_mock()
+
+        # Test case 5: Test group behavior with explicit_yes_required=True 
         # Group preferences should not be automatically applied, requiring explicit confirmation
         group = ConfirmGroup()
         io.yes = None
@@ -215,7 +231,7 @@ class TestInputOutput(unittest.TestCase):
         self.assertIsNone(group.preference)  # Group preference should not be set in explicit mode
         mock_input.reset_mock()
 
-        # Test case 5: Test "don't ask again" option with explicit_yes_required=True
+        # Test case 6: Test "don't ask again" option with explicit_yes_required=True
         # Should still allow user to set don't-ask-again preference
         io.yes = None
         mock_input.return_value = "d"
@@ -225,7 +241,7 @@ class TestInputOutput(unittest.TestCase):
         self.assertIn(("Are you sure?", None), io.never_prompts)
         mock_input.reset_mock()
 
-        # Test case 6: Test with subject parameter to provide context
+        # Test case 7: Test with subject parameter to provide context
         # Should display subject text before prompt
         io.yes = None
         mock_input.return_value = "y"
@@ -234,7 +250,7 @@ class TestInputOutput(unittest.TestCase):
         mock_input.assert_called_once()
         mock_input.reset_mock()
 
-        # Test case 7: Test with multiline subject
+        # Test case 8: Test with multiline subject
         # Should properly format and display multiline subject text
         io.yes = None
         mock_input.return_value = "y"

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -261,8 +261,38 @@ class TestInputOutput(unittest.TestCase):
         self.assertIsNone(group.preference)  # Group preference should not be set in explicit mode
         mock_input.reset_mock()
 
-        # Test case 9: Test with subject parameter
-        # Should display subject text before prompt
+        # Test case 9: Test group behavior with explicit_yes_required=True - 'A' (All)
+        # Group preferences should not be automatically applied, 'A' should be treated as 'N'
+        group = ConfirmGroup()
+        io.yes = None
+        mock_input.return_value = "a"
+        result = io.confirm_ask("Are you sure?", explicit_yes_required=True, group=group)
+        self.assertFalse(result)  # 'A' should be treated as 'N' when explicit_yes_required=True
+        mock_input.assert_called_once()
+        self.assertIsNone(group.preference)  # Group preference should not be set in explicit mode
+        mock_input.reset_mock()
+
+        # Test case 10: Test group behavior with explicit_yes_required=True - 'A' (All) with allow_never=True
+        # Group preferences should not be automatically applied, 'A' should be treated as 'N'
+        group = ConfirmGroup()
+        io.yes = None
+        mock_input.return_value = "a"
+        result = io.confirm_ask("Are you sure?", explicit_yes_required=True, group=group, allow_never=True)
+        self.assertFalse(result)  # 'A' should be treated as 'N' when explicit_yes_required=True
+        mock_input.assert_called_once()
+        self.assertIsNone(group.preference)  # Group preference should not be set in explicit mode
+        mock_input.reset_mock()
+
+        # Test case 11: Test group behavior with explicit_yes_required=True - 'S' (Skip) with allow_never=True
+        # Skip should work as a form of 'No' and set group preference
+        mock_input.return_value = "s"
+        result = io.confirm_ask("Are you sure?", explicit_yes_required=True, group=group, allow_never=True)
+        self.assertFalse(result)
+        mock_input.assert_called_once()
+        self.assertEqual(group.preference, "skip")  # Skip preference should be set
+        mock_input.reset_mock()
+
+        # Test case 12: Test with subject parameter
         io.yes = None
         mock_input.return_value = "y"
         result = io.confirm_ask("Are you sure?", explicit_yes_required=True, subject="Test subject")
@@ -270,7 +300,7 @@ class TestInputOutput(unittest.TestCase):
         mock_input.assert_called_once()
         mock_input.reset_mock()
 
-        # Test case 10: Test with multiline subject
+        # Test case 13: Test with multiline subject
         # Should properly format and display multiline subject text
         mock_input.return_value = "y"
         result = io.confirm_ask("Are you sure?", explicit_yes_required=True, subject="Line 1\nLine 2")

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -178,9 +178,13 @@ class TestInputOutput(unittest.TestCase):
 
         # Test case 1: explicit_yes_required=True, self.yes=True
         io.yes = True
+        mock_input.return_value = "n"
         result = io.confirm_ask("Are you sure?", explicit_yes_required=True)
         self.assertFalse(result)
-        mock_input.assert_not_called()
+        mock_input.assert_called_once()
+
+        # Reset mock_input
+        mock_input.reset_mock()
 
         # Test case 2: explicit_yes_required=True, self.yes=False
         io.yes = False


### PR DESCRIPTION
This PR refactors the confirm_ask function to ensure consistent behavior when handling the explicit_yes_required parameter. The changes include:

Improved Logic: The function now handles cases where self.yes is True, False, or None more predictably, ensuring that user confirmation is appropriately prompted or bypassed based on the context.
Removed Unused Code: The unused valid_responses logic has been removed, simplifying the code and improving maintainability.
Enhanced Use Case Support: This update is particularly useful in scenarios where commands suggested by an LLM require manual confirmation even when --yes-always flag is set. It ensures that users are prompted for confirmation when necessary, rather than skipping the confirmation step unintentionally.
These changes improve the clarity, reliability, and usability of the confirm_ask function.