### PR TITLE
deps: Bump tree-sitter-language-pack 0.7.2 → 0.7.3

### DIFF
--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -546,7 +546,7 @@ tree-sitter-c-sharp==0.23.1
     # via tree-sitter-language-pack
 tree-sitter-embedded-template==0.23.2
     # via tree-sitter-language-pack
-tree-sitter-language-pack==0.7.2
+tree-sitter-language-pack==0.7.3
     # via grep-ast
 tree-sitter-yaml==0.7.0
     # via tree-sitter-language-pack


### PR DESCRIPTION
Bump tree-sitter-language-pack 0.7.2 → 0.7.3 to get a fix for swift macros and copyable:
- https://github.com/Goldziher/tree-sitter-language-pack/pull/39
- https://github.com/Goldziher/tree-sitter-language-pack/releases/tag/v0.7.3

How I generated this:

1. In `requirements/common-constraints.txt`, I deleted everything from grep-ast:
```diff
$ git diff
diff --git a/requirements/common-constraints.txt b/requirements/common-constraints.txt
index 0f0d0991..4a8bdf70 100644
--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -160,8 +160,6 @@ greenlet==3.2.1
     # via
     #   playwright
     #   sqlalchemy
-grep-ast==0.8.1
-    # via -r requirements/requirements.in
 griffe==1.7.3
     # via banks
 grpcio==1.71.0
@@ -311,10 +309,6 @@ pandas==2.2.3
     #   streamlit
 pathos==0.3.4
     # via lox
-pathspec==0.12.1
-    # via
-    #   -r requirements/requirements.in
-    #   grep-ast
 pexpect==4.9.0
     # via -r requirements/requirements.in
 pillow==11.2.1
@@ -546,8 +540,6 @@ tree-sitter-c-sharp==0.23.1
     # via tree-sitter-language-pack
 tree-sitter-embedded-template==0.23.2
     # via tree-sitter-language-pack
-tree-sitter-language-pack==0.7.2
-    # via grep-ast
 tree-sitter-yaml==0.7.0
     # via tree-sitter-language-pack
 typer==0.15.3
```

2. Then I ran the commands documented at the top of `requirements/common-constraints.txt` + `requirements.txt`:
```sh
# This one I ran as is
$ uv pip compile --no-strip-extras --output-file=requirements/common-constraints.txt requirements/requirements.in requirements/requirements-browser.in requirements/requirements-dev.in requirements/requirements-help.in requirements/requirements-playwright.in

# This one I had to edit: --output-file=tmp.requirements.txt -> --output-file=requirements.txt
$ uv pip compile --no-strip-extras --constraint=requirements/common-constraints.txt --output-file=requirements.txt requirements/requirements.in
```

3. And the net diff was this:
```diff
$ git diff
diff --git a/requirements/common-constraints.txt b/requirements/common-constraints.txt
index 0f0d0991..09aa8333 100644
--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -546,7 +546,7 @@ tree-sitter-c-sharp==0.23.1
     # via tree-sitter-language-pack
 tree-sitter-embedded-template==0.23.2
     # via tree-sitter-language-pack
-tree-sitter-language-pack==0.7.2
+tree-sitter-language-pack==0.7.3
     # via grep-ast
 tree-sitter-yaml==0.7.0
     # via tree-sitter-language-pack
```