### PR TITLE
fix: Correct Vertex AI model name prefixes in settings

### DIFF
--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -978,16 +978,16 @@
 - name: vertex_ai/gemini-2.5-pro-exp-03-25
   edit_format: diff-fenced
   use_repo_map: true
-  weak_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  weak_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
   overeager: true
-  editor_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  editor_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
 
 - name: vertex_ai/gemini-2.5-pro-preview-03-25
   edit_format: diff-fenced
   use_repo_map: true
-  weak_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  weak_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
   overeager: true
-  editor_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  editor_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
 
 - name: openrouter/openrouter/quasar-alpha
   use_repo_map: true
@@ -1382,7 +1382,7 @@
   use_repo_map: true
   accepts_settings: ["reasoning_effort", "thinking_tokens"]
 
-- name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+- name: vertex_ai/gemini-2.5-flash-preview-04-17
   edit_format: diff
   use_repo_map: true
   accepts_settings: ["reasoning_effort", "thinking_tokens"]
@@ -1409,16 +1409,16 @@
 - name: vertex_ai/gemini-2.5-pro-preview-05-06
   edit_format: diff-fenced
   use_repo_map: true
-  weak_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  weak_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
   overeager: true
-  editor_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  editor_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
 
 - name: vertex_ai/gemini-2.5-pro-preview-06-05
   edit_format: diff-fenced
   use_repo_map: true
-  weak_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  weak_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
   overeager: true
-  editor_model_name: vertex_ai-language-models/gemini-2.5-flash-preview-04-17
+  editor_model_name: vertex_ai/gemini-2.5-flash-preview-04-17
   accepts_settings: ["thinking_tokens"]
 
 - name: openrouter/google/gemini-2.5-pro-preview-05-06


### PR DESCRIPTION
If I call `aider --model vertex_ai/gemini-2.5-pro-preview-05-06`, the default for the weak model is incorrect. It'll say print this error when making a commit message:

```
litellm.BadRequestError: LLM Provider NOT provided. 
Pass in the LLM provider you are trying to call. 
You passed model=vertex_ai-language-models/gemini-2.5-flash-preview-04-17

Pass model as E.g. For 'Huggingface' inference endpoints pass in 
`completion(model='huggingface/starcoder',..)`

Learn more: https://docs.litellm.ai/docs/providers
 ```

I think this is the fix - it replaces `vertexai-language-models/` with `vertexai/` 

