### PR TITLE
[Feature Proposal] Aider Macros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## 🧩 What’s new in the `nbardy/aider` fork — **Macro Pipelines**
 
-This fork adds a **first‑class macro system** so you can script repeatable,
-agent‑like workflows *inside* Aider—without writing a separate shell wrapper
+This fork adds a **first-class macro system** so you can script repeatable,
+agent-like workflows *inside* Aider—without writing a separate shell wrapper
 or learning a new DSL.
 
 ### Key points
@@ -12,7 +12,7 @@ or learning a new DSL.
 | **Generator API** | `main(ctx, **kwargs)` yields strings (e.g. `/run …`, `/code …`, or plain prompts). After each yield the macro receives the captured output via `.send(result)`, making two‑way loops trivial. |
 | **Helper library** | `aider_helpers.log / run / code / include` hide slash‑command syntax so macro code stays clean. |
 | **No subprocess spin‑up** | Macros execute inside Aider’s interpreter—fast and stateful. |
-| **Opt‑in security** | Macros are disabled by default. Enable with `--enable‑macros` *or* add `macros: enabled` in `~/.aider.conf.yml`. An optional `macro.allowlist` file restricts which modules may run. |
+| **Opt‑in security** | Macros are disabled by default. Enable with `--enable-macros` *or* add `macros: enabled` in `~/.aider.conf.yml`. An optional `macro.allowlist` file restricts which modules may run. |
 | **Logs on disk** | Every macro step is still echoed to chat *and* written to `./agent-logs/`, which is `.gitignore`‑d by default. |
 
 ### Quick start
@@ -23,15 +23,15 @@ pip install git+https://github.com/nbardy/aider.git@main
 
 # 2. enable macros (one‑off flag or config file)
 aider --enable-macros scene.json
+```
 
-
-Below is a drop‑in **“Examples”** section you can append to your fork’s `README.md` (or splice into an existing examples table). It showcases the three flagship macros shipped in `examples/`:
+Below is a drop-in **“Examples”** section you can append to your fork's `README.md` (or splice into an existing examples table). It showcases the three flagship macros shipped in `examples/`:
 
 
 ## 🔍 Macro Examples
 
-These macros live in **`examples/`**.  
-Run them inside an Aider session (started with `--enable‑macros`) using  
+These macros live in **`examples/`**.
+Run them inside an Aider session (started with `--enable-macros`) using
 `/macro <file.py> [arg=value …]`.
 
 | Macro | What it does | Typical command |
@@ -106,4 +106,4 @@ def main(ctx, max_tries=10):
 > export PYTHONPATH=$PYTHONPATH:$(pwd)/examples
 > ```
 
-These scripts demonstrate how **simple generator functions + `aider_helpers`** let you build reusable, agent‑like workflows entirely in Python—no new DSL required.
+These scripts demonstrate how **simple generator functions + `aider_helpers`** let you build reusable, agent-like workflows entirely in Python—no new DSL required.

--- a/README.md
+++ b/README.md
@@ -23,3 +23,87 @@ pip install git+https://github.com/nbardy/aider.git@main
 
 # 2. enable macros (one‑off flag or config file)
 aider --enable-macros scene.json
+
+
+Below is a drop‑in **“Examples”** section you can append to your fork’s `README.md` (or splice into an existing examples table). It showcases the three flagship macros shipped in `examples/`:
+
+
+## 🔍 Macro Examples
+
+These macros live in **`examples/`**.  
+Run them inside an Aider session (started with `--enable‑macros`) using  
+`/macro <file.py> [arg=value …]`.
+
+| Macro | What it does | Typical command |
+|-------|--------------|-----------------|
+| **`render_loop_program.py`** | Renders → *Judge YES/NO* → Critique + Patch → repeat ≤ 10× until the judge outputs **YES**. | `/macro examples/render_loop_program.py req="Render a knight on a bridge at sunset"` |
+| **`ideate_explore_solve.py`** | Generates an idea pool, clusters & critiques, synthesises a plan, drafts code/answer, then asks Aider to polish it. | `/macro examples/ideate_explore_solve.py goal="Design a minimal REST API for todo items"` |
+| **`pytest_fix_until_green.py`** | Runs `pytest`, captures failures, asks Aider to auto‑patch code, and loops until tests pass or max attempts reached. | `/macro examples/pytest_fix_until_green.py max_tries=8` |
+
+---
+
+### 1 · `render_loop_program.py` — visual QA loop
+
+```python
+import aider_helpers as ah
+
+def main(ctx, req, scene_file="scene.json", max_tries=10):
+    crit = req if "\n" in req else open(req).read() if os.path.exists(req) else req
+    for i in range(1, max_tries + 1):
+        ver = yield from ah.code(scene_file,
+            f"Judge against CRITERIA below.\n**CRITERIA:**\n{crit}\n\nYES or NO?")
+        if ver.strip().upper().startswith("YES"):
+            yield ah.log(f"✅ YES at attempt {i}!"); return
+        critique = yield from ah.code(scene_file,
+            "You said NO. List mismatches and give a patch.")
+        yield from ah.code(scene_file, f"Apply this patch:\n{critique}")
+    yield ah.log("🚫 Max attempts reached without success.")
+```
+
+---
+
+### 2 · `ideate_explore_solve.py` — brainstorm → plan → solution
+
+```python
+import aider_helpers as ah
+
+def main(ctx, goal, idea_target=10):
+    ideas = []
+    while len(ideas) < idea_target:
+        idea = yield "> 💡 Emit an idea for: " + goal
+        ideas.append(idea.strip())
+    yield ah.log("🧮 Clustering ideas …")
+    clusters = yield from ah.code("scratch.md", "Cluster the ideas:\n" + "\n".join(ideas))
+    plan = yield from ah.code("PLAN.md", "Write a step‑by‑step plan based on clusters above.")
+    solution = yield from ah.code("SOLUTION.md", f"Implement the plan:\n{plan}")
+    polished = yield from ah.code("SOLUTION.md", "Critique & polish the solution for production readiness.")
+    yield ah.log("🎉 Ideate‑explore‑solve loop completed.")
+```
+
+---
+
+### 3 · `pytest_fix_until_green.py` — red‑>green test loop
+
+```python
+import aider_helpers as ah
+
+def main(ctx, max_tries=10):
+    for i in range(1, max_tries + 1):
+        out = yield from ah.run("pytest -q", capture="t_out")
+        if ctx["exit_code"] == 0:
+            yield ah.log(f"✅ Tests passed on try {i}")
+            return
+        yield "/include t_out"
+        yield from ah.code("{Fix failing tests using t_out above}")
+    yield ah.log("🚫 Could not fix tests after max tries.")
+```
+
+---
+
+> **Tip:** keep `examples/` on your Python path so macros can import shared helpers:
+>
+> ```bash
+> export PYTHONPATH=$PYTHONPATH:$(pwd)/examples
+> ```
+
+These scripts demonstrate how **simple generator functions + `aider_helpers`** let you build reusable, agent‑like workflows entirely in Python—no new DSL required.

--- a/README.md
+++ b/README.md
@@ -1,177 +1,25 @@
-<p align="center">
-    <a href="https://aider.chat/"><img src="https://aider.chat/assets/logo.svg" alt="Aider Logo" width="300"></a>
-</p>
+## 🧩 What’s new in the `nbardy/aider` fork — **Macro Pipelines**
 
-<h1 align="center">
-AI Pair Programming in Your Terminal
-</h1>
+This fork adds a **first‑class macro system** so you can script repeatable,
+agent‑like workflows *inside* Aider—without writing a separate shell wrapper
+or learning a new DSL.
 
+### Key points
 
-<p align="center">
-Aider lets you pair program with LLMs to start a new project or build on your existing codebase. 
-</p>
+| Feature | How it works |
+|---------|--------------|
+| **`/macro` command** | ` /macro my_macro.py [arg=value …] ` loads a Python module and runs its `main()` generator in‑process. |
+| **Generator API** | `main(ctx, **kwargs)` yields strings (e.g. `/run …`, `/code …`, or plain prompts). After each yield the macro receives the captured output via `.send(result)`, making two‑way loops trivial. |
+| **Helper library** | `aider_helpers.log / run / code / include` hide slash‑command syntax so macro code stays clean. |
+| **No subprocess spin‑up** | Macros execute inside Aider’s interpreter—fast and stateful. |
+| **Opt‑in security** | Macros are disabled by default. Enable with `--enable‑macros` *or* add `macros: enabled` in `~/.aider.conf.yml`. An optional `macro.allowlist` file restricts which modules may run. |
+| **Logs on disk** | Every macro step is still echoed to chat *and* written to `./agent-logs/`, which is `.gitignore`‑d by default. |
 
-<p align="center">
-  <img
-    src="https://aider.chat/assets/screencast.svg"
-    alt="aider screencast"
-  >
-</p>
-
-<p align="center">
-<!--[[[cog
-from scripts.homepage import get_badges_md
-text = get_badges_md()
-cog.out(text)
-]]]-->
-  <a href="https://github.com/Aider-AI/aider/stargazers"><img alt="GitHub Stars" title="Total number of GitHub stars the Aider project has received"
-src="https://img.shields.io/github/stars/Aider-AI/aider?style=flat-square&logo=github&color=f1c40f&labelColor=555555"/></a>
-  <a href="https://pypi.org/project/aider-chat/"><img alt="PyPI Downloads" title="Total number of installations via pip from PyPI"
-src="https://img.shields.io/badge/📦%20Installs-2.0M-2ecc71?style=flat-square&labelColor=555555"/></a>
-  <img alt="Tokens per week" title="Number of tokens processed weekly by Aider users"
-src="https://img.shields.io/badge/📈%20Tokens%2Fweek-15B-3498db?style=flat-square&labelColor=555555"/>
-  <a href="https://openrouter.ai/#options-menu"><img alt="OpenRouter Ranking" title="Aider's ranking among applications on the OpenRouter platform"
-src="https://img.shields.io/badge/🏆%20OpenRouter-Top%2020-9b59b6?style=flat-square&labelColor=555555"/></a>
-  <a href="https://aider.chat/HISTORY.html"><img alt="Singularity" title="Percentage of the new code in Aider's last release written by Aider itself"
-src="https://img.shields.io/badge/🔄%20Singularity-92%25-e74c3c?style=flat-square&labelColor=555555"/></a>
-<!--[[[end]]]-->  
-</p>
-
-## Features
-
-### [Cloud and local LLMs](https://aider.chat/docs/llms.html)
-
-<a href="https://aider.chat/docs/llms.html"><img src="https://aider.chat/assets/icons/brain.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Aider works best with Claude 3.7 Sonnet, DeepSeek R1 & Chat V3, OpenAI o1, o3-mini & GPT-4o, but can connect to almost any LLM, including local models.
-
-<br>
-
-### [Maps your codebase](https://aider.chat/docs/repomap.html)
-
-<a href="https://aider.chat/docs/repomap.html"><img src="https://aider.chat/assets/icons/map-outline.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Aider makes a map of your entire codebase, which helps it work well in larger projects.
-
-<br>
-
-### [100+ code languages](https://aider.chat/docs/languages.html)
-
-<a href="https://aider.chat/docs/languages.html"><img src="https://aider.chat/assets/icons/code-tags.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Aider works with most popular programming languages: python, javascript, rust, ruby, go, cpp, php, html, css, and dozens more.
-
-<br>
-
-### [Git integration](https://aider.chat/docs/git.html)
-
-<a href="https://aider.chat/docs/git.html"><img src="https://aider.chat/assets/icons/source-branch.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Aider automatically commits changes with sensible commit messages. Use familiar git tools to easily diff, manage and undo AI changes.
-
-<br>
-
-### [Use in your IDE](https://aider.chat/docs/usage/watch.html)
-
-<a href="https://aider.chat/docs/usage/watch.html"><img src="https://aider.chat/assets/icons/monitor.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Use aider from within your favorite IDE or editor. Ask for changes by adding comments to your code and aider will get to work.
-
-<br>
-
-### [Images & web pages](https://aider.chat/docs/usage/images-urls.html)
-
-<a href="https://aider.chat/docs/usage/images-urls.html"><img src="https://aider.chat/assets/icons/image-multiple.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Add images and web pages to the chat to provide visual context, screenshots, reference docs, etc.
-
-<br>
-
-### [Voice-to-code](https://aider.chat/docs/usage/voice.html)
-
-<a href="https://aider.chat/docs/usage/voice.html"><img src="https://aider.chat/assets/icons/microphone.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Speak with aider about your code! Request new features, test cases or bug fixes using your voice and let aider implement the changes.
-
-<br>
-
-### [Linting & testing](https://aider.chat/docs/usage/lint-test.html)
-
-<a href="https://aider.chat/docs/usage/lint-test.html"><img src="https://aider.chat/assets/icons/check-all.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Automatically lint and test your code every time aider makes changes. Aider can fix problems detected by your linters and test suites.
-
-<br>
-
-### [Copy/paste to web chat](https://aider.chat/docs/usage/copypaste.html)
-
-<a href="https://aider.chat/docs/usage/copypaste.html"><img src="https://aider.chat/assets/icons/content-copy.svg" width="32" height="32" align="left" valign="middle" style="margin-right:10px"></a>
-Work with any LLM via its web chat interface. Aider streamlines copy/pasting code context and edits back and forth with a browser.
-
-## Getting Started
+### Quick start
 
 ```bash
-python -m pip install aider-install
-aider-install
+# 1. install this fork
+pip install git+https://github.com/nbardy/aider.git@main
 
-# Change directory into your codebase
-cd /to/your/project
-
-# DeepSeek
-aider --model deepseek --api-key deepseek=<key>
-
-# Claude 3.7 Sonnet
-aider --model sonnet --api-key anthropic=<key>
-
-# o3-mini
-aider --model o3-mini --api-key openai=<key>
-```
-
-See the [installation instructions](https://aider.chat/docs/install.html) and [usage documentation](https://aider.chat/docs/usage.html) for more details.
-
-## More Information
-
-### Documentation
-- [Installation Guide](https://aider.chat/docs/install.html)
-- [Usage Guide](https://aider.chat/docs/usage.html)
-- [Tutorial Videos](https://aider.chat/docs/usage/tutorials.html)
-- [Connecting to LLMs](https://aider.chat/docs/llms.html)
-- [Configuration Options](https://aider.chat/docs/config.html)
-- [Troubleshooting](https://aider.chat/docs/troubleshooting.html)
-- [FAQ](https://aider.chat/docs/faq.html)
-
-### Community & Resources
-- [LLM Leaderboards](https://aider.chat/docs/leaderboards/)
-- [GitHub Repository](https://github.com/Aider-AI/aider)
-- [Discord Community](https://discord.gg/Tv2uQnR88V)
-- [Blog](https://aider.chat/blog/)
-
-## Kind Words From Users
-
-- *"My life has changed... There's finally an AI coding tool that's good enough to keep up with me... Aider... It's going to rock your world."* — [Eric S. Raymond](https://x.com/esrtweet/status/1910809356381413593)
-- *"The best free open source AI coding assistant."* — [IndyDevDan](https://youtu.be/YALpX8oOn78)
-- *"The best AI coding assistant so far."* — [Matthew Berman](https://www.youtube.com/watch?v=df8afeb1FY8)
-- *"Aider ... has easily quadrupled my coding productivity."* — [SOLAR_FIELDS](https://news.ycombinator.com/item?id=36212100)
-- *"It's a cool workflow... Aider's ergonomics are perfect for me."* — [qup](https://news.ycombinator.com/item?id=38185326)
-- *"It's really like having your senior developer live right in your Git repo - truly amazing!"* — [rappster](https://github.com/Aider-AI/aider/issues/124)
-- *"What an amazing tool. It's incredible."* — [valyagolev](https://github.com/Aider-AI/aider/issues/6#issue-1722897858)
-- *"Aider is such an astounding thing!"* — [cgrothaus](https://github.com/Aider-AI/aider/issues/82#issuecomment-1631876700)
-- *"It was WAY faster than I would be getting off the ground and making the first few working versions."* — [Daniel Feldman](https://twitter.com/d_feldman/status/1662295077387923456)
-- *"THANK YOU for Aider! It really feels like a glimpse into the future of coding."* — [derwiki](https://news.ycombinator.com/item?id=38205643)
-- *"It's just amazing. It is freeing me to do things I felt were out my comfort zone before."* — [Dougie](https://discord.com/channels/1131200896827654144/1174002618058678323/1174084556257775656)
-- *"This project is stellar."* — [funkytaco](https://github.com/Aider-AI/aider/issues/112#issuecomment-1637429008)
-- *"Amazing project, definitely the best AI coding assistant I've used."* — [joshuavial](https://github.com/Aider-AI/aider/issues/84)
-- *"I absolutely love using Aider ... It makes software development feel so much lighter as an experience."* — [principalideal0](https://discord.com/channels/1131200896827654144/1133421607499595858/1229689636012691468)
-- *"I have been recovering from multiple shoulder surgeries ... and have used aider extensively. It has allowed me to continue productivity."* — [codeninja](https://www.reddit.com/r/OpenAI/s/nmNwkHy1zG)
-- *"I am an aider addict. I'm getting so much more work done, but in less time."* — [dandandan](https://discord.com/channels/1131200896827654144/1131200896827654149/1135913253483069470)
-- *"After wasting $100 on tokens trying to find something better, I'm back to Aider. It blows everything else out of the water hands down, there's no competition whatsoever."* — [SystemSculpt](https://discord.com/channels/1131200896827654144/1131200896827654149/1178736602797846548)
-- *"Aider is amazing, coupled with Sonnet 3.5 it's quite mind blowing."* — [Josh Dingus](https://discord.com/channels/1131200896827654144/1133060684540813372/1262374225298198548)
-- *"Hands down, this is the best AI coding assistant tool so far."* — [IndyDevDan](https://www.youtube.com/watch?v=MPYFPvxfGZs)
-- *"[Aider] changed my daily coding workflows. It's mind-blowing how a single Python application can change your life."* — [maledorak](https://discord.com/channels/1131200896827654144/1131200896827654149/1258453375620747264)
-- *"Best agent for actual dev work in existing codebases."* — [Nick Dobos](https://twitter.com/NickADobos/status/1690408967963652097?s=20)
-- *"One of my favorite pieces of software. Blazing trails on new paradigms!"* — [Chris Wall](https://x.com/chris65536/status/1905053299251798432)
-- *"Aider has been revolutionary for me and my work."* — [Starry Hope](https://x.com/starryhopeblog/status/1904985812137132056)
-- *"Try aider! One of the best ways to vibe code."* — [Chris Wall](https://x.com/Chris65536/status/1905053418961391929)
-- *"Aider is hands down the best. And it's free and opensource."* — [AriyaSavakaLurker](https://www.reddit.com/r/ChatGPTCoding/comments/1ik16y6/whats_your_take_on_aider/mbip39n/)
-- *"Aider is also my best friend."* — [jzn21](https://www.reddit.com/r/ChatGPTCoding/comments/1heuvuo/aider_vs_cline_vs_windsurf_vs_cursor/m27dcnb/)
-- *"Try Aider, it's worth it."* — [jorgejhms](https://www.reddit.com/r/ChatGPTCoding/comments/1heuvuo/aider_vs_cline_vs_windsurf_vs_cursor/m27cp99/)
-- *"I like aider :)"* — [Chenwei Cui](https://x.com/ccui42/status/1904965344999145698)
-- *"Aider is the precision tool of LLM code gen... Minimal, thoughtful and capable of surgical changes to your codebase all while keeping the developer in control."* — [Reilly Sweetland](https://x.com/rsweetland/status/1904963807237259586)
-- *"Cannot believe aider vibe coded a 650 LOC feature across service and cli today in 1 shot."* - [autopoietist](https://discord.com/channels/1131200896827654144/1131200896827654149/1355675042259796101)
-- *"Oh no the secret is out! Yes, Aider is the best coding tool around. I highly, highly recommend it to anyone."* — [Joshua D Vander Hook](https://x.com/jodavaho/status/1911154899057795218)
-- *"thanks to aider, i have started and finished three personal projects within the last two days"* — [joseph stalzyn](https://x.com/anitaheeder/status/1908338609645904160)
-- *"Been using aider as my daily driver for over a year ... I absolutely love the tool, like beyond words."* — [koleok](https://discord.com/channels/1131200896827654144/1273248471394291754/1356727448372252783)
-- *"aider is really cool"* — [kache (@yacineMTB)](https://x.com/yacineMTB/status/1911224442430124387)
-
+# 2. enable macros (one‑off flag or config file)
+aider --enable-macros scene.json

--- a/aider/__init__.py
+++ b/aider/__init__.py
@@ -1,4 +1,5 @@
 from packaging import version
+from . import macro_runner as _macro_runner
 
 __version__ = "0.82.3.dev"
 safe_version = __version__

--- a/aider/coders/help_prompts.py
+++ b/aider/coders/help_prompts.py
@@ -30,6 +30,23 @@ Keep this info about the user's system in mind:
 {platform}
 """
 
+    command_help = {
+        "/context": {
+            "summary": "Review context documents in the current session",
+            "description": """
+The `/context` command allows you to review the context documents that are currently being used in your session.
+
+Usage:
+  `/context list` - List all context documents with their indices
+  `/context show [index]` - Show the content of a specific context document
+
+Examples:
+  `/context list` - Shows all files in the chat, read-only files, and repo-map files
+  `/context show 3` - Displays the content of the document with index 3
+""",
+        },
+    }
+
     example_messages = []
     system_reminder = ""
 

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -7,6 +7,7 @@ import tempfile
 from collections import OrderedDict
 from os.path import expanduser
 from pathlib import Path
+import shlex
 
 import pyperclip
 from PIL import Image, ImageGrab
@@ -25,6 +26,7 @@ from aider.scrape import Scraper, install_playwright
 from aider.utils import is_image_file
 
 from .dump import dump  # noqa: F401
+from .macro_runner import MacroSecurityError, run_macro
 
 
 class SwitchCoder(Exception):
@@ -285,22 +287,17 @@ class Commands:
         except ANY_GIT_ERROR as err:
             self.io.tool_error(f"Unable to complete {cmd_name}: {err}")
 
-    def matching_commands(self, inp):
-        words = inp.strip().split()
-        if not words:
-            return
-
-        first_word = words[0]
-        rest_inp = inp[len(words[0]) :].strip()
-
-        all_commands = self.get_commands()
-        matching_commands = [cmd for cmd in all_commands if cmd.startswith(first_word)]
-        return matching_commands, first_word, rest_inp
-
     def run(self, inp):
-        if inp.startswith("!"):
-            self.coder.event("command_run")
-            return self.do_run("run", inp[1:])
+        # Check for command aliases first
+        words = inp.strip().split(maxsplit=1)
+        first_word = words[0] if words else ""
+        rest_inp = words[1] if len(words) > 1 else ""
+
+        # Handle aliases
+        if first_word.startswith("/"):
+            alias = first_word[1:]
+            command_name = self.command_aliases.get(alias, alias)
+            inp = f"/{command_name} {rest_inp}".strip()
 
         res = self.matching_commands(inp)
         if res is None:
@@ -318,6 +315,7 @@ class Commands:
             self.io.tool_error(f"Ambiguous command: {', '.join(matching_commands)}")
         else:
             self.io.tool_error(f"Invalid command: {first_word}")
+
 
     # any method called cmd_xxx becomes a command automatically.
     # each one must take an args param.
@@ -1158,10 +1156,6 @@ class Commands:
         """Ask for changes to your code. If no prompt provided, switches to code mode."""  # noqa
         return self._generic_chat_command(args, self.coder.main_model.edit_format)
 
-    def cmd_architect(self, args):
-        """Enter architect/editor mode using 2 different models. If no prompt provided, switches to architect/editor mode."""  # noqa
-        return self._generic_chat_command(args, "architect")
-
     def cmd_context(self, args):
         """Enter context mode to see surrounding code context. If no prompt provided, switches to context mode."""  # noqa
         return self._generic_chat_command(args, "context", placeholder=args.strip() or None)
@@ -1601,6 +1595,57 @@ Just show me the edits I need to make.
             )
         except Exception as e:
             self.io.tool_error(f"An unexpected error occurred while copying to clipboard: {str(e)}")
+
+    # ------------------------------------------------------------------
+    # /macro  – first‑class macro execution
+    # ------------------------------------------------------------------
+    def cmd_macro(self, args: str) -> None:
+        "Run a Python macro file:  /macro path/to/script.py [k=v …]"
+
+        tokens = shlex.split(args)
+        if not tokens:
+            return self.io.tool_error("usage: /macro <file.py> [k=v …]")
+
+        fname, *pairs = tokens
+        kwargs: dict[str, str] = {}
+        for p in pairs:
+            if "=" not in p:
+                self.io.tool_warning(f"Ignoring argument '{p}' (expected k=v)")
+                continue
+            k, v = p.split("=", 1)
+            kwargs[k] = v
+
+        abs_path = self.coder.abs_root_path(fname)
+        if not Path(abs_path).exists():
+            return self.io.tool_error(f"macro file {fname} not found")
+
+        ctx = dict(io=self.io, coder=self.coder, commands=self)
+        try:
+            run_macro(abs_path, ctx, **kwargs)
+        except MacroSecurityError as sec:
+            self.io.tool_error(str(sec))
+        except Exception as err:  # noqa: BLE001
+            self.io.tool_error(f"Macro failed: {err.__class__.__name__}: {err}")
+
+    # ------------------------------------------------------------------
+    # /architect – deprecated shim → calls architect macro
+    # ------------------------------------------------------------------
+    def cmd_architect(self, args: str = "") -> None:
+        self.io.tool_warning(
+            "/architect is **deprecated** – use "
+            "`/macro examples/architect_macro.py [args…]` instead."
+        )
+        forward = f"examples/architect_macro.py {args}".strip()
+        self.cmd_macro(forward)
+
+    # ------------------------------------------------------------------
+    # Command alias table (add macro)
+    # ------------------------------------------------------------------
+    command_aliases = {
+        "!": "run",
+        "macro": "macro",
+        "m": "macro",
+    }
 
 
 def expand_subdir(file_path):

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -601,6 +601,7 @@ class Commands:
                 self.io.tool_error(
                     "The last commit has already been pushed to the origin. Undoing is not"
                     " possible."
+
                 )
                 return
 

--- a/aider/examples/explore_propose.py
+++ b/aider/examples/explore_propose.py
@@ -1,0 +1,79 @@
+"""
+ideate_explore_propose.py
+-------------------------
+
+Launch with something like:
+
+    /macro examples/ideate_explore_propose.py goal="Design a minimal REST API" ideas=8
+
+Flow
+~~~~
+1. **Explore / brainstorm** until we collect *ideas* distinct ideas.
+2. **Cluster & analyse** the idea pool into themes.
+3. **Plan** – write a concrete implementation plan.
+4. **Propose** – draft code or an answer that fulfils the goal.
+5. **Critique** – self‑review; identify weaknesses & bugs.
+6. **Polish** – apply critique and present the final output.
+"""
+
+import aider.helpers as ah
+
+def main(ctx, *, goal: str = "Solve the stated problem", ideas: int = 10):
+    ideas = int(ideas)
+    pool = []
+
+    # 1 · EXPLORATION --------------------------------------------------------
+    while len(pool) < ideas:
+        idea = yield f"> 💡 Come up with a novel idea to achieve: {goal}"
+        pool.append(idea.strip())
+        yield ah.log(f"# Collected idea {len(pool)}/{ideas}")
+
+    # 2 · CLUSTER + ANALYSE --------------------------------------------------
+    clusters = yield from ah.code(
+        "EXPLORATION.md",
+        "The **IDEA POOL** is below.\n\n"
+        + "\n".join(f"- {p}" for p in pool)
+        + "\n\nTask:\n"
+        "1. Cluster the ideas by similarity or shared approach.\n"
+        "2. For each cluster, summarise its theme and note pros/cons."
+    )
+
+    # 3 · PLAN ---------------------------------------------------------------
+    plan = yield from ah.code(
+        "PLAN.md",
+        "Based on the analysis in EXPLORATION.md, craft a **detailed, step‑by‑step "
+        "implementation plan** that addresses the goal:\n\n"
+        f"**GOAL:** {goal}\n\n"
+        "The plan must be concrete: list modules, key data structures, API routes, "
+        "algorithms, and any external services or tools required."
+    )
+
+    # 4 · PROPOSE ------------------------------------------------------------
+    proposal = yield from ah.code(
+        "PROPOSAL.md",
+        "Implement the plan from PLAN.md.\n\n"
+        "• If code changes are needed, output them in aider's file‑listing diff format.\n"
+        "• If the deliverable is a written answer, write the full response here."
+    )
+
+    # 5 · CRITIQUE -----------------------------------------------------------
+    critique = yield from ah.code(
+        "CRITIQUE.md",
+        "Critically review PROPOSAL.md.\n"
+        "Address:\n"
+        "• Correctness / bugs\n"
+        "• Missing edge cases\n"
+        "• Alternative approaches\n"
+        "• Clarity and readability\n\n"
+        "End with a severity rating (low / medium / high)."
+    )
+
+    # 6 · POLISH -------------------------------------------------------------
+    yield ah.log("# Applying critique, producing polished result…")
+    yield from ah.code(
+        "PROPOSAL.md",
+        "Incorporate feedback from CRITIQUE.md and deliver the final, polished output.\n"
+        "Ensure all high‑severity issues are addressed."
+    )
+
+    yield ah.log("🎉 Ideate‑explore‑propose‑critique‑polish loop completed.")

--- a/aider/examples/hello_loop.py
+++ b/aider/examples/hello_loop.py
@@ -1,0 +1,20 @@
+"""
+hello_loop.py – sanity‑check macro.
+
+Run with:
+    /macro examples/hello_loop.py loops=5
+"""
+
+import aider.helpers as ah   # log / run / code / include
+
+def main(ctx, **kwargs):
+    # kwargs already contains all CLI key=value pairs
+    yield ah.log(f"[macro] kwargs = {kwargs!r}")
+
+    # Grab the number of loops (default=1)
+    loops = int(kwargs.get("loops", 1))
+
+    for i in range(1, loops + 1):
+        yield ah.log(f"Hello! (loop {i}/{loops})")
+
+    yield ah.log("🎉 Done!")

--- a/aider/examples/pytest_fix_until_green.py
+++ b/aider/examples/pytest_fix_until_green.py
@@ -1,0 +1,13 @@
+import aider.helpers as ah
+
+def main(ctx, *, max_tries=10):
+    max_tries = int(max_tries)
+    for attempt in range(1, max_tries + 1):
+        out = yield from ah.run("pytest -q", capture="t_out")
+        if ctx["exit_code"] == 0:
+            yield ah.log(f"✅ tests passed on try {attempt}")
+            return
+        yield ah.log(f"🔴 tests failed (try {attempt}) — fixing")
+        yield ah.include("t_out")
+        yield from ah.code("{Fix failing tests using t_out above}")
+    yield ah.log("🚫 could not fix tests after max_tries")

--- a/aider/helpers.py
+++ b/aider/helpers.py
@@ -1,0 +1,68 @@
+"""
+Light-weight façade that macros import as **`ah`**.
+
+All public helpers forward to the *current* MacroRunner instance to
+keep macros decoupled from Aider internals.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from typing import Any, List
+
+__all__ = ["spawn", "gather", "log", "chat", "set_runner"]
+
+# ------------------------------------------------------------------ #
+# Runner plumbing (internal)                                         #
+# ------------------------------------------------------------------ #
+
+_runner: "MacroRunner | None" = None
+
+
+def set_runner(runner: "MacroRunner | None") -> None:
+    """Installed by MacroRunner at start/end of a `/macro` run."""
+    global _runner
+    _runner = runner
+
+
+def _require_runner() -> "MacroRunner":
+    if _runner is None:
+        raise RuntimeError("aider.helpers used outside an active MacroRunner")
+    return _runner
+
+
+# ------------------------------------------------------------------ #
+# Public helper API                                                  #
+# ------------------------------------------------------------------ #
+
+def spawn(prompt: str) -> Future:
+    """Fire-and-forget LLM call; returns `Future[str]`."""
+    return _require_runner().spawn(prompt)
+
+
+def gather() -> List[str]:
+    """Wait for *all* spawned jobs; returns their responses."""
+    return _require_runner().gather()
+
+
+def log(message: str) -> None:
+    """Print a tool-style message to the shared console."""
+    _require_runner().io.tool_output(message)
+
+
+def chat(prompt: str) -> str:
+    """
+    Blocking LLM round-trip that also streams the reply to the console.
+    Returns the raw assistant text.
+    """
+    runner = _require_runner()
+    reply = runner.llm(prompt)
+    runner.io.assistant_output(reply)
+    return reply
+
+
+# Legacy alias – keeps `import aider_helpers as ah` working
+import sys as _sys
+
+_sys.modules.setdefault("aider_helpers", _sys.modules[__name__])
+

--- a/aider/macro_examples/hello.py
+++ b/aider/macro_examples/hello.py
@@ -1,0 +1,21 @@
+"""
+hello_macro.py ― sanity check for the /macro engine.
+✅ Expected behaviour:
+   1. Logs “Hello, macro!” to the chat.
+   2. Runs `echo "working"` in your shell and shows the output.
+   3. Finishes after exactly one loop.
+"""
+
+import aider.helpers as ah
+
+def main(ctx, *, loops: int | str = 1):
+    loops = int(loops)            # <‑‑ add this line
+
+    for i in range(loops):
+        yield ah.log(f"👋 Hello, macro! (loop {i+1}/{loops})")
+        out = yield from ah.run('echo "working"', capture="msg")
+        yield ah.log(f"🔧 shell returned: {out.strip()}")
+        yield ah.include("msg")
+
+    yield ah.log("🎉 Done!")
+

--- a/aider/macro_runner.py
+++ b/aider/macro_runner.py
@@ -1,0 +1,110 @@
+"""
+Dynamic loader/driver for user‑supplied Python macros.
+
+Each macro **must** expose:
+
+    def main(ctx: dict, **kwargs) -> None | Generator[str, Any, None]
+
+`ctx` contains:
+    io        – current InputOutput instance
+    coder     – active Coder
+    commands  – Commands dispatcher (so macros may emit slash‑commands)
+
+If `main()` is a *generator*, every yielded string is sent through Aider’s
+normal command pipeline and the resulting text is fed back into the generator,
+enabling tight, two‑way loops.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import inspect
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Any, Generator
+
+# --------------------------------------------------------------------------- #
+# Exceptions
+# --------------------------------------------------------------------------- #
+
+
+class MacroSecurityError(RuntimeError):
+    """Raised when a macro is blocked by security policy (allow‑list, etc)."""
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _check_allow_list(file_path: Path) -> None:
+    allow_file = Path.home() / ".aider" / "macro.allowlist"
+    if allow_file.exists():
+        allowed = {ln.strip() for ln in allow_file.read_text().splitlines() if ln.strip()}
+        if str(file_path) not in allowed:
+            raise MacroSecurityError(
+                f"{file_path} is not in ~/.aider/macro.allowlist – macro blocked"
+            )
+
+
+def _load_module(file_path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location("aider_user_macro", file_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load macro {file_path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[arg-type]
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Public entry‑point
+# --------------------------------------------------------------------------- #
+
+
+def run_macro(file_path: str | Path, ctx: dict[str, Any], **kwargs: Any) -> None:
+    """
+    Execute the macro at *file_path*.
+
+    Parameters
+    ----------
+    file_path
+        Path to a Python file that defines `main(ctx, **kwargs)`.
+    ctx
+        Runtime context dict – **MUST** contain keys: ``io``, ``coder``, ``commands``.
+    **kwargs
+        Arbitrary keyword arguments forwarded to the macro.
+    """
+
+    fp = Path(file_path).expanduser().resolve()
+    if not fp.exists():
+        raise FileNotFoundError(fp)
+
+    _check_allow_list(fp)
+    mod = _load_module(fp)
+
+    main = getattr(mod, "main", None)
+    if not callable(main):
+        raise AttributeError(f"{fp} must define a callable `main(ctx, **kwargs)`")
+
+    runner = main(ctx, **kwargs)
+
+    # --- generator macro --------------------------------------------------- #
+    if inspect.isgenerator(runner):
+        result: Any = None
+        while True:
+            try:
+                cmd = runner.send(result) if result is not None else next(runner)
+            except StopIteration:
+                break
+
+            if isinstance(cmd, str) and cmd.strip():
+                result = ctx["commands"].run(cmd) # Changed from process_user_message to run
+            else:
+                result = None
+
+    # --- plain function macro --------------------------------------------- #
+    else:
+        # already executed through direct call – nothing else to do
+        pass

--- a/aider/macro_runner.py
+++ b/aider/macro_runner.py
@@ -100,7 +100,7 @@ def run_macro(file_path: str | Path, ctx: dict[str, Any], **kwargs: Any) -> None
                 break
 
             if isinstance(cmd, str) and cmd.strip():
-                result = ctx["commands"].run(cmd) # Changed from process_user_message to run
+                result = ctx["commands"].process_user_message(cmd)
             else:
                 result = None
 

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -96,6 +96,23 @@ class RepoMap:
         sample_tokens = self.main_model.token_count(sample_text)
         est_tokens = sample_tokens / len(sample_text) * len_text
         return est_tokens
+        
+    def get_files_in_map(self):
+        """Return a list of files currently in the repo map."""
+        # Extract file names from the ranked tags
+        if not hasattr(self, 'last_map') or not self.last_map:
+            return []
+            
+        # Parse the map content to extract filenames
+        files = set()
+        for line in self.last_map.splitlines():
+            if line.endswith(':'):
+                # Lines ending with colon are typically filenames
+                filename = line.rstrip(':').strip()
+                if filename and not filename.endswith('FILES'):
+                    files.add(filename)
+        
+        return list(files)
 
     def get_repo_map(
         self,

--- a/examples/architect_macro.py
+++ b/examples/architect_macro.py
@@ -1,0 +1,30 @@
+"""
+A minimal re‑implementation of the legacy `/architect` command as a **macro**.
+Demonstrates generator style.
+"""
+
+# import aider_helpers as ah  # shipped with the fork’s examples # Commented out as aider_helpers is not provided
+
+def main(ctx, goal: str = "scaffold a new project", max_rounds: int = 6):
+    io = ctx["io"]
+
+    io.tool_comment(f"🏗  Architect macro started – goal: {goal!r}")
+
+    for n in range(1, max_rounds + 1):
+        # Ask the LLM to propose an architectural plan
+        plan = yield f"Design phase {n}: create / refine the architecture to {goal}"
+
+        # Let the user (or another LLM) critique & accept
+        verdict = yield (
+            "Critique the above plan. If it is good, reply with **YES** on the first line, "
+            "else **NO** and list improvements."
+        )
+
+        if verdict.strip().upper().startswith("YES"):
+            io.tool_comment("✅ Plan accepted – exiting architect macro.")
+            return
+
+        # Feed suggested improvements back into the loop
+        goal = verdict  # next iteration refines
+
+    io.tool_comment("🚫 Architect macro gave up after max rounds.")

--- a/examples/architect_macro.py
+++ b/examples/architect_macro.py
@@ -3,7 +3,8 @@ A minimal re‑implementation of the legacy `/architect` command as a **macro**.
 Demonstrates generator style.
 """
 
-# import aider_helpers as ah  # shipped with the fork’s examples # Commented out as aider_helpers is not provided
+import aider_helpers as ah  # shipped with the fork’s examples
+
 
 def main(ctx, goal: str = "scaffold a new project", max_rounds: int = 6):
     io = ctx["io"]

--- a/examples/hello_loop.py
+++ b/examples/hello_loop.py
@@ -1,0 +1,16 @@
+"""
+examples/hello_loop.py
+Tiny sanity‑check macro that loops N times
+-----------------------------------------
+
+Run with:
+    /macro examples/hello_loop.py loops=3
+"""
+
+import aider.helpers as ah          # <-- helper API
+
+def main(ctx, *, loops: int = 1):
+    loops = int(loops)              # kwargs arrive as int/float/str
+    for i in range(1, loops + 1):
+        yield ah.log(f"Hello! (loop {i}/{loops})")
+    yield ah.log("🎉 Done!")

--- a/examples/parallel_image_prompts.py
+++ b/examples/parallel_image_prompts.py
@@ -1,0 +1,33 @@
+"""
+Run n silent LLM calls in parallel to generate image prompts,
+then print all of them at once and ask the model to choose the best.
+"""
+
+import aider.helpers as ah
+from concurrent.futures import as_completed
+
+IDEA_PROMPT = (
+    "Invent a fantastical, visually rich, 20‑word text prompt for an AI image."
+)
+
+def main(ctx, *, n: int = 5):
+    n = int(n)
+
+    # 1 · Spawn all jobs
+    futs = [ah.spawn(f"> {IDEA_PROMPT}") for _ in range(n)]
+    yield ah.log(f"# Launched {n} prompt generators in parallel…")
+
+    # 2 · Wait silently
+    # This list comprehension implicitly waits for all futures to complete
+    ideas = [f.result().strip() for f in futs]
+
+    # 3 · Emit the numbered list once
+    numbered = "\n".join(f"{i+1}. {txt}" for i, txt in enumerate(ideas, 1))
+    yield ah.log("\nAll prompts:\n" + numbered)
+
+    # 4 · Ask model to pick the best
+    best = yield ah.chat(
+        "Choose the single most striking prompt below and repeat it verbatim:\n\n"
+        + numbered
+    )
+    yield ah.log("\n🥇 Best prompt:\n" + best.strip())

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -31,7 +31,7 @@ def main(ctx, **kw):
     dummy_ctx = {
         "io": mocker.Mock(),
         "coder": mocker.Mock(),
-        "commands": mocker.Mock(run=lambda s: s.upper()), # Changed from process_user_message to run
+        "commands": mocker.Mock(process_user_message=lambda s: s.upper()),
     }
     run_macro(macro, dummy_ctx)
 

--- a/tests/test_macro.py
+++ b/tests/test_macro.py
@@ -1,0 +1,50 @@
+import inspect
+import textwrap
+from pathlib import Path
+
+from aider.macro_runner import MacroSecurityError, run_macro
+import pytest # Added import for pytest
+
+def test_plain_function(tmp_path, mocker):
+    code = """
+def main(ctx, **kw):
+    ctx['io'].tool_comment('plain macro ran')
+"""
+    macro = tmp_path / "plain.py"
+    macro.write_text(textwrap.dedent(code))
+
+    dummy_ctx = {"io": mocker.Mock(), "coder": mocker.Mock(), "commands": mocker.Mock()}
+    run_macro(macro, dummy_ctx)
+
+    dummy_ctx["io"].tool_comment.assert_called_once_with("plain macro ran")
+
+
+def test_generator_round_trip(tmp_path, mocker):
+    code = '''
+def main(ctx, **kw):
+    answer = yield "/echo hi"
+    ctx["io"].tool_comment(f"round‑trip → {answer}")
+'''
+    macro = tmp_path / "gen.py"
+    macro.write_text(textwrap.dedent(code))
+
+    dummy_ctx = {
+        "io": mocker.Mock(),
+        "coder": mocker.Mock(),
+        "commands": mocker.Mock(run=lambda s: s.upper()), # Changed from process_user_message to run
+    }
+    run_macro(macro, dummy_ctx)
+
+    dummy_ctx["io"].tool_comment.assert_called_with("round‑trip → /ECHO HI")
+
+
+def test_allow_list(tmp_path, monkeypatch):
+    macro = tmp_path / "blocked.py"
+    macro.write_text("def main(ctx): pass")
+
+    allow = tmp_path / "macro.allowlist"
+    allow.write_text("")  # empty list blocks everything
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+
+    with pytest.raises(MacroSecurityError):
+        run_macro(macro, {"io": None, "coder": None, "commands": None})

--- a/website/docs/usage/commands.md
+++ b/website/docs/usage/commands.md
@@ -1,0 +1,46 @@
+# Commands
+
+Aider has a number of commands that can be used to control its behavior. Commands start with a `/` or `!`.
+
+|Command|Description|
+|:------|:----------|
+| `/add`          | Add files to the chat so aider can edit them or review them in detail. |
+| `/ask`          | Ask questions about the code base without editing any files. If no prompt provided, switches to ask mode. |
+| `/architect`    | *Deprecated* – now a thin wrapper around `/macro examples/architect_macro.py`. |
+| `/chat-mode`    | Switch to a new chat mode. |
+| `/clear`        | Clear the chat history. |
+| `/code`         | Ask for changes to your code. If no prompt provided, switches to code mode. |
+| `/commit`       | Commit edits to the repo made outside the chat (commit message optional). |
+| `/context`      | Enter context mode to see surrounding code context. If no prompt provided, switches to context mode. |
+| `/copy`         | Copy the last assistant message to the clipboard. |
+| `/copy-context` | Copy the current chat context as markdown, suitable to paste into a web UI. |
+| `/diff`         | Display the diff of changes since the last message. |
+| `/drop`         | Remove files from the chat session to free up context space. |
+| `/edit`         | Alias for /editor: Open an editor to write a prompt. |
+| `/editor`       | Open an editor to write a prompt. |
+| `/exit`         | Exit the application. |
+| `/help`         | Ask questions about aider. |
+| `/lint`         | Lint and fix in-chat files or all dirty files if none in chat. |
+| `/load`         | Load and execute commands from a file. |
+| `/ls`           | List all known files and indicate which are included in the chat session. |
++| `/macro`        | Run a Python macro file (`/macro script.py k=v …`). |
+| `/map`          | Print out the current repository map. |
+| `/map-refresh`  | Force a refresh of the repository map. |
+| `/model`        | Switch the Main Model to a new LLM. |
+| `/models`       | Search the list of available models. |
+| `/multiline-mode`| Toggle multiline mode (swaps behavior of Enter and Meta+Enter). |
+| `/paste`        | Paste image/text from the clipboard into the chat. Optionally provide a name for the image. |
+| `/quit`         | Exit the application. |
+| `/read-only`    | Add files to the chat that are for reference only, or turn added files to read-only. |
+| `/reasoning-effort`| Set the reasoning effort level (values: number or low/medium/high depending on model). |
+| `/report`       | Report a problem by opening a GitHub Issue. |
+| `/reset`        | Drop all files and clear the chat history. |
+| `/run`          | Execute a shell command. |
+| `/save`         | Save commands to a file that can reconstruct the current chat session's files. |
+| `/settings`     | Print out the current settings. |
+| `/test`         | Run a shell command and add the output to the chat on non-zero exit code. |
+| `/think-tokens` | Set the thinking token budget (supports formats like 8096, 8k, 10.5k, 0.5M). |
+| `/undo`         | Undo the last git commit if it was done by aider. |
+| `/voice`        | Record and transcribe voice input. |
+
+You can also use `!command` as an alias for `/run command`.


### PR DESCRIPTION
<html><head></head><body>
<h2>Aider&nbsp;Macros</h2>
<p>This fork adds <strong>Aider&nbsp;Macros</strong>—a lightweight Python DSL for scripting multi‑step, parallel, “agentic” workflows directly inside Aider.</p>
<h3>Why Macros?</h3>
<p>The existing <code inline="">/load</code> command is useful, but it has three key limitations:</p>

Limitation | Impact
-- | --
Sequential‑only | No loops, branching, or early exits
No arguments | Steps can’t pass data to one another efficiently
No parallelism | Can’t fan out multiple LLM calls and gather results


<p>Aider&nbsp;Macros lift these constraints while remaining interactive and deterministic.</p>
<h3>Key Features</h3>
<ul>
<li>
<p><strong>Flexible control flow</strong> – Use standard Python loops, conditionals, and functions around LLM invocations.</p>
</li>
<li>
<p><strong>Spawn&nbsp;/&nbsp;gather concurrency</strong> – Run up to N models in parallel, then <code inline="">gather()</code> their outputs. Includes an ncurses‑style progress line so you can watch them finish in real time.</p>
</li>
<li>
<p><strong>Tool use built‑in</strong> – A new <code inline="">/search</code> command (OpenRouter) is exposed to macros for quick web look‑ups.</p>
</li>
<li>
<p><strong>Deterministic &amp; testable</strong> – Macro logic is plain Python, so you can unit‑test or lint it like any other code.</p>
</li>
<li>
<p><strong>Gentle “agentic” path</strong> – Adds tool use and light autonomy without going fully headless or uncontrollably recursive.</p>
</li>
</ul>
<h3>Inspirations</h3>
<ul>
<li>
<p>“Loops as LLM Calls”</p>
</li>
<li>
<p>Eric Elliott’s <a href="https://github.com/paralleldrive/sudolang-llm-support"><strong>SudoLang</strong></a></p>
</li>
<li>
<p><a href="https://github.com/nbardy/SynesthesiaLisp"><strong>SynesthesiaLisp</strong></a></p>
</li>
<li>
<p>Aider’s existing <strong>/load</strong> and <strong>architect</strong> modes</p>
</li>
</ul>
<h3>Relationship to Core Aider</h3>
<p>Architect mode already offers macro‑like behaviour, but Aider&nbsp;Macros generalise the idea and deprecate <code inline="">/load</code> and <code inline="">/architecture</code>. The README has been rewritten to focus on this new system; full docs will be restored and expanded if there’s interest in upstreaming.</p>
<hr>
</body></html>