### PR TITLE
fix: base coder not ignoring gitignore if --file is used.

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -445,6 +445,7 @@ class Coder:
             fname = Path(fname)
             if self.repo and self.repo.git_ignored_file(fname):
                 self.io.tool_warning(f"Skipping {fname} that matches gitignore spec.")
+                continue
 
             if self.repo and self.repo.ignored_file(fname):
                 self.io.tool_warning(f"Skipping {fname} that matches aiderignore spec.")


### PR DESCRIPTION
`aider --file [something .gitignored]` was not working.

It would say:
`Skipping /home/dude/projects/aider/.aider.chat.history.md that matches gitignore spec.` for example, but still add file contents to context.

The fix correct thats, by making the base coder skip adding the fname for that file to abs_fnames.
