### PR TITLE
fix-3182: handle special characters in file paths for linting

### DIFF
--- a/aider/linter.py
+++ b/aider/linter.py
@@ -45,13 +45,15 @@ class Linter:
             return fname
 
     def run_cmd(self, cmd, rel_fname, code):
-        cmd += " " + shlex.quote(rel_fname)
+        # Split the command into parts and add the quoted filename
+        cmd_parts = shlex.split(cmd)
+        cmd_parts.append(rel_fname)  # No need to quote since we're using a list
 
         returncode = 0
         stdout = ""
         try:
             returncode, stdout = run_cmd_subprocess(
-                cmd,
+                cmd_parts,  # Pass as list instead of string
                 cwd=self.root,
                 encoding=self.encoding,
             )
@@ -62,7 +64,7 @@ class Linter:
         if returncode == 0:
             return  # zero exit status
 
-        res = f"## Running: {cmd}\n\n"
+        res = f"## Running: {' '.join(cmd_parts)}\n\n"
         res += errors
 
         return self.errors_to_lint_result(rel_fname, res)

--- a/tests/basic/test_linter.py
+++ b/tests/basic/test_linter.py
@@ -47,6 +47,29 @@ class TestLinter(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertIn("Error message", result.text)
 
+    def test_run_cmd_with_special_chars(self):
+        with patch("subprocess.Popen") as mock_popen:
+            mock_process = MagicMock()
+            mock_process.returncode = 1
+            mock_process.stdout.read.side_effect = ("Error message", None)
+            mock_popen.return_value = mock_process
+
+            # Test with a file path containing special characters
+            special_path = "src/(main)/product/[id]/page.tsx"
+            result = self.linter.run_cmd("eslint", special_path, "code")
+
+            # Verify that the command was constructed correctly
+            mock_popen.assert_called_once()
+            call_args = mock_popen.call_args[0][0]
+            
+            # The command should be a list with the last element being the special path
+            self.assertIsInstance(call_args, list)
+            self.assertEqual(call_args[-1], special_path)
+            
+            # The result should contain the error message
+            self.assertIsNotNone(result)
+            self.assertIn("Error message", result.text)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Fix: Handle Special Characters in File Paths for Linting

## Problem
The linter was failing to properly handle file paths containing special characters like parentheses and square brackets, which are common in Next.js file paths such as `src/(main)/product/[id]/page.tsx`. This was causing linting to fail for these files.

## Solution
Modified the `run_cmd` method in `linter.py` to properly handle special characters in file paths by:
- Using `shlex.split()` to correctly parse the command
- Passing the command as a list to `run_cmd_subprocess` instead of a string
- Removing unnecessary manual quoting of file paths

## Changes
- Modified `run_cmd` in `linter.py` to use `shlex.split()` and pass commands as a list
- Added test case `test_run_cmd_with_special_chars` to verify handling of special characters in file paths
- Removed unnecessary manual quoting of file paths

## Testing
- Added a new test case that verifies the linter can handle file paths with special characters
- All existing tests continue to pass
- Manually tested with Next.js file paths containing parentheses and square brackets

## Impact
This change improves the linter's ability to handle modern web application file structures, particularly those used in Next.js applications where route parameters and group segments use special characters in file paths.