### PR TITLE
feat: add configurable PostHog host and API key parameters

### DIFF
--- a/aider/analytics.py
+++ b/aider/analytics.py
@@ -70,9 +70,17 @@ class Analytics:
     # ephemeral
     logfile = None
 
-    def __init__(self, logfile=None, permanently_disable=False):
+    def __init__(
+            self,
+            logfile=None,
+            permanently_disable=False,
+            posthog_host=None,
+            posthog_project_api_key=None
+    ):
         self.logfile = logfile
         self.get_or_create_uuid()
+        self.custom_posthog_host = posthog_host
+        self.custom_posthog_project_api_key = posthog_project_api_key
 
         if self.permanently_disable or permanently_disable or not self.asked_opt_in:
             self.disable(permanently_disable)
@@ -92,8 +100,8 @@ class Analytics:
 
         # self.mp = Mixpanel(mixpanel_project_token)
         self.ph = Posthog(
-            project_api_key=posthog_project_api_key,
-            host=posthog_host,
+            project_api_key=self.custom_posthog_project_api_key or posthog_project_api_key,
+            host=self.custom_posthog_host or posthog_host,
             on_error=self.posthog_error,
             enable_exception_autocapture=True,
             super_properties=self.get_system_info(),  # Add system info to all events

--- a/aider/args.py
+++ b/aider/args.py
@@ -542,6 +542,16 @@ def get_parser(default_config_files, git_root):
         help="Permanently disable analytics",
         default=False,
     )
+    group.add_argument(
+        "--analytics-posthog-host",
+        metavar="ANALYTICS_POSTHOG_HOST",
+        help="Send analytics to custom PostHog instance",
+    )
+    group.add_argument(
+        "--analytics-posthog-project-api-key",
+        metavar="ANALYTICS_POSTHOG_PROJECT_API_KEY",
+        help="Send analytics to custom PostHog project"
+    )
 
     #########
     group = parser.add_argument_group("Upgrading")

--- a/aider/main.py
+++ b/aider/main.py
@@ -626,7 +626,12 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         )
         os.environ["OPENAI_ORGANIZATION"] = args.openai_organization_id
 
-    analytics = Analytics(logfile=args.analytics_log, permanently_disable=args.analytics_disable)
+    analytics = Analytics(
+        logfile=args.analytics_log,
+        permanently_disable=args.analytics_disable,
+        posthog_host=args.analytics_posthog_host,
+        posthog_project_api_key=args.analytics_posthog_project_api_key
+    )
     if args.analytics is not False:
         if analytics.need_to_ask(args.analytics):
             io.tool_output(

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -292,6 +292,12 @@
 ## Permanently disable analytics
 #analytics-disable: false
 
+## PostHog host (default: https://us.i.posthog.com)
+#analytics-posthog-host: xxx
+
+## PostHog project api key (default: phc_99T7muzafUMMZX15H8XePbMSreEUzahHbtWjy3l5Qbv)
+#analytics-posthog-project-api-key: xxx
+
 ############
 # Upgrading:
 

--- a/aider/website/docs/more/analytics.md
+++ b/aider/website/docs/more/analytics.md
@@ -106,6 +106,12 @@ If you want to just log analytics without reporting them, you can do:
 aider --analytics-log filename.jsonl --no-analytics
 ```
 
+### Sending analytics to custom PostHog project or installation
+
+Aider uses PostHog for analytics collection. You can configure aider to send analytics to your own PostHog project or a custom PostHog installation using these parameters:
+
+- `--analytics-posthog-project-api-key KEY` - Set a custom PostHog project API key
+- `--analytics-posthog-host HOST` - Set a custom PostHog host (default is app.posthog.com)
 
 ## Reporting issues
 


### PR DESCRIPTION
Hi! 👋🏻

Would you consider adding configuration options to specify a custom PostHog project or a custom PostHog host?

This could be helpful for teams using aider within a company who want to monitor adoption and usage among engineers using their own PostHog setup.

Thanks for considering it!