### PR TITLE
[Feature] Chat history archive

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -295,10 +295,21 @@ def get_parser(default_config_files, git_root):
         default=None,
         help=(
             "Specify a directory to archive dated chat history files (e.g., .ai-chats). If set,"
-            " chat history files will be saved as YYYY-MM-DD HH-MM.aider.md in this directory,"
-            " overriding the --chat-history-file setting."
+            " chat history files will be saved as YYYY-MM-DD HH-MM.aider.md (or YYYY-MM-DD HH-MM"
+            " TASK_TITLE.aider.md if --task is used) in this directory, overriding the"
+            " --chat-history-file setting."
         ),
     ).complete = shtab.DIR
+    group.add_argument(
+        "--task",
+        metavar="TASK_TITLE",
+        default=None,
+        help=(
+            "Specify a title for the chat session. If --chat-history-archive is enabled, this"
+            " title will be included in the archived chat history filename (e.g., YYYY-MM-DD HH-MM"
+            " TASK_TITLE.aider.md)."
+        ),
+    )
     group.add_argument(
         "--llm-history-file",
         metavar="LLM_HISTORY_FILE",

--- a/aider/args.py
+++ b/aider/args.py
@@ -290,6 +290,16 @@ def get_parser(default_config_files, git_root):
         help="Restore the previous chat history messages (default: False)",
     )
     group.add_argument(
+        "--chat-history-archive",
+        metavar="CHAT_HISTORY_ARCHIVE_DIR",
+        default=None,
+        help=(
+            "Specify a directory to archive dated chat history files (e.g., .ai-chats). If set,"
+            " chat history files will be saved as YYYY-MM-DD HH-MM.aider.md in this directory,"
+            " overriding the --chat-history-file setting."
+        ),
+    ).complete = shtab.DIR
+    group.add_argument(
         "--llm-history-file",
         metavar="LLM_HISTORY_FILE",
         default=None,

--- a/aider/main.py
+++ b/aider/main.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import re
@@ -502,6 +503,15 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
     # Parse again to include any arguments that might have been defined in .env
     args = parser.parse_args(argv)
+
+    if args.chat_history_archive:
+        archive_dir = Path(args.chat_history_archive).resolve()
+        datetime_str = datetime.datetime.now().strftime("%Y-%m-%d %H-%M")
+        dated_filename = f"{datetime_str}.aider.md"
+        final_chat_history_path = archive_dir / dated_filename
+
+        os.makedirs(archive_dir, exist_ok=True)
+        args.chat_history_file = str(final_chat_history_path)
 
     if args.shell_completions:
         # Ensure parser.prog is set for shtab, though it should be by default

--- a/aider/main.py
+++ b/aider/main.py
@@ -507,7 +507,17 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if args.chat_history_archive:
         archive_dir = Path(args.chat_history_archive).resolve()
         datetime_str = datetime.datetime.now().strftime("%Y-%m-%d %H-%M")
-        dated_filename = f"{datetime_str}.aider.md"
+
+        task_title_for_filename = ""
+        if args.task:
+            # Sanitize the task title for use in a filename. Keep only allowed characters.
+            allowed_chars = ".,_-+#%&'!()[]=; "
+            core_sanitized_title = "".join([c for c in args.task if c.isalnum() or c in allowed_chars]).strip()
+
+            if core_sanitized_title:
+                task_title_for_filename = " " + core_sanitized_title
+
+        dated_filename = f"{datetime_str}{task_title_for_filename}.aider.md"
         final_chat_history_path = archive_dir / dated_filename
 
         os.makedirs(archive_dir, exist_ok=True)

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -152,6 +152,11 @@
 ## Restore the previous chat history messages (default: False)
 #restore-chat-history: false
 
+## Specify a directory to archive dated chat history files.
+## If set, files like YYYY-MM-DD HH-MM.aider.md will be saved here,
+## overriding the chat-history-file setting.
+#chat-history-archive: .ai-chats
+
 ## Log the conversation with the LLM to this file (for example, .aider.llm.history)
 #llm-history-file: xxx
 

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -153,8 +153,8 @@
 #restore-chat-history: false
 
 ## Specify a directory to archive dated chat history files.
-## If set, files like YYYY-MM-DD HH-MM.aider.md will be saved here,
-## overriding the chat-history-file setting.
+## If set, files like YYYY-MM-DD HH-MM.aider.md (or YYYY-MM-DD HH-MM TASK_TITLE.aider.md if --task is used)
+## will be saved here, overriding the chat-history-file setting.
 #chat-history-archive: .ai-chats
 
 ## Log the conversation with the LLM to this file (for example, .aider.llm.history)

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -201,10 +201,16 @@ cog.outl("```")
 #input-history-file: .aider.input.history
 
 ## Specify the chat history file (default: .aider.chat.history.md)
+## This setting is overridden if chat-history-archive is used.
 #chat-history-file: .aider.chat.history.md
 
 ## Restore the previous chat history messages (default: False)
 #restore-chat-history: false
+
+## Specify a directory to archive dated chat history files.
+## If set, files like YYYY-MM-DD HH-MM.aider.md will be saved here,
+## overriding the chat-history-file setting.
+#chat-history-archive: .ai-chats
 
 ## Log the conversation with the LLM to this file (for example, .aider.llm.history)
 #llm-history-file: xxx

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -208,8 +208,8 @@ cog.outl("```")
 #restore-chat-history: false
 
 ## Specify a directory to archive dated chat history files.
-## If set, files like YYYY-MM-DD HH-MM.aider.md will be saved here,
-## overriding the chat-history-file setting.
+## If set, files like YYYY-MM-DD HH-MM.aider.md (or YYYY-MM-DD HH-MM TASK_TITLE.aider.md if --task is used)
+## will be saved here, overriding the chat-history-file setting.
 #chat-history-archive: .ai-chats
 
 ## Log the conversation with the LLM to this file (for example, .aider.llm.history)

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -289,9 +289,13 @@ Aliases:
   - `--no-restore-chat-history`
 
 ### `chat-history-archive CHAT_HISTORY_ARCHIVE_DIR`
-Specify a directory to archive dated chat history files (e.g., `.ai-chats`). If set, chat history files will be saved as `YYYY-MM-DD HH-MM.aider.md` in this directory, overriding the `--chat-history-file` setting. This option is typically set in the `.aider.conf.yml` file or via the `AIDER_CHAT_HISTORY_ARCHIVE` environment variable.  
+Specify a directory to archive dated chat history files (e.g., `.ai-chats`). If set, chat history files will be saved as `YYYY-MM-DD HH-MM.aider.md` (or `YYYY-MM-DD HH-MM TASK_TITLE.aider.md` if `--task` is used) in this directory, overriding the `--chat-history-file` setting. This option is typically set in the `.aider.conf.yml` file or via the `AIDER_CHAT_HISTORY_ARCHIVE` environment variable.  
 Default: None  
 Environment variable: `AIDER_CHAT_HISTORY_ARCHIVE`  
+
+### `--task TASK_TITLE`
+Specify a title for the chat session. If `--chat-history-archive` is enabled, this title will be included in the archived chat history filename (e.g., `YYYY-MM-DD HH-MM TASK_TITLE.aider.md`).  
+Environment variable: `AIDER_TASK`  
 
 ### `--llm-history-file LLM_HISTORY_FILE`
 Log the conversation with the LLM to this file (for example, .aider.llm.history)  

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -276,7 +276,7 @@ Default: .aider.input.history
 Environment variable: `AIDER_INPUT_HISTORY_FILE`  
 
 ### `--chat-history-file CHAT_HISTORY_FILE`
-Specify the chat history file (default: .aider.chat.history.md)  
+Specify the chat history file (default: .aider.chat.history.md). This setting is overridden if `chat-history-archive` is used.  
 Default: .aider.chat.history.md  
 Environment variable: `AIDER_CHAT_HISTORY_FILE`  
 
@@ -287,6 +287,11 @@ Environment variable: `AIDER_RESTORE_CHAT_HISTORY`
 Aliases:
   - `--restore-chat-history`
   - `--no-restore-chat-history`
+
+### `chat-history-archive CHAT_HISTORY_ARCHIVE_DIR`
+Specify a directory to archive dated chat history files (e.g., `.ai-chats`). If set, chat history files will be saved as `YYYY-MM-DD HH-MM.aider.md` in this directory, overriding the `--chat-history-file` setting. This option is typically set in the `.aider.conf.yml` file or via the `AIDER_CHAT_HISTORY_ARCHIVE` environment variable.  
+Default: None  
+Environment variable: `AIDER_CHAT_HISTORY_ARCHIVE`  
 
 ### `--llm-history-file LLM_HISTORY_FILE`
 Log the conversation with the LLM to this file (for example, .aider.llm.history)  


### PR DESCRIPTION
I believe chat histories are not valued enough by Aider. See #3574

This PR adds a `--chat-history-archive` that points to a folder and then a `--task` that receives a title from user about the session. It then saves that particular session under the specified directory with a file name like `YYYY-MM-DD HH-MM TASK_TITLE.aider.md` (as if `--chat-history-file` is used). So as long as users use Aider, they end up having a nice archive of previous chats.

These chat files provide valuable information similar to `git blame`. So when you search some string in a project directory, you also search in the chat history which brings you up the specific AI chat that is related to your search.

`--task` is optional, if it is not specified, files are created as `YYYY-MM-DD HH-MM.aider.md`.