### PR TITLE
Allow to create multiple model configurations for the same model

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -129,6 +129,7 @@ class ModelSettings:
     remove_reasoning: Optional[str] = None  # Deprecated alias for reasoning_tag
     system_prompt_prefix: Optional[str] = None
     accepts_settings: Optional[list] = None
+    name_override: Optional[str] = None
 
 
 # Load model settings from package resource
@@ -326,6 +327,10 @@ class Model(ModelSettings):
             (ms for ms in MODEL_SETTINGS if ms.name == "aider/extra_params"), None
         )
 
+        self.configure_model_settings(model)
+        if self.name_override:
+            self.configure_model_settings(self.name_override)
+            model = self.name
         self.info = self.get_model_info(model)
 
         # Are all needed keys/params available?
@@ -338,7 +343,6 @@ class Model(ModelSettings):
         # with minimum 1k and maximum 8k
         self.max_chat_history_tokens = min(max(max_input_tokens / 16, 1024), 8192)
 
-        self.configure_model_settings(model)
         if weak_model is False:
             self.weak_model_name = None
         else:

--- a/aider/models.py
+++ b/aider/models.py
@@ -329,7 +329,22 @@ class Model(ModelSettings):
 
         self.configure_model_settings(model)
         if self.name_override:
+            # Store settings that differ from defaults
+            non_defaults = {}
+            defaults = {field.name: field.default for field in fields(ModelSettings)}
+            for field in fields(ModelSettings):
+                value = getattr(self, field.name)
+                if value != defaults[field.name]:
+                    non_defaults[field.name] = value
+            
+            # Apply override model settings
             self.configure_model_settings(self.name_override)
+            
+            # Restore non-default settings
+            for field_name, value in non_defaults.items():
+                if field_name != 'name':
+                    setattr(self, field_name, value)
+            
             model = self.name
         self.info = self.get_model_info(model)
 


### PR DESCRIPTION
Closes #3365
# Why
I'd really love to see this functionality in Aider, as sometimes I want to use X just for a current file, without additional system prompts or repo map that consume tons of tokens. Re-starting Aider is not an exciting option, neither is creating LiteLLM proxy
# How
Adds `model_override` setting (maybe not the best name) that is used as a template (`name` is the most important field there). All the additional settings are applied on top of it. So it would allow this
```
- name: sonnet_think
  edit_format: diff
  weak_model_name: anthropic/claude-3-5-haiku-20241022
  use_repo_map: true
  examples_as_sys_msg: true
  use_temperature: false
  extra_params:
    extra_headers:
      anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
    max_tokens: 64000
    thinking:
      type: enabled
      budget_tokens: 32000 # Adjust this number
  cache_control: true
  editor_model_name: anthropic/claude-3-7-sonnet-20250219
  editor_edit_format: editor-diff
  model_override: anthropic/claude-3-7-sonnet-20250219
```
In this case the main model would this it is `anthropic/claude-3-7-sonnet-20250219`, yet `/model sonnet_think` would still be possible
 