### PR TITLE
feat(voice): support for  local voice transcription using pywhispercpp

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -698,6 +698,18 @@ def get_parser(default_config_files, git_root):
         default=None,
         help="Specify the input device name for voice recording",
     )
+    group.add_argument(
+        "--voice-local",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Use local transcription with WhisperCpp (default: False)",
+    )
+    group.add_argument(
+        "--voice-local-model",
+        metavar="VOICE_LOCAL_MODEL",
+        default="tiny",
+        help="Model to use for local transcription with WhisperCpp (default: tiny)",
+    )
 
     ######
     group = parser.add_argument_group("Other settings")

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1223,12 +1223,17 @@ class Commands:
         "Record and transcribe voice input"
 
         if not self.voice:
-            if "OPENAI_API_KEY" not in os.environ:
+            use_local = getattr(self.args, "voice_local", False)
+            local_model = getattr(self.args, "voice_local_model", "tiny")
+            if not use_local and "OPENAI_API_KEY" not in os.environ:
                 self.io.tool_error("To use /voice you must provide an OpenAI API key.")
                 return
             try:
                 self.voice = voice.Voice(
-                    audio_format=self.voice_format or "wav", device_name=self.voice_input_device
+                    audio_format=self.voice_format or "wav",
+                    device_name=self.voice_input_device,
+                    use_local=use_local,
+                    local_model=local_model,
                 )
             except voice.SoundDeviceError:
                 self.io.tool_error(

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -6,6 +6,7 @@ import time
 import warnings
 
 from prompt_toolkit.shortcuts import prompt
+
 from aider.llm import litellm
 
 # Optional imports
@@ -47,9 +48,7 @@ class Voice:
     Supports both OpenAI Whisper API and local WhisperCpp transcription.
     """
 
-    def __init__(
-        self, audio_format="wav", device_name=None, use_local=False, local_model="tiny"
-    ):
+    def __init__(self, audio_format="wav", device_name=None, use_local=False, local_model="tiny"):
         self.use_local = use_local
         self.local_model = local_model
         self.audio_format = audio_format
@@ -97,11 +96,7 @@ class Voice:
 
     def get_prompt(self):
         num = 10
-        cnt = (
-            0
-            if math.isnan(self.pct) or self.pct < self.threshold
-            else int(self.pct * 10)
-        )
+        cnt = 0 if math.isnan(self.pct) or self.pct < self.threshold else int(self.pct * 10)
         bar = "░" * cnt + "█" * (num - cnt)
         bar = bar[:num]
         dur = time.time() - self.start_time
@@ -114,18 +109,14 @@ class Voice:
             return
         except SoundDeviceError as e:
             print(f"Error: {e}")
-            print(
-                "Please ensure you have a working audio input device connected and try again."
-            )
+            print("Please ensure you have a working audio input device connected and try again.")
             return
 
     def _get_target_sample_rate(self):
         if self.use_local:
             return 16000
         try:
-            return int(
-                self.sd.query_devices(self.device_id, "input")["default_samplerate"]
-            )
+            return int(self.sd.query_devices(self.device_id, "input")["default_samplerate"])
         except (TypeError, ValueError, AttributeError):
             return 16000
         except self.sd.PortAudioError:
@@ -168,22 +159,16 @@ class Voice:
         except Exception as e:
             raise SoundDeviceError(f"Unexpected error opening audio stream: {e}")
 
-        with sf.SoundFile(
-            temp_wav, mode="x", samplerate=target_sample_rate, channels=1
-        ) as file:
+        with sf.SoundFile(temp_wav, mode="x", samplerate=target_sample_rate, channels=1) as file:
             while not self.q.empty():
                 file.write(self.q.get())
 
         filename, use_audio_format = self._maybe_convert_audio(temp_wav)
         try:
             if self.use_local:
-                return self._transcribe_local(
-                    filename, use_audio_format, temp_wav, language
-                )
+                return self._transcribe_local(filename, use_audio_format, temp_wav, language)
             else:
-                return self._transcribe_api(
-                    filename, use_audio_format, temp_wav, history, language
-                )
+                return self._transcribe_api(filename, use_audio_format, temp_wav, history, language)
         finally:
             self._cleanup_files(filename, temp_wav, use_audio_format)
 
@@ -211,9 +196,7 @@ class Voice:
 
     def _transcribe_local(self, filename, use_audio_format, temp_wav, language):
         if not HAS_WHISPER_CPP:
-            print(
-                "pywhispercpp is not installed. Please install it to use local transcription."
-            )
+            print("pywhispercpp is not installed. Please install it to use local transcription.")
             return
         try:
             model = WhisperModel(

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -6,19 +6,30 @@ import time
 import warnings
 
 from prompt_toolkit.shortcuts import prompt
-
 from aider.llm import litellm
+
+# Optional imports
+try:
+    from pywhispercpp.model import Model as WhisperModel
+
+    HAS_WHISPER_CPP = True
+except ImportError:
+    HAS_WHISPER_CPP = False
 
 from .dump import dump  # noqa: F401
 
 warnings.filterwarnings(
-    "ignore", message="Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work"
+    "ignore",
+    message="Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work",
 )
 warnings.filterwarnings("ignore", category=SyntaxWarning)
 
-
-from pydub import AudioSegment  # noqa
-from pydub.exceptions import CouldntDecodeError, CouldntEncodeError  # noqa
+try:
+    from pydub import AudioSegment
+    from pydub.exceptions import CouldntDecodeError, CouldntEncodeError
+except ImportError:
+    AudioSegment = None
+    CouldntDecodeError = CouldntEncodeError = Exception
 
 try:
     import soundfile as sf
@@ -31,126 +42,159 @@ class SoundDeviceError(Exception):
 
 
 class Voice:
-    max_rms = 0
-    min_rms = 1e5
-    pct = 0
+    """
+    Voice recording and transcription utility.
+    Supports both OpenAI Whisper API and local WhisperCpp transcription.
+    """
 
-    threshold = 0.15
+    def __init__(
+        self, audio_format="wav", device_name=None, use_local=False, local_model="tiny"
+    ):
+        self.use_local = use_local
+        self.local_model = local_model
+        self.audio_format = audio_format
+        self.max_rms = 0
+        self.min_rms = 1e5
+        self.pct = 0
+        self.threshold = 0.15
 
-    def __init__(self, audio_format="wav", device_name=None):
         if sf is None:
-            raise SoundDeviceError
+            raise SoundDeviceError("soundfile is not available.")
+
         try:
-            print("Initializing sound device...")
             import sounddevice as sd
 
             self.sd = sd
-
             devices = sd.query_devices()
-
-            if device_name:
-                # Find the device with matching name
-                device_id = None
-                for i, device in enumerate(devices):
-                    if device_name in device["name"]:
-                        device_id = i
-                        break
-                if device_id is None:
-                    available_inputs = [d["name"] for d in devices if d["max_input_channels"] > 0]
-                    raise ValueError(
-                        f"Device '{device_name}' not found. Available input devices:"
-                        f" {available_inputs}"
-                    )
-
-                print(f"Using input device: {device_name} (ID: {device_id})")
-
-                self.device_id = device_id
-            else:
-                self.device_id = None
-
+            self.device_id = self._find_device_id(devices, device_name)
         except (OSError, ModuleNotFoundError):
-            raise SoundDeviceError
+            raise SoundDeviceError("sounddevice is not available.")
+
         if audio_format not in ["wav", "mp3", "webm"]:
             raise ValueError(f"Unsupported audio format: {audio_format}")
-        self.audio_format = audio_format
+
+    def _find_device_id(self, devices, device_name):
+        if not device_name:
+            return None
+        for i, device in enumerate(devices):
+            if device_name in device["name"]:
+                print(f"Using input device: {device_name} (ID: {i})")
+                return i
+        available_inputs = [d["name"] for d in devices if d["max_input_channels"] > 0]
+        raise ValueError(
+            f"Device '{device_name}' not found. Available input devices: {available_inputs}"
+        )
 
     def callback(self, indata, frames, time, status):
-        """This is called (from a separate thread) for each audio block."""
         import numpy as np
 
         rms = np.sqrt(np.mean(indata**2))
         self.max_rms = max(self.max_rms, rms)
         self.min_rms = min(self.min_rms, rms)
-
         rng = self.max_rms - self.min_rms
-        if rng > 0.001:
-            self.pct = (rms - self.min_rms) / rng
-        else:
-            self.pct = 0.5
-
+        self.pct = (rms - self.min_rms) / rng if rng > 0.001 else 0.5
         self.q.put(indata.copy())
 
     def get_prompt(self):
         num = 10
-        if math.isnan(self.pct) or self.pct < self.threshold:
-            cnt = 0
-        else:
-            cnt = int(self.pct * 10)
-
+        cnt = (
+            0
+            if math.isnan(self.pct) or self.pct < self.threshold
+            else int(self.pct * 10)
+        )
         bar = "░" * cnt + "█" * (num - cnt)
         bar = bar[:num]
-
         dur = time.time() - self.start_time
         return f"Recording, press ENTER when done... {dur:.1f}sec {bar}"
 
     def record_and_transcribe(self, history=None, language=None):
         try:
-            return self.raw_record_and_transcribe(history, language)
+            return self._record_and_transcribe(history, language)
         except KeyboardInterrupt:
             return
         except SoundDeviceError as e:
             print(f"Error: {e}")
-            print("Please ensure you have a working audio input device connected and try again.")
+            print(
+                "Please ensure you have a working audio input device connected and try again."
+            )
             return
 
-    def raw_record_and_transcribe(self, history, language):
-        self.q = queue.Queue()
-
-        temp_wav = tempfile.mktemp(suffix=".wav")
-
+    def _get_target_sample_rate(self):
+        if self.use_local:
+            return 16000
         try:
-            sample_rate = int(self.sd.query_devices(self.device_id, "input")["default_samplerate"])
-        except (TypeError, ValueError):
-            sample_rate = 16000  # fallback to 16kHz if unable to query device
+            return int(
+                self.sd.query_devices(self.device_id, "input")["default_samplerate"]
+            )
+        except (TypeError, ValueError, AttributeError):
+            return 16000
         except self.sd.PortAudioError:
             raise SoundDeviceError(
                 "No audio input device detected. Please check your audio settings and try again."
             )
 
+    def _check_audio_device(self):
+        try:
+            self.sd.query_devices(self.device_id, "input")
+        except self.sd.PortAudioError as pa_err:
+            raise SoundDeviceError(
+                f"Audio input device issue: {pa_err}. Please check your audio settings."
+            )
+        except Exception as e:
+            raise SoundDeviceError(f"Unexpected error querying audio device: {e}")
+
+    def _record_and_transcribe(self, history, language):
+        self.q = queue.Queue()
+        temp_wav = tempfile.mktemp(suffix=".wav")
+        target_sample_rate = self._get_target_sample_rate()
+        self._check_audio_device()
         self.start_time = time.time()
 
         try:
             with self.sd.InputStream(
-                samplerate=sample_rate, channels=1, callback=self.callback, device=self.device_id
+                samplerate=target_sample_rate,
+                channels=1,
+                callback=self.callback,
+                device=self.device_id,
             ):
                 prompt(self.get_prompt, refresh_interval=0.1)
         except self.sd.PortAudioError as err:
-            raise SoundDeviceError(f"Error accessing audio input device: {err}")
+            device_name = self.device_id if self.device_id is not None else "default"
+            raise SoundDeviceError(
+                f"Error opening audio stream at {target_sample_rate} Hz on device"
+                f" '{device_name}': {err}. This might mean the sample rate is not supported"
+                " or the device is in use."
+            )
+        except Exception as e:
+            raise SoundDeviceError(f"Unexpected error opening audio stream: {e}")
 
-        with sf.SoundFile(temp_wav, mode="x", samplerate=sample_rate, channels=1) as file:
+        with sf.SoundFile(
+            temp_wav, mode="x", samplerate=target_sample_rate, channels=1
+        ) as file:
             while not self.q.empty():
                 file.write(self.q.get())
 
-        use_audio_format = self.audio_format
+        filename, use_audio_format = self._maybe_convert_audio(temp_wav)
+        try:
+            if self.use_local:
+                return self._transcribe_local(
+                    filename, use_audio_format, temp_wav, language
+                )
+            else:
+                return self._transcribe_api(
+                    filename, use_audio_format, temp_wav, history, language
+                )
+        finally:
+            self._cleanup_files(filename, temp_wav, use_audio_format)
 
-        # Check file size and offer to convert to mp3 if too large
+    def _maybe_convert_audio(self, temp_wav):
+        use_audio_format = self.audio_format
         file_size = os.path.getsize(temp_wav)
         if file_size > 24.9 * 1024 * 1024 and self.audio_format == "wav":
-            print("\nWarning: {temp_wav} is too large, switching to mp3 format.")
+            print(f"\nWarning: {temp_wav} is too large, switching to mp3 format.")
             use_audio_format = "mp3"
-
         filename = temp_wav
-        if use_audio_format != "wav":
+        if use_audio_format != "wav" and AudioSegment:
             try:
                 new_filename = tempfile.mktemp(suffix=f".{use_audio_format}")
                 audio = AudioSegment.from_wav(temp_wav)
@@ -163,25 +207,63 @@ class Voice:
                 print(f"File system error during conversion: {e}")
             except Exception as e:
                 print(f"Unexpected error during audio conversion: {e}")
+        return filename, use_audio_format
 
-        with open(filename, "rb") as fh:
-            try:
+    def _transcribe_local(self, filename, use_audio_format, temp_wav, language):
+        if not HAS_WHISPER_CPP:
+            print(
+                "pywhispercpp is not installed. Please install it to use local transcription."
+            )
+            return
+        try:
+            model = WhisperModel(
+                self.local_model,
+                language=language,
+                # print_realtime=True,
+                # print_progress=False,
+            )
+            segments = model.transcribe(filename)
+            return "".join(segment.text for segment in segments)
+        except Exception as err:
+            print(f"Unable to transcribe {filename} using pywhispercpp: {err}")
+            return
+
+    def _transcribe_api(self, filename, use_audio_format, temp_wav, history, language):
+        try:
+            with open(filename, "rb") as fh:
                 transcript = litellm.transcription(
-                    model="whisper-1", file=fh, prompt=history, language=language
+                    model="whisper-1",
+                    file=fh,
+                    prompt=history,
+                    language=language,
                 )
-            except Exception as err:
-                print(f"Unable to transcribe {filename}: {err}")
-                return
+            return transcript.text
+        except Exception as err:
+            print(f"Unable to transcribe {filename}: {err}")
+            return
 
-        if filename != temp_wav:
+    def _cleanup_files(self, filename, temp_wav, use_audio_format):
+        # Remove temp files
+        if filename != temp_wav and os.path.exists(filename):
             os.remove(filename)
-
-        text = transcript.text
-        return text
+        if os.path.exists(temp_wav):
+            os.remove(temp_wav)
 
 
 if __name__ == "__main__":
-    api_key = os.getenv("OPENAI_API_KEY")
-    if not api_key:
-        raise ValueError("Please set the OPENAI_API_KEY environment variable.")
-    print(Voice().record_and_transcribe())
+    use_local = HAS_WHISPER_CPP
+    try:
+        if use_local:
+            print("Using local transcription with pywhispercpp")
+            print(Voice(use_local=True).record_and_transcribe())
+        else:
+            api_key = os.getenv("OPENAI_API_KEY")
+            if not api_key:
+                raise ValueError(
+                    "Please set the OPENAI_API_KEY environment variable for API transcription."
+                )
+            print(Voice().record_and_transcribe())
+    except SoundDeviceError as e:
+        print(f"SoundDeviceError: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -219,8 +219,6 @@ class Voice:
             model = WhisperModel(
                 self.local_model,
                 language=language,
-                # print_realtime=True,
-                # print_progress=False,
             )
             segments = model.transcribe(filename)
             return "".join(segment.text for segment in segments)

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -17,6 +17,9 @@ try:
 except ImportError:
     HAS_WHISPER_CPP = False
 
+from pydub import AudioSegment
+from pydub.exceptions import CouldntDecodeError, CouldntEncodeError
+
 from .dump import dump  # noqa: F401
 
 warnings.filterwarnings(
@@ -24,13 +27,6 @@ warnings.filterwarnings(
     message="Couldn't find ffmpeg or avconv - defaulting to ffmpeg, but may not work",
 )
 warnings.filterwarnings("ignore", category=SyntaxWarning)
-
-try:
-    from pydub import AudioSegment
-    from pydub.exceptions import CouldntDecodeError, CouldntEncodeError
-except ImportError:
-    AudioSegment = None
-    CouldntDecodeError = CouldntEncodeError = Exception
 
 try:
     import soundfile as sf

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -198,6 +198,9 @@ class Voice:
             model = WhisperModel(
                 self.local_model,
                 language=language,
+                print_progress=False,
+                print_realtime=False,
+                redirect_whispercpp_logs_to=None,
             )
             segments = model.transcribe(filename)
             return "".join(segment.text for segment in segments)

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -358,6 +358,12 @@
 ## Specify the input device name for voice recording
 #voice-input-device: xxx
 
+## Use local voice transcription using whisper.cpp
+#voice-local: false
+
+## Set the whisper.cpp model
+#voice-local-model: tiny
+
 #################
 # Other settings:
 

--- a/aider/website/docs/usage/voice.md
+++ b/aider/website/docs/usage/voice.md
@@ -20,8 +20,8 @@ Your voice coding instructions will be transcribed,
 as if you had typed them into
 the aider chat session.
 
-By default, `aider` will try to use OpenAIs whisper model using the API. This requires an OpenAI API key to be set.
-Local voice transcription using `pywhisercpp` can be enabled by passing the `--voice-local` argument to `aider`.
+By default, aider will try to use OpenAIs whisper model using the API. This requires an OpenAI API key to be set.
+Local voice transcription using `pywhisercpp` can be enabled by passing the `--voice-local` argument to aider.
 This will download and use the `tiny` model. A different local model can be specified with the `--voice-local-model` argument.
 
 See the [installation instructions](https://aider.chat/docs/install/optional.html#enable-voice-coding) for

--- a/aider/website/docs/usage/voice.md
+++ b/aider/website/docs/usage/voice.md
@@ -21,6 +21,7 @@ as if you had typed them into
 the aider chat session.
 
 By default, aider will try to use OpenAIs whisper model using the API. This requires an OpenAI API key to be set.
+
 Local voice transcription using `pywhisercpp` can be enabled by passing the `--voice-local` argument to aider.
 This will download and use the `tiny` model. A different local model can be specified with the `--voice-local-model` argument.
 

--- a/aider/website/docs/usage/voice.md
+++ b/aider/website/docs/usage/voice.md
@@ -16,9 +16,13 @@ when you ask aider to edit your code.
 
 Use the in-chat `/voice` command to start recording,
 and press `ENTER` when you're done speaking.
-Your voice coding instructions will be transcribed, 
-as if you had  typed them into
+Your voice coding instructions will be transcribed,
+as if you had typed them into
 the aider chat session.
+
+By default, `aider` will try to use OpenAIs whisper model using the API. This requires an OpenAI API key to be set.
+Local voice transcription using `pywhisercpp` can be enabled by passing the `--voice-local` argument to `aider`.
+This will download and use the `tiny` model. A different local model can be specified with the `--voice-local-model` argument.
 
 See the [installation instructions](https://aider.chat/docs/install/optional.html#enable-voice-coding) for
 information on how to enable the `/voice` command.
@@ -27,7 +31,7 @@ information on how to enable the `/voice` command.
 <div class="chat-transcript" markdown="1">
 
 > Aider v0.11.2-dev  
-> Added app.py to the chat.  
+> Added app.py to the chat.
 
 #### /voice
 
@@ -83,7 +87,7 @@ window.onload = function() {
 “&nbsp;add a factorial endpoint that uses math factorial&nbsp;”
 </div>
 
-#### Add a factorial endpoint that uses math.factorial.
+#### Add a factorial endpoint that uses math.factorial
 
 To add a factorial endpoint to the Flask application, we need to modify the `app.py` file.
 
@@ -92,7 +96,7 @@ Here are the steps:
 1. Add a new route `/fact/<int:x>` to the Flask application.
 2. In the function for this route, call `math.factorial(x)` and return the result as a string.
 
-Here is the *edit block* for these changes:
+Here is the _edit block_ for these changes:
 
 ```python
 app.py
@@ -113,7 +117,7 @@ if __name__ == '__main__':
 ```
 
 > Applied edit to app.py  
-> Commit ef9e3e7 aider: Add a factorial endpoint that uses math.factorial.  
+> Commit ef9e3e7 aider: Add a factorial endpoint that uses math.factorial.
 
 </div>
 <br/>

--- a/requirements.txt
+++ b/requirements.txt
@@ -253,6 +253,7 @@ networkx==3.4.2
 numpy==1.26.4
     # via
     #   -c requirements/common-constraints.txt
+    #   pywhispercpp
     #   scipy
     #   soundfile
 openai==1.75.0
@@ -281,6 +282,10 @@ pillow==11.2.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
+platformdirs==4.3.8
+    # via
+    #   -c requirements/common-constraints.txt
+    #   pywhispercpp
 posthog==4.0.1
     # via
     #   -c requirements/common-constraints.txt
@@ -375,6 +380,10 @@ python-dotenv==1.1.0
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
+pywhispercpp==1.3.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   -r requirements/requirements.in
 pyyaml==6.0.2
     # via
     #   -c requirements/common-constraints.txt
@@ -396,6 +405,7 @@ requests==2.32.3
     #   huggingface-hub
     #   mixpanel
     #   posthog
+    #   pywhispercpp
     #   tiktoken
 rich==14.0.0
     # via
@@ -463,6 +473,7 @@ tqdm==4.67.1
     #   google-generativeai
     #   huggingface-hub
     #   openai
+    #   pywhispercpp
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -290,11 +290,43 @@ numpy==1.26.4
     #   matplotlib
     #   pandas
     #   pydeck
+    #   pywhispercpp
     #   scikit-learn
     #   scipy
     #   soundfile
     #   streamlit
     #   transformers
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.19.3
+    # via torch
+nvidia-nvjitlink-cu12==12.9.41
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
 openai==1.75.0
     # via litellm
 oslex==0.1.3
@@ -337,6 +369,7 @@ pip-tools==7.4.1
 platformdirs==4.3.8
     # via
     #   banks
+    #   pywhispercpp
     #   virtualenv
 playwright==1.52.0
     # via -r requirements/requirements-playwright.in
@@ -432,6 +465,8 @@ python-dotenv==1.1.0
     # via litellm
 pytz==2025.2
     # via pandas
+pywhispercpp==1.3.1
+    # via -r requirements/requirements.in
 pyyaml==6.0.2
     # via
     #   -r requirements/requirements.in
@@ -456,6 +491,7 @@ requests==2.32.3
     #   llama-index-core
     #   mixpanel
     #   posthog
+    #   pywhispercpp
     #   streamlit
     #   tiktoken
     #   transformers
@@ -542,6 +578,7 @@ tqdm==4.67.1
     #   llama-index-core
     #   nltk
     #   openai
+    #   pywhispercpp
     #   sentence-transformers
     #   transformers
 transformers==4.51.3
@@ -596,6 +633,8 @@ uv==0.7.3
     # via -r requirements/requirements-dev.in
 virtualenv==20.31.2
     # via pre-commit
+watchdog==6.0.0
+    # via streamlit
 watchfiles==1.0.5
     # via -r requirements/requirements.in
 wcwidth==0.2.13

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -153,3 +153,7 @@ urllib3==2.4.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests
+watchdog==6.0.0
+    # via
+    #   -c requirements/common-constraints.txt
+    #   streamlit

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -180,6 +180,58 @@ numpy==1.26.4
     #   scikit-learn
     #   scipy
     #   transformers
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cufft-cu12==11.0.2.54
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-curand-cu12==10.3.2.106
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.19.3
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-nvjitlink-cu12==12.9.41
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
 packaging==24.2
     # via
     #   -c requirements/common-constraints.txt

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -16,6 +16,7 @@ PyYAML
 diff-match-patch
 pypandoc
 litellm
+pywhispercpp
 flake8
 importlib_resources
 pyperclip

--- a/tests/basic/test_voice.py
+++ b/tests/basic/test_voice.py
@@ -47,18 +47,14 @@ def test_voice_init_invalid_device(mock_sounddevice):
 
 
 def test_voice_init_invalid_format():
-    with patch(
-        "aider.voice.sf", MagicMock()
-    ):  # Need to mock sf to avoid SoundDeviceError
+    with patch("aider.voice.sf", MagicMock()):  # Need to mock sf to avoid SoundDeviceError
         with pytest.raises(ValueError) as exc:
             Voice(audio_format="invalid")
         assert "Unsupported audio format" in str(exc.value)
 
 
 def test_callback_processing():
-    with patch(
-        "aider.voice.sf", MagicMock()
-    ):  # Need to mock sf to avoid SoundDeviceError
+    with patch("aider.voice.sf", MagicMock()):  # Need to mock sf to avoid SoundDeviceError
         voice = Voice()
         voice.q = queue.Queue()
 
@@ -77,9 +73,7 @@ def test_callback_processing():
 
 
 def test_get_prompt():
-    with patch(
-        "aider.voice.sf", MagicMock()
-    ):  # Need to mock sf to avoid SoundDeviceError
+    with patch("aider.voice.sf", MagicMock()):  # Need to mock sf to avoid SoundDeviceError
         voice = Voice()
         voice.start_time = os.times().elapsed
         voice.pct = 0.5  # 50% volume level
@@ -94,9 +88,7 @@ def test_get_prompt():
 def test_record_and_transcribe_keyboard_interrupt():
     with patch("aider.voice.sf", MagicMock()):
         voice = Voice()
-        with patch.object(
-            voice, "_record_and_transcribe", side_effect=KeyboardInterrupt()
-        ):
+        with patch.object(voice, "_record_and_transcribe", side_effect=KeyboardInterrupt()):
             result = voice.record_and_transcribe()
             assert result is None
 

--- a/tests/basic/test_voice.py
+++ b/tests/basic/test_voice.py
@@ -47,14 +47,18 @@ def test_voice_init_invalid_device(mock_sounddevice):
 
 
 def test_voice_init_invalid_format():
-    with patch("aider.voice.sf", MagicMock()):  # Need to mock sf to avoid SoundDeviceError
+    with patch(
+        "aider.voice.sf", MagicMock()
+    ):  # Need to mock sf to avoid SoundDeviceError
         with pytest.raises(ValueError) as exc:
             Voice(audio_format="invalid")
         assert "Unsupported audio format" in str(exc.value)
 
 
 def test_callback_processing():
-    with patch("aider.voice.sf", MagicMock()):  # Need to mock sf to avoid SoundDeviceError
+    with patch(
+        "aider.voice.sf", MagicMock()
+    ):  # Need to mock sf to avoid SoundDeviceError
         voice = Voice()
         voice.q = queue.Queue()
 
@@ -73,7 +77,9 @@ def test_callback_processing():
 
 
 def test_get_prompt():
-    with patch("aider.voice.sf", MagicMock()):  # Need to mock sf to avoid SoundDeviceError
+    with patch(
+        "aider.voice.sf", MagicMock()
+    ):  # Need to mock sf to avoid SoundDeviceError
         voice = Voice()
         voice.start_time = os.times().elapsed
         voice.pct = 0.5  # 50% volume level
@@ -88,7 +94,9 @@ def test_get_prompt():
 def test_record_and_transcribe_keyboard_interrupt():
     with patch("aider.voice.sf", MagicMock()):
         voice = Voice()
-        with patch.object(voice, "raw_record_and_transcribe", side_effect=KeyboardInterrupt()):
+        with patch.object(
+            voice, "_record_and_transcribe", side_effect=KeyboardInterrupt()
+        ):
             result = voice.record_and_transcribe()
             assert result is None
 
@@ -97,7 +105,9 @@ def test_record_and_transcribe_device_error():
     with patch("aider.voice.sf", MagicMock()):
         voice = Voice()
         with patch.object(
-            voice, "raw_record_and_transcribe", side_effect=SoundDeviceError("Test error")
+            voice,
+            "_record_and_transcribe",
+            side_effect=SoundDeviceError("Test error"),
         ):
             result = voice.record_and_transcribe()
             assert result is None


### PR DESCRIPTION
Hey,

this PR adds optional support for local CPU voice transcriptions using `pywhispercpp`. 

It can be enabled using  `--voice-local`. The model can be specified using `--voice-local-model` and  will be downloaded on the first `/voice` run for the specified model.

Due to the OpenAI whisper call still being the default method, this should be a non-breaking change for existing voice users.

---
The `pip compile` output is a bit strange. It seems to add a handful of `nvidia-cuda-*` constraints to `common-constraints.txt`.
I think this is due to `requirements-in.help` and the `torch` dep that is specified there? Is torch really needed as a help dependency?
No `torch` dependencies are being installed,,  however constraints are set.... 


