### PR TITLE
refactor: Update OpenRouter Gemini 2.5 Pro Exp model ID

### DIFF
--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -312,7 +312,7 @@
         "supports_tool_choice": true,
         "source": "https://cloud.google.com/vertex-ai/generative-ai/pricing"
     },
-    "openrouter/google/gemini-2.5-pro-exp-03-25:free": {
+    "openrouter/google/gemini-2.5-pro-exp-03-25": {
         "max_tokens": 8192,
         "max_input_tokens": 1048576,
         "max_output_tokens": 64000,

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -969,7 +969,7 @@
   overeager: true
   weak_model_name: gemini/gemini-2.5-flash-preview-04-17
 
-- name: openrouter/google/gemini-2.5-pro-exp-03-25:free
+- name: openrouter/google/gemini-2.5-pro-exp-03-25
   edit_format: diff-fenced
   overeager: true
   use_repo_map: true


### PR DESCRIPTION
Hello @paul-gauthier,

This PR removes the `:free` suffix from the `openrouter/google/gemini-2.5-pro-exp-03-25` model identifier in `aider/resources/model-settings.yml` and renames its corresponding entry in `aider/resources/model-metadata.json`.

This change aligns our configuration with OpenRouter's recent update, where they now alias the `:free` suffixed model ID to the standard, non-suffixed ID. Consequently, the model remains free to use via this standard ID, albeit subject to new, stricter rate limits.

https://openrouter.ai/google/gemini-2.5-pro-exp-03-25