### PR TITLE
[Docs] VSCode Copilot no longer writes out tokens

### DIFF
--- a/aider/website/docs/llms/github.md
+++ b/aider/website/docs/llms/github.md
@@ -45,7 +45,7 @@ Copy the `oauth_token` value – that string is your `OPENAI_API_KEY`.
 
 *Note:* tokens created by the Neovim **copilot.lua** plugin (old `hosts.json`) sometimes lack the
 needed scopes. If you see “access to this endpoint is forbidden”, regenerate the token with a
-JetBrains IDE or the VS Code Copilot extension.
+JetBrains IDE.
 
 ---
 


### PR DESCRIPTION
When I login with the VSCode Copilot extension, I can't find the `.json` files containing GitHub/Copilot oauth tokens anymore, so I've removed that suggestion from the docs.