### PR TITLE
Add Clojure repomap queries (Close #3416)

### DIFF
--- a/aider/queries/tree-sitter-language-pack/clojure-tags.scm
+++ b/aider/queries/tree-sitter-language-pack/clojure-tags.scm
@@ -1,0 +1,7 @@
+(list_lit
+  meta: _*
+  . (sym_lit name: (sym_name) @ignore)
+  . (sym_lit name: (sym_name) @name.definition.method)
+  (#match? @ignore "^def.*"))
+
+(sym_lit name: (sym_name) @name.reference.call)

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -468,10 +468,11 @@ class RepoMap:
             mul = 1.0
 
             is_snake = ("_" in ident) and any(c.isalpha() for c in ident)
+            is_kebab = ("-" in ident) and any(c.isalpha() for c in ident)
             is_camel = any(c.isupper() for c in ident) and any(c.islower() for c in ident)
             if ident in mentioned_idents:
                 mul *= 10
-            if (is_snake or is_camel) and len(ident) >= 8:
+            if (is_snake or is_kebab or is_camel) and len(ident) >= 8:
                 mul *= 10
             if ident.startswith("_"):
                 mul *= 0.1


### PR DESCRIPTION
Definitions: symbol name (without namespace) immediately following a `def` prefixed symbol
References: symbol name (without namespace) found anywhere

The definitions is pretty good; using `def` prefix is a very standard Clojure pattern even for 3rd party macros.

References is less than ideal, as it causes building the repo map to be a bit slow. The alternative would be to treat only symbols as the first entry in a `list_lit` as a reference. This works, but I've gotten better results allowing every symbol to contribute to the ranking of definitions.

Also added kebab-case as a condition to contribute a definition's ranking. It shouldn't impact most other languages, as `-` is typically unary operation and not allowed in idents.