### PR TITLE
feat: Add server address and port options for browser mode

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -628,6 +628,24 @@ def get_parser(default_config_files, git_root):
         default=False,
     )
     group.add_argument(
+        "--server-address",
+        type=str,
+        default=None,
+        help=(
+            "The address on which aider should listen when running in browser mode. By default"
+            " it listens on localhost."
+        ),
+    )
+    group.add_argument(
+        "--server-port",
+        type=int,
+        default=None,
+        help=(
+            "The port on which aider should listen when running in browser mode. By default"
+            " a random port is chosen."
+        ),
+    )
+    group.add_argument(
         "--copy-paste",
         action=argparse.BooleanOptionalAction,
         default=False,

--- a/aider/main.py
+++ b/aider/main.py
@@ -230,7 +230,7 @@ def write_streamlit_credentials():
         print("Streamlit credentials already exist.")
 
 
-def launch_gui(args):
+def launch_gui(args, server_port=None, server_address=None):
     from streamlit.web import cli
 
     from aider import gui
@@ -250,6 +250,12 @@ def launch_gui(args):
         "--runner.magicEnabled=false",
         "--server.runOnSave=false",
     ]
+
+    if server_port is not None:
+        st_args.append(f"--server.port={server_port}")
+
+    if server_address is not None:
+        st_args.append(f"--server.address={server_address}")
 
     # https://github.com/Aider-AI/aider/issues/2193
     is_dev = "-dev" in str(__version__)
@@ -663,7 +669,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             analytics.event("exit", reason="Streamlit not installed")
             return
         analytics.event("gui session")
-        launch_gui(argv)
+        launch_gui(argv, server_port=args.server_port, server_address=args.server_address)
         analytics.event("exit", reason="GUI session ended")
         return
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -382,6 +382,12 @@ cog.outl("```")
 ## Run aider in your browser (default: False)
 #gui: false
 
+## The address on which aider should listen when running in browser mode (default: localhost)
+#server-address: "0.0.0.0"
+
+## The port on which aider should listen when running in browser mode (default: None)
+#server-port: 12345
+
 ## Enable automatic copy/paste of chat between aider and web UI (default: False)
 #copy-paste: false
 

--- a/tests/browser/test_browser.py
+++ b/tests/browser/test_browser.py
@@ -6,7 +6,7 @@ from aider.main import main
 
 
 class TestBrowser(unittest.TestCase):
-    @patch("aider.main.launch_gui")
+    @patch("aider.main.launch_gui", autospec=True)
     def test_browser_flag_imports_streamlit(self, mock_launch_gui):
         os.environ["AIDER_ANALYTICS"] = "false"
 


### PR DESCRIPTION
This change adds two new options:
- `--server-address`
- `--server-port`

These options are only used in `--browser` mode.

Motivation: This is useful if you want to run aider as a permanent service over the web (behind an authenticated HTTPS reverse proxy, of course). This way aider can be running on your server and you can access it remotely while on the go.

Note: This change was written 100% with aider.