### PR TITLE
Change `max_tokens` to 32000 for `claude-opus-4-20250514` family model

### DIFF
--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -1621,7 +1621,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: claude-sonnet-4-20250514
   editor_edit_format: editor-diff
@@ -1635,7 +1635,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: anthropic/claude-sonnet-4-20250514
   editor_edit_format: editor-diff
@@ -1649,7 +1649,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: anthropic.claude-sonnet-4-20250514-v1:0
   editor_edit_format: editor-diff
@@ -1663,7 +1663,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: bedrock_converse/anthropic.claude-sonnet-4-20250514-v1:0
   editor_edit_format: editor-diff
@@ -1677,7 +1677,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: bedrock_converse/us.anthropic.claude-sonnet-4-20250514-v1:0
   editor_edit_format: editor-diff
@@ -1691,7 +1691,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: bedrock_converse/eu.anthropic.claude-sonnet-4-20250514-v1:0
   editor_edit_format: editor-diff
@@ -1705,7 +1705,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: eu.anthropic.claude-sonnet-4-20250514-v1:0
   editor_edit_format: editor-diff
@@ -1719,7 +1719,7 @@
   extra_params:
     extra_headers:
       anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
-    max_tokens: 64000
+    max_tokens: 32000
   cache_control: true
   editor_model_name: us.anthropic.claude-sonnet-4-20250514-v1:0
   editor_edit_format: editor-diff
@@ -1731,7 +1731,7 @@
   use_repo_map: true
   examples_as_sys_msg: false
   extra_params:
-    max_tokens: 64000
+    max_tokens: 32000
   editor_model_name: vertex_ai/claude-sonnet-4@20250514
   editor_edit_format: editor-diff
   accepts_settings: ["thinking_tokens"]
@@ -1742,7 +1742,7 @@
   use_repo_map: true
   examples_as_sys_msg: false
   extra_params:
-    max_tokens: 64000
+    max_tokens: 32000
   editor_model_name: vertex_ai-anthropic_models/vertex_ai/claude-sonnet-4@20250514
   editor_edit_format: editor-diff
   accepts_settings: ["thinking_tokens"]


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration

___

### **PR Description**
- Reduced `max_tokens` for all `claude-opus-4-20250514` model variants to `32000`.

- Updated settings in `aider/resources/model-settings.yml` for consistency.

- Ensured all aliases and regional variants reflect the new token limit.

- No changes to other model configurations or parameters.
