### PR TITLE
fix: add suffix "md" when opening editor in InputOutput class

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -595,7 +595,7 @@ class InputOutput:
             current_text = buffer.text
 
             # Open the editor with the current text
-            edited_text = pipe_editor(input_data=current_text)
+            edited_text = pipe_editor(input_data=current_text, suffix="md")
 
             # Replace the buffer with the edited text, strip any trailing newlines
             buffer.text = edited_text.rstrip("\n")


### PR DESCRIPTION
First of all, thanks a lot for Aider — it's an amazing tool and has been super helpful!

## What
When using `C-x C-e` to edit the current input in an external editor, the temp file didn't have a suffix.
Now it sets `suffix="md"` when calling `pipe_editor`, so editors like vim can pick up Markdown syntax highlighting.

## Why
Editing without a file suffix makes it harder for editors to guess the right language mode.
Adding `.md` improves the editing experience.

Also, the `/editor` command already uses a `.md` suffix — this change brings `C-x C-e` in line with that.

## Impact
- Only affects the temp file name when opening the editor
- Better UX for editing Markdown
- Consistent behavior between `C-x C-e` and `/editor`
