### PR TITLE
feat: cmd_enable_thinking

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -133,6 +133,14 @@ def get_parser(default_config_files, git_root):
         help="Set the thinking token budget for models that support it (default: not set)",
     )
     group.add_argument(
+        "--enable-thinking",
+        type=str,
+        help=(
+            "Switches between thinking and non-thinking modes for models that support it."
+            " (default: not set)"
+        ),
+    )
+    group.add_argument(
         "--verify-ssl",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1564,6 +1564,28 @@ class Commands:
         announcements = "\n".join(self.coder.get_announcements())
         self.io.tool_output(announcements)
 
+    def cmd_enable_thinking(self, args):
+        """Enable or disable thinking for models that support it."""
+        model = self.coder.main_model
+        if not args.strip():
+            # Display current value if no args are provided
+            thinking_value = model.get_enable_thinking()
+            if thinking_value is None:
+                self.io.tool_output("thinking effort is not currently set.")
+            else:
+                self.io.tool_output(f"Current thinking setting: {thinking_value}")
+            return
+
+        value = args.strip()
+        model.set_enable_thinking(value)
+        thinking_value = model.get_enable_thinking()
+        self.io.tool_output(f"Set enable thinking to {thinking_value}")
+        self.io.tool_output()
+
+        # Output announcements
+        announcements = "\n".join(self.coder.get_announcements())
+        self.io.tool_output(announcements)
+
     def cmd_copy_context(self, args=None):
         """Copy the current chat context as markdown, suitable to paste into a web UI"""
 

--- a/aider/models.py
+++ b/aider/models.py
@@ -743,6 +743,15 @@ class Model(ModelSettings):
                     self.extra_params["extra_body"] = {}
                 self.extra_params["extra_body"]["reasoning_effort"] = effort
 
+    def set_enable_thinking(self, setting):
+        """Set the enable thinking parameter for models that support it"""
+        if setting is not None:
+            if not self.extra_params:
+                self.extra_params = {}
+            if "extra_body" not in self.extra_params:
+                self.extra_params["extra_body"] = {}
+            self.extra_params["extra_body"]["enable_thinking"] = setting
+
     def parse_token_value(self, value):
         """
         Parse a token value string into an integer.
@@ -850,6 +859,16 @@ class Model(ModelSettings):
                 and "reasoning_effort" in self.extra_params["extra_body"]
             ):
                 return self.extra_params["extra_body"]["reasoning_effort"]
+        return None
+
+    def get_enable_thinking(self):
+        """Get enable thinking value if available"""
+        if (
+            self.extra_params
+            and "extra_body" in self.extra_params
+            and "enable_thinking" in self.extra_params["extra_body"]
+        ):
+            return self.extra_params["extra_body"]["enable_thinking"]
         return None
 
     def is_deepseek_r1(self):


### PR DESCRIPTION
Adds a command which can be used to enable or disable reasoning by supported models (Qwen3). This is more robust than using the /no_think prompt and saves a small number of tokens.

Mostly copied from reasoning effort.
Tested with local Qwen3 via TabbyAPI.