### PR TITLE
build: update Dockerfile to avoid long rebuilds + add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  # Run this using `docker compose run --rm aider-base` on the CLI
+  # To run with forced build: `docker compose run --build --rm aider-base` on the CLI
+  aider-base:
+    build:
+      context: .
+      args: [--rm]
+      dockerfile: docker/Dockerfile
+    container_name: aider
+    #volumes:
+    #  - .:/app
+    #working_dir: /app
+    command: /bin/bash
+
+  # Run this using `docker compose run --rm aider` on the CLI
+  # You can add arguments: `docker compose run --rm aider --architect -m "Do this task"`
+  # And you can request to update the build: `docker compose run --build --rm aider` on the CLI
+  aider:
+    extends: aider-base
+    command: aider
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,19 +36,27 @@ FROM base AS aider-full
 
 ENV AIDER_DOCKER_IMAGE=paulgauthier/aider-full
 
-COPY . /tmp/aider
+# Copy requirements files
+COPY requirements.txt /tmp/aider/
+COPY requirements/ /tmp/aider/requirements/
 
 # Install dependencies as root
 RUN /venv/bin/python -m pip install --upgrade --no-cache-dir pip && \
-    /venv/bin/python -m pip install --no-cache-dir /tmp/aider[help,browser,playwright] boto3 \
-       --extra-index-url https://download.pytorch.org/whl/cpu && \
+    /venv/bin/python -m pip install --no-cache-dir -r /tmp/aider/requirements.txt && \
     rm -rf /tmp/aider
 
 # Install playwright browsers
-RUN /venv/bin/python -m playwright install --with-deps chromium
+RUN /venv/bin/python -m pip install --no-cache-dir playwright && \
+    /venv/bin/python -m playwright install --with-deps chromium
 
 # Fix site-packages permissions
 RUN find /venv/lib/python3.10/site-packages \( -type d -exec chmod a+rwx {} + \) -o \( -type f -exec chmod a+rw {} + \)
+
+# Copy the rest of the application code
+COPY . /app/
+
+# Install the application as a package
+RUN /venv/bin/python -m pip install .
 
 # Switch to appuser
 USER appuser
@@ -60,19 +68,27 @@ FROM base AS aider
 
 ENV AIDER_DOCKER_IMAGE=paulgauthier/aider
 
-COPY . /tmp/aider
+# Copy requirements files
+COPY requirements.txt /tmp/aider/
+COPY requirements/ /tmp/aider/requirements/
 
 # Install dependencies as root
 RUN /venv/bin/python -m pip install --upgrade --no-cache-dir pip && \
-    /venv/bin/python -m pip install --no-cache-dir /tmp/aider[playwright] boto3 google-cloud-aiplatform \
-       --extra-index-url https://download.pytorch.org/whl/cpu && \
+    /venv/bin/python -m pip install --no-cache-dir -r /tmp/aider/requirements.txt && \
     rm -rf /tmp/aider
 
 # Install playwright browsers
-RUN /venv/bin/python -m playwright install --with-deps chromium
+RUN /venv/bin/python -m pip install --no-cache-dir playwright && \
+    /venv/bin/python -m playwright install --with-deps chromium
 
 # Fix site-packages permissions
 RUN find /venv/lib/python3.10/site-packages \( -type d -exec chmod a+rwx {} + \) -o \( -type f -exec chmod a+rw {} + \)
+
+# Copy the rest of the application code
+COPY . /app/
+
+# Install the application as a package
+RUN /venv/bin/python -m pip install .
 
 # Switch to appuser
 USER appuser


### PR DESCRIPTION
- Avoid rebuilding all the steps by installing requirements depending on the requirement files only first. Use actual application code as a reference in the last Dockerfile layer.
- Add docker-compose.yml to make running easier / provide example.

Further optimisation is probably possible, but I can test code updates faster with this.