### PR TITLE
Add --playwright-proxy option for `/web` using playwright with chromium

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -738,6 +738,12 @@ def get_parser(default_config_files, git_root):
         help="Specify the language to use in the chat (default: None, uses system settings)",
     )
     group.add_argument(
+        "--playwright-proxy",
+        metavar="PROXY_URL",
+        default=None,
+        help="Specify a proxy URL for Playwright web scraping (default: None)",
+    )
+    group.add_argument(
         "--commit-language",
         metavar="COMMIT_LANGUAGE",
         default=None,

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -233,6 +233,7 @@ class Commands:
                 print_error=self.io.tool_error,
                 playwright_available=res,
                 verify_ssl=self.verify_ssl,
+                playwright_proxy=getattr(self.args, "playwright_proxy", None),
             )
 
         content = self.scraper.scrape(url) or ""


### PR DESCRIPTION
Hi Team,

Thanks a lot for the great work.


It seems that playwright with chromium does not use proxy be default. So this pull request introduces support for specifying a proxy server when using Playwright for web scraping. It adds a new --playwright-proxy command-line argument, allowing users to route Playwright browser traffic through a proxy. This is useful for users who need to access web content behind a firewall or want to anonymize their scraping activities (I guess this feature could be particularly useful for users in China).

Changes

 • New Argument: Added --playwright-proxy to the CLI (in aider/args.py and aider/scrape.py) to allow users to specify a proxy URL for Playwright.
 • Scraper Update: Updated the Scraper class (aider/scrape.py) to accept and use the proxy setting when launching Playwright browsers. If the argument is not provided, it falls back to the HTTP_PROXY/http_proxy environment variables.


The code changes are done by aider
 