### PR TITLE
docs: update editor usage instructions in multi-line guide

### DIFF
--- a/aider/website/_includes/multi-line.md
+++ b/aider/website/_includes/multi-line.md
@@ -4,7 +4,7 @@ You can send long, multi-line messages in the chat in a few ways:
     - Or, start with `{tag` (where "tag" is any sequence of letters/numbers) and end with `tag}`. This is useful when you need to include closing braces `}` in your message.
   - Use Meta-ENTER to start a new line without sending the message (Esc+ENTER in some environments).
   - Use `/paste` to paste text from the clipboard into the chat.
-  - Use the `/editor` command to open your editor to create the next chat message. See [editor configuration docs](/docs/config/editor.html) for more info.
+  - Use the `/editor` command (or press `Ctrl-X Ctrl-E` if your terminal allows) to open your editor to create the next chat message. See [editor configuration docs](/docs/config/editor.html) for more info.
   - Use multiline-mode, which swaps the function of Meta-Enter and Enter, so that Enter inserts a newline, and Meta-Enter submits your command. To enable multiline mode:
     - Use the `/multiline-mode` command to toggle it during a session.
     - Use the `--multiline` switch.


### PR DESCRIPTION
I've just discovered that as I can in my bash (as I configured in .bashrc) press ctrl+x ctrl+e to edit in `$EDITOR`  command line(s) before execution, that it also works in Aider! So I do not have to come back to beginning of prompt and add `/editor` anymore! (what is especially annoying in multi line `{` mode etc...) . It's life changer ! :) So IMHO should be communicated somehow in documentation to people that this also works in Aider prompt!

---

* Added keybinding `Ctrl-X Ctrl-E` for invoking editor via terminal compatibility.
* Enhances user ergonomics for terminals supporting this shortcut, streamlining workflow.
* Maintains reference to editor configuration documentation.