### PR TITLE
Skip expensive `get_tracked_files` call if `skip_sanity_check_repo` is true

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -922,7 +922,8 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             return 1
 
     if repo:
-        analytics.event("repo", num_files=len(repo.get_tracked_files()))
+        num_files = 0 if args.skip_sanity_check_repo else len(repo.get_tracked_files())
+        analytics.event("repo", num_files=num_files)
     else:
         analytics.event("no-repo")
 


### PR DESCRIPTION
On a very large repo aider spends 8 seconds for each launch to just get the number of files ( `aider/main.py:925` on flamegraph). Put this check behind the existing flag `skip_sanity_check_repo`. One-liner change


Flamegraph for reference:


![aider_profile](https://github.com/user-attachments/assets/ba9e7113-4838-40cb-94ad-a8d068f27404)

