### PR TITLE
Loading env files no longer clobbers the loaded environment

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -14,7 +14,7 @@ except ImportError:
     git = None
 
 import importlib_resources
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 from prompt_toolkit.enums import EditingMode
 
 from aider import __version__, models, urls, utils
@@ -326,7 +326,6 @@ def generate_search_path_list(default_file, git_root, command_line_file):
     uniq.reverse()
     files = uniq
     files = list(map(str, files))
-    files = list(dict.fromkeys(files))
 
     return files
 
@@ -374,15 +373,18 @@ def load_dotenv_files(git_root, dotenv_fname, encoding="utf-8"):
         dotenv_files = list(dict.fromkeys(dotenv_files))
 
     loaded = []
+    config = {}
     for fname in dotenv_files:
         try:
             if Path(fname).exists():
-                load_dotenv(fname, override=True, encoding=encoding)
+                config.update(dotenv_values(fname, encoding=encoding))
                 loaded.append(fname)
         except OSError as e:
             print(f"OSError loading {fname}: {e}")
         except Exception as e:
             print(f"Error loading {fname}: {e}")
+    config.update(os.environ)
+    os.environ |= config
     return loaded
 
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -199,7 +199,7 @@ class TestMain(TestCase):
             named_env = git_dir / "named.env"
 
             os.environ["E"] = "existing"
-            home_env.write_text("A=home\nB=home\nC=home\nD=home")
+            home_env.write_text("A=home\nB=home\nC=home\nD=home\nE=home")
             git_env.write_text("A=git\nB=git\nC=git")
             cwd_env.write_text("A=cwd\nB=cwd")
             named_env.write_text("A=named")


### PR DESCRIPTION
If the user has an env variable loaded, that variable is no longer clobbered by a .env file referencing the same variable.

So if your env has "ANTHROPIC_API_KEY", and you have an env file with "ANTHROPIC_API_KEY", you will use the value from your environment, rather than your env file.  This sets up the priority:

$HOME/.env
$GIT_ROOT/.env
$PWD/.env
${--env-file}
<loaded environment>

This is what *I* expect, but if there are other opinions, then you can ignore this PR.