### PR TITLE
feat: load local model metadata in benchmark if available

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -314,8 +314,13 @@ def main(
 
     test_dnames = sorted(str(d.relative_to(original_dname)) for d in exercise_dirs)
 
+    # Load built‑in metadata first, then any optional local overrides
     resource_metadata = importlib_resources.files("aider.resources").joinpath("model-metadata.json")
-    model_metadata_files_loaded = models.register_litellm_models([resource_metadata])
+    meta_files = [str(resource_metadata)]
+    local_meta = Path(".aider.model.metadata.json")
+    if local_meta.exists():
+        meta_files.append(str(local_meta))
+    model_metadata_files_loaded = models.register_litellm_models(meta_files)
     dump(model_metadata_files_loaded)
 
     if read_model_settings:


### PR DESCRIPTION
this change makes benchmark.py load model metadata from .aider.model.metadata.json if it exists, matching aider's normal behavior.