### PR TITLE
fix: UnicodeDecodeError when reading UTF-8 config files on Windows CJK locales(non-UTF-8; e.g. Japanese cp932)

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -39,6 +39,12 @@ def get_parser(default_config_files, git_root):
         config_file_parser_class=configargparse.YAMLConfigFileParser,
         auto_env_var_prefix="AIDER_",
     )
+
+    # Prevent UnicodeDecodeError when reading UTF-8 config files
+    # on Windows CJK locales (e.g., Japanese),
+    # where default encoding is not UTF-8
+    parser._config_file_open_func = lambda fname: open(fname, mode="r", encoding="utf-8")
+
     group = parser.add_argument_group("Main model")
     group.add_argument(
         "files", metavar="FILE", nargs="*", help="files to edit with an LLM (optional)"


### PR DESCRIPTION
Hi,

This patch fixes a config file decoding issue that occurs on Windows systems with non-UTF-8 locales (e.g., Japanese cp932).


On Windows systems with non-UTF-8 locales (especially CJK: Chinese, Japanese, Korean),
`aider` fails to read UTF-8-encoded config files (e.g., `.aider.conf`) if they contain non-ASCII characters.

For example, Japanese Windows uses code page 932 (Shift_JIS),
so Python's open() fails to decode UTF-8 content by default.
This results in a `UnicodeDecodeError` during startup when loading config files.

This patch explicitly sets `encoding="utf-8"` via `configargparse`'s internal
`_config_file_open_func`, ensuring consistent and locale-independent config parsing.

The change is safe for UTF-8 environments and prevents locale-dependent errors
on non-UTF-8 systems (e.g., Japanese Windows).

Thanks!

