### PR TITLE
Fix clipboard decode-error when using command `/paste`

### DIFF
--- a/aider/copypaste.py
+++ b/aider/copypaste.py
@@ -18,12 +18,16 @@ class ClipboardWatcher:
     def start(self):
         """Start watching clipboard for changes"""
         self.stop_event = threading.Event()
-        self.last_clipboard = pyperclip.paste()
+        # guard against non-UTF8 bytes in the clipboard
+        try:
+            self.last_clipboard = pyperclip.paste()
+        except UnicodeDecodeError:
+            self.last_clipboard = ""
 
         def watch_clipboard():
             while not self.stop_event.is_set():
                 try:
-                    current = pyperclip.paste()
+                    current = self._safe_paste()
                     if current != self.last_clipboard:
                         self.last_clipboard = current
                         self.io.interrupt_input()
@@ -50,6 +54,23 @@ class ClipboardWatcher:
             self.watcher_thread.join()
             self.watcher_thread = None
             self.stop_event = None
+
+    def _safe_paste(self) -> str:
+        """
+        Attempt a normal pyperclip.paste(); if it raises a UnicodeDecodeError
+        fall back to a raw xclip call and replace invalid bytes.
+        """
+        try:
+            return pyperclip.paste()
+        except UnicodeDecodeError:
+            # linux fallback via xclip
+            import subprocess, shlex
+            try:
+                raw = subprocess.check_output(shlex.split("xclip -selection clipboard -o"))
+                # replace any invalid bytes with �
+                return raw.decode("utf-8", errors="replace")
+            except Exception:
+                return ""
 
 
 def main():


### PR DESCRIPTION
### **PR Type**
Bug fix

___

### **PR Description**
- Fixed clipboard decode errors by adding safe paste handling.
  - Added `_safe_paste` method to handle `UnicodeDecodeError`.
  - Falls back to `xclip` on Linux when standard paste fails.

- Improved clipboard watching reliability with error handling.
