### PR TITLE
doc: Add links to translated README versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@
 AI Pair Programming in Your Terminal
 </h1>
 
+<p align="center">
+    <!-- Keep these links. Translations will automatically update with the README. -->
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=de">Deutsch</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=es">Español</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=fr">français</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=ja">日本語</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=ko">한국어</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=pt">Português</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=ru">Русский</a> | 
+    <a href="https://www.readme-i18n.com/Aider-AI/aider?lang=zh">中文</a>
+</p>
 
 <p align="center">
 Aider lets you pair program with LLMs to start a new project or build on your existing codebase. 


### PR DESCRIPTION
Allowing users around the world to read the documentation in their native languages — including German, Spanish, French, Japanese, Korean, Portuguese, Russian, and Chinese. 

This update improves accessibility and project understanding for non-English speakers around the world.

The updated links can be previewed in my forked repository: https://github.com/dowithless/aider/tree/patch-1