### PR TITLE
Assistant's and User's input style tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -153,7 +153,7 @@ The built documentation will be available in the `aider/website/_site` directory
 
 ## Suggesting UI/UX Style Changes
 
-We welcome suggestions for improving the default look and feel of the user input and other terminal interface elements. Aider utilizes `prompt_toolkit` which in turn often uses `Pygments` tokens for styling various text components.
+Aider utilizes `prompt_toolkit` which in turn often uses `Pygments` tokens for styling various text components.
 
 If you have ideas for different colors, text styles (like bold, underline, italics), or other visual enhancements, you can help by:
 
@@ -191,7 +191,9 @@ def main():
     from pygments.lexers.markup import MarkdownLexer
     tokens = list(pygments.lex("""# some title
 * something
-* else""", lexer=MarkdownLexer()))
+* else
+
+some `code`""", lexer=MarkdownLexer()))
     print("Tokens found:")
     print(tokens)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,7 +151,7 @@ The project's documentation is built using Jekyll and hosted on GitHub Pages. To
 
 The built documentation will be available in the `aider/website/_site` directory.
 
-### Suggesting UI/UX Style Changes
+## Suggesting UI/UX Style Changes
 
 We welcome suggestions for improving the default look and feel of the user input and other terminal interface elements. Aider utilizes `prompt_toolkit` which in turn often uses `Pygments` tokens for styling various text components.
 
@@ -163,7 +163,7 @@ If you have ideas for different colors, text styles (like bold, underline, itali
 
 You can submit these suggestions as GitHub issues or, if you're comfortable, as part of a Pull Request modifying the relevant style definitions in the Aider codebase.
 
-#### Example: Identifying Pygments Tokens
+### Example: Identifying Pygments Tokens
 
 The following Python script can help you identify the Pygments tokens used for different text elements. You can adapt it to explore Aider's UI components.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,6 +151,74 @@ The project's documentation is built using Jekyll and hosted on GitHub Pages. To
 
 The built documentation will be available in the `aider/website/_site` directory.
 
+### Suggesting UI/UX Style Changes
+
+We welcome suggestions for improving the default look and feel of the user input and other terminal interface elements. Aider utilizes `prompt_toolkit` which in turn often uses `Pygments` tokens for styling various text components.
+
+If you have ideas for different colors, text styles (like bold, underline, italics), or other visual enhancements, you can help by:
+
+1.  Identifying the specific UI element you'd like to change (e.g., user input prompt, code blocks, AI responses).
+2.  Using a script to determine the `Pygments` token associated with that element.
+3.  Suggesting the new style (e.g., color, attributes) for that token.
+
+You can submit these suggestions as GitHub issues or, if you're comfortable, as part of a Pull Request modifying the relevant style definitions in the Aider codebase.
+
+#### Example: Identifying Pygments Tokens
+
+The following Python script can help you identify the Pygments tokens used for different text elements. You can adapt it to explore Aider's UI components.
+
+```python
+#!/usr/bin/env python
+"""
+Printing a list of Pygments (Token, text) tuples,
+or an output of a Pygments lexer.
+"""
+
+import pygments
+from pygments.lexers.python import PythonLexer
+from pygments.token import Token
+
+from prompt_toolkit import print_formatted_text
+from prompt_toolkit.formatted_text import PygmentsTokens
+from prompt_toolkit.styles import Style
+
+
+def main():
+    # Printing the output of a pygments lexer.
+    # This example uses MarkdownLexer. You may need to install it
+    # (e.g., it's part of Pygments' standard lexers) or ensure Pygments is installed.
+    # You can import it with: from pygments.lexers.markup import MarkdownLexer
+    from pygments.lexers.markup import MarkdownLexer
+    tokens = list(pygments.lex("""# some title
+* something
+* else""", lexer=MarkdownLexer()))
+    print("Tokens found:")
+    print(tokens)
+
+    # With a custom style.
+    style = Style.from_dict(
+        {
+            "pygments.generic.heading": "underline",
+            "pygments.keyword": "underline", # Example style for keywords
+        }
+    )
+    print("\nFormatted text with custom style:")
+    print_formatted_text(PygmentsTokens(tokens), style=style)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+To use this script:
+
+1.  **Input Text**: Change the string in `pygments.lex()` to match the UI element you're inspecting.
+2.  **Lexer**: Select an appropriate lexer. For general input, `TextLexer` (from `pygments.lexers.special`) is a good start. For code, use the relevant language lexer (e.g., `PythonLexer`). Ensure `Pygments` is installed.
+3.  **Output**: Run the script. It will print `(Token, text)` tuples. The `Token` (e.g., `Token.Generic.Heading`) is what you need.
+4.  **Styles**: Experiment by modifying the `style` dictionary with token names and `prompt_toolkit` style strings (e.g., `"underline"`, `"#ff0000"`).
+
+This process will help you pinpoint tokens and test styles, providing valuable information for suggesting UI improvements.
+
 ## Coding Standards
 
 ### Python Compatibility

--- a/aider/io.py
+++ b/aider/io.py
@@ -403,6 +403,8 @@ class InputOutput:
             style_dict.update(
                 {
                     "pygments.literal.string": f"bold italic {self.user_input_color}",
+                    "pygments.generic.heading": f"bold {self.user_input_color}",
+                    "pygments.keyword": f"{self.user_input_color}",
                 }
             )
 

--- a/aider/io.py
+++ b/aider/io.py
@@ -31,8 +31,8 @@ from rich.columns import Columns
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.style import Style as RichStyle
-from rich.theme import Theme
 from rich.text import Text
+from rich.theme import Theme
 
 from aider.mdstream import MarkdownStream
 
@@ -351,7 +351,7 @@ class InputOutput:
                 session_kwargs["history"] = FileHistory(self.input_history_file)
             try:
                 self.prompt_session = PromptSession(**session_kwargs)
-                theme = Theme({'markdown.code': f'bold {self.assistant_output_color}'})
+                theme = Theme({"markdown.code": f"bold {self.assistant_output_color}"})
                 self.console = Console(theme=theme)  # pretty console
             except Exception as err:
                 self.console = Console(force_terminal=False, no_color=True)
@@ -1003,12 +1003,9 @@ class InputOutput:
         self.console.print(*messages, style=style)
 
     def get_assistant_mdstream(self):
-        mdargs = dict(
-            style=self.assistant_output_color,
-            code_theme=self.code_theme,
-            inline_code_lexer="text",
-        )
-        mdStream = MarkdownStream(mdargs=mdargs)
+        mdargs = dict(style=self.assistant_output_color, code_theme=self.code_theme)
+        console_theme = Theme({"markdown.code": f"bold {self.assistant_output_color}"})
+        mdStream = MarkdownStream(mdargs=mdargs, console_theme=console_theme)
         return mdStream
 
     def assistant_output(self, message, pretty=None):

--- a/aider/io.py
+++ b/aider/io.py
@@ -31,6 +31,7 @@ from rich.columns import Columns
 from rich.console import Console
 from rich.markdown import Markdown
 from rich.style import Style as RichStyle
+from rich.theme import Theme
 from rich.text import Text
 
 from aider.mdstream import MarkdownStream
@@ -350,7 +351,8 @@ class InputOutput:
                 session_kwargs["history"] = FileHistory(self.input_history_file)
             try:
                 self.prompt_session = PromptSession(**session_kwargs)
-                self.console = Console()  # pretty console
+                theme = Theme({'markdown.code': f'bold {self.assistant_output_color}'})
+                self.console = Console(theme=theme)  # pretty console
             except Exception as err:
                 self.console = Console(force_terminal=False, no_color=True)
                 self.tool_error(f"Can't initialize prompt toolkit: {err}")  # non-pretty

--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -102,7 +102,7 @@ class MarkdownStream:
     min_delay = 1.0 / 20  # Minimum time between updates (20fps)
     live_window = 6  # Number of lines to keep visible at bottom during streaming
 
-    def __init__(self, mdargs=None):
+    def __init__(self, mdargs=None, console_theme=None):
         """Initialize the markdown stream.
 
         Args:
@@ -114,6 +114,7 @@ class MarkdownStream:
             self.mdargs = mdargs
         else:
             self.mdargs = dict()
+        self.console_theme = console_theme
 
         # Defer Live creation until the first update.
         self.live = None
@@ -130,7 +131,7 @@ class MarkdownStream:
         """
         # Render the markdown to a string buffer
         string_io = io.StringIO()
-        console = Console(file=string_io, force_terminal=True)
+        console = Console(file=string_io, force_terminal=True, theme=self.console_theme)
         markdown = NoInsetMarkdown(text, **self.mdargs)
         console.print(markdown)
         output = string_io.getvalue()


### PR DESCRIPTION
Two main style-related changes are included into this PR.

1. Coloring markdown code blocks in the assistant's output as per `assistant_output_color`
2. Styling user input, specifically for headings and keywords, as per `user_input_color`

Note: it took me a little bit of time to figure out which pygments tokens to use for which markdown section, so I went on and added some notes to CONTRIBUTING.md hoping it would make things easier for others.