### PR TITLE
Let 'rich' use code_theme as inline_code_theme

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -1001,7 +1001,11 @@ class InputOutput:
         self.console.print(*messages, style=style)
 
     def get_assistant_mdstream(self):
-        mdargs = dict(style=self.assistant_output_color, code_theme=self.code_theme)
+        mdargs = dict(
+            style=self.assistant_output_color,
+            code_theme=self.code_theme,
+            inline_code_lexer="text",
+        )
         mdStream = MarkdownStream(mdargs=mdargs)
         return mdStream
 


### PR DESCRIPTION
# Problem
The inline code snippets in the reply from AI models are formatted using some default theme. They are somewhat harder to read and are just ugly.
<img width="262" alt="image" src="https://github.com/user-attachments/assets/d5d625f2-22c7-4727-a590-f32fa98b47ae" />


# Solution
> Let the `inline_code_theme` as used in the `rich.markdown.Markdown`'s `__init__` have effect.

But if a `inline_code_lexer` is **not** passed to `rich.markdown.Markdown`, `inline_code_theme` is not being used to style inline code, as evident in the `__init__` of `rich.markdown.MarkdownContext`. But there's no reasonably easy way to determine the programming language of inline code snippets to be able to identify the lexer. This PR's solution is to utilize the lexer `text` as the value of the `inline_code_lexer` passed to `Markdown`. In this scenario "rich" uses `code_theme` as the fallback value for `inline_code_theme`