### PR TITLE
Added link to GH Copilot docs that allow 3rd party agents. 

### DIFF
--- a/aider/website/docs/llms/github.md
+++ b/aider/website/docs/llms/github.md
@@ -99,7 +99,7 @@ show-model-warnings: false
 
 * Calls made through aider are billed through your Copilot subscription  
   (aider will still print *estimated* costs).
-* The Copilot docs explicitly allow third-party “agents” that hit this API – aider is playing by
+* [The Copilot docs explicitly allow third-party “agents”](https://docs.github.com/en/copilot/building-copilot-extensions/building-a-copilot-agent-for-your-copilot-extension/using-copilots-llm-for-your-agent) that hit this API – aider is playing by
   the rules.
 * Aider talks directly to the REST endpoint—no web-UI scraping or browser automation.
 


### PR DESCRIPTION
The docs on this page mention that Github explicitly allows the use of third party agents. 

However, for business users, it's important to have a link to where this is stated so that we are sure we're not in violation of TOS. 

Added this link to help make it easier for people to find. 

