### PR TITLE
fix: Always pass `extra_headers` to Copilot models

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -16,6 +16,7 @@ import json5
 import yaml
 from PIL import Image
 
+from aider import __version__
 from aider.dump import dump  # noqa: F401
 from aider.llm import litellm
 from aider.openrouter import OpenRouterModelManager
@@ -876,7 +877,7 @@ class Model(ModelSettings):
     def is_ollama(self):
         return self.name.startswith("ollama/") or self.name.startswith("ollama_chat/")
 
-    def github_copilot_token_to_open_ai_key(self):
+    def github_copilot_token_to_open_ai_key(self, extra_headers):
         # check to see if there's an openai api key
         # If so, check to see if it's expire
         openai_api_key = "OPENAI_API_KEY"
@@ -889,10 +890,8 @@ class Model(ModelSettings):
 
             headers = {
                 "Authorization": f"Bearer {os.environ['GITHUB_COPILOT_TOKEN']}",
-                "Editor-Version": self.extra_params["extra_headers"]["Editor-Version"],
-                "Copilot-Integration-Id": self.extra_params["extra_headers"][
-                    "Copilot-Integration-Id"
-                ],
+                "Editor-Version": extra_headers["Editor-Version"],
+                "Copilot-Integration-Id": extra_headers["Copilot-Integration-Id"],
                 "Content-Type": "application/json",
             }
             res = requests.get("https://api.github.com/copilot_internal/v2/token", headers=headers)
@@ -941,7 +940,13 @@ class Model(ModelSettings):
 
         # Are we using github copilot?
         if "GITHUB_COPILOT_TOKEN" in os.environ:
-            self.github_copilot_token_to_open_ai_key()
+            if "extra_headers" not in kwargs:
+                kwargs["extra_headers"] = {
+                    "Editor-Version": f"aider/{__version__}",
+                    "Copilot-Integration-Id": "vscode-chat",
+                }
+
+            self.github_copilot_token_to_open_ai_key(kwargs["extra_headers"])
 
         res = litellm.completion(**kwargs)
         return hash_object, res


### PR DESCRIPTION
As a few people mentioned in the #2227 issue, it is necessary to pass some `extra_headers` to Copilot with each request in order for it to work properly. Furthermore, without a specific `.aider.model.settings.yml`, the most recent patch #4092 that automatically refreshes the GH Copilot API Key does not work because it requires `extra_params` to be explicitly provided for a model; otherwise, the following error occurs:

```
  File "~/code/stackbuilders/aider/aider/models.py", line 892, in github_copilot_token_to_open_ai_key
    "Editor-Version": self.extra_params["extra_headers"]["Editor-Version"],
                      ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

This PR defines some default `extra_headers` for each model request, as well as the call to the Copilot API to refresh the token if no headers are explicitly defined in a configuration file.