### PR TITLE
Fix for #3957

### DIFF
--- a/aider/run_cmd.py
+++ b/aider/run_cmd.py
@@ -113,7 +113,7 @@ def run_cmd_pexpect(command, verbose=False, cwd=None):
             # Use the shell from SHELL environment variable
             if verbose:
                 print("Running pexpect.spawn with shell:", shell)
-            child = pexpect.spawn(shell, args=["-i", "-c", command], encoding="utf-8", cwd=cwd)
+            child = pexpect.spawn(shell, args=["-c", command], encoding="utf-8", cwd=cwd)
         else:
             # Fall back to spawning the command directly
             if verbose:


### PR DESCRIPTION
Hi, this is liked to #3957 discovered earlier today.

I don't think AIDER needs anything from the interactive shell (line-editing, history, etc.. ). So removing -i leaves the child shell non-interactive, meaning it inherits the active environment exactly as it is, so no surprise context-switch.

Testing on my project doesn't seem to affect the workflow either. 