### PR TITLE
Add --commit-language option to configure commit message language

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -732,6 +732,12 @@ def get_parser(default_config_files, git_root):
         help="Specify the language to use in the chat (default: None, uses system settings)",
     )
     group.add_argument(
+        "--commit-language",
+        metavar="COMMIT_LANGUAGE",
+        default=None,
+        help="Specify the language to use in the commit message (default: None, user language)",
+    )
+    group.add_argument(
         "--yes-always",
         action="store_true",
         help="Always say yes to every confirmation",

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -118,6 +118,7 @@ class Coder:
     detect_urls = True
     ignore_mentions = None
     chat_language = None
+    commit_language = None
     file_watcher = None
 
     @classmethod
@@ -328,6 +329,7 @@ class Coder:
         num_cache_warming_pings=0,
         suggest_shell_commands=True,
         chat_language=None,
+        commit_language=None,
         detect_urls=True,
         ignore_mentions=None,
         total_tokens_sent=0,
@@ -341,6 +343,7 @@ class Coder:
 
         self.event = self.analytics.event
         self.chat_language = chat_language
+        self.commit_language = commit_language
         self.commit_before_message = []
         self.aider_commit_hashes = set()
         self.rejected_urls = set()

--- a/aider/main.py
+++ b/aider/main.py
@@ -993,6 +993,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             num_cache_warming_pings=args.cache_keepalive_pings,
             suggest_shell_commands=args.suggest_shell_commands,
             chat_language=args.chat_language,
+            commit_language=args.commit_language,
             detect_urls=args.detect_urls,
             auto_copy_context=args.copy_paste,
             auto_accept_architect=args.auto_accept_architect,

--- a/aider/repo.py
+++ b/aider/repo.py
@@ -210,7 +210,9 @@ class GitRepo:
         else:
             user_language = None
             if coder:
-                user_language = coder.get_user_language()
+                user_language = coder.commit_language
+                if not user_language:
+                    user_language = coder.get_user_language()
             commit_message = self.get_commit_message(diffs, context, user_language)
 
         # Retrieve attribute settings, prioritizing coder.args if available

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -386,6 +386,9 @@
 ## Specify the language to use in the chat (default: None, uses system settings)
 #chat-language: xxx
 
+## Specify the language to use in the commit message (default: None, user language)
+#commit-language: xxx
+
 ## Always say yes to every confirmation
 #yes-always: false
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -440,6 +440,9 @@ cog.outl("```")
 ## Specify the language to use in the chat (default: None, uses system settings)
 #chat-language: xxx
 
+## Specify the language to use in the commit message (default: None, user language)
+#commit-language: xxx
+
 ## Always say yes to every confirmation
 #yes-always: false
 

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -74,7 +74,7 @@ usage: aider [-h] [--model] [--openai-api-key] [--anthropic-api-key]
              [--apply-clipboard-edits] [--exit] [--show-repo-map]
              [--show-prompts] [--voice-format] [--voice-language]
              [--voice-input-device] [--disable-playwright] [--file]
-             [--read] [--vim] [--chat-language] [--yes-always] [-v]
+             [--read] [--vim] [--chat-language] [--commit-language] [--yes-always] [-v]
              [--load] [--encoding] [--line-endings] [-c]
              [--env-file]
              [--suggest-shell-commands | --no-suggest-shell-commands]
@@ -682,6 +682,10 @@ Environment variable: `AIDER_VIM`
 ### `--chat-language CHAT_LANGUAGE`
 Specify the language to use in the chat (default: None, uses system settings)  
 Environment variable: `AIDER_CHAT_LANGUAGE`  
+
+### `--commit-language COMMIT_LANGUAGE`
+Specify the language to use in the commit message (default: None, user language)  
+Environment variable: `AIDER_COMMIT_LANGUAGE`  
 
 ### `--yes-always`
 Always say yes to every confirmation  

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -1035,6 +1035,16 @@ class TestMain(TestCase):
             system_info = coder.get_platform_info()
             self.assertIn("Spanish", system_info)
 
+    def test_commit_language_japanese(self):
+        with GitTemporaryDirectory():
+            coder = main(
+                ["--commit-language", "japanese", "--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+                return_coder=True,
+            )
+            self.assertIn("japanese", coder.commit_language)
+
     @patch("git.Repo.init")
     def test_main_exit_with_git_command_not_found(self, mock_git_init):
         mock_git_init.side_effect = git.exc.GitCommandNotFound("git", "Command 'git' not found")


### PR DESCRIPTION
This PR adds a new `--commit-language` option that allows users to specify a different language for commit messages, separate from the chat language. This addresses issue #4049 where users wanted the ability to configure commit message language independently.