### PR TITLE
fix: Restore full base path at api endpoint for litellm >= 1.68.0

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -619,6 +619,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     handle_deprecated_model_args(args, io)
     if args.openai_api_base:
         os.environ["OPENAI_API_BASE"] = args.openai_api_base
+        # Add the new canonical ENV variable for litellm
+        # (see: https://github.com/BerriAI/litellm/pull/10423)
+        os.environ["OPENAI_BASE_URL"] = args.openai_api_base
     if args.openai_api_version:
         io.tool_warning(
             "--openai-api-version is deprecated, use --set-env OPENAI_API_VERSION=<value>"


### PR DESCRIPTION
aider-chat > 0.82.2 sends incorrect base path to openai compatible endpoints due to requirement bump to litellm >= 1.68.0

For example, the /v1 route is missing when sent via litellm to llama-swap for use with local models.

This PR adds one line of change to update the environment to include the (now canonical) [environment variable expected by litellm](https://github.com/BerriAI/litellm/pull/10423): "OPENAI_BASE_URL"

This PR resolves: #4027 