### PR TITLE
feat: allow running Playwright remotely (e.g. in a Docker container)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,13 @@ pytest tests/basic/test_coder.py
 pytest tests/basic/test_coder.py::TestCoder::test_specific_case
 ```
 
+If you are running Playwright remotely, specify the endpoint URL using the
+`--playwright-ws-endpoint` command line option when running `pytest`:
+
+```
+pytest --playwright-ws-endpoint ws://127.0.0.1:3000
+```
+
 #### Continuous Integration
 
 The project uses GitHub Actions for continuous integration. The testing workflows are defined in the following files:

--- a/aider/args.py
+++ b/aider/args.py
@@ -705,14 +705,27 @@ def get_parser(default_config_files, git_root):
         help="Specify the input device name for voice recording",
     )
 
-    ######
-    group = parser.add_argument_group("Other settings")
+    ##########
+    group = parser.add_argument_group("Playwright settings")
     group.add_argument(
         "--disable-playwright",
+        "--playwright-disable",
         action="store_true",
         help="Never prompt for or attempt to install Playwright for web scraping (default: False).",
         default=False,
     )
+    group.add_argument(
+        "--playwright-ws-endpoint",
+        metavar="URL",
+        default=None,
+        help=(
+            "Specify the WebSocket endpoint for a Playwright browser server to connect to "
+            "(default: None, use the locally installed Playwright)."
+        ),
+    )
+
+    ##########
+    group = parser.add_argument_group("Other settings")
     group.add_argument(
         "--file",
         action="append",

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -21,7 +21,7 @@ from aider.io import CommandCompletionException
 from aider.llm import litellm
 from aider.repo import ANY_GIT_ERROR
 from aider.run_cmd import run_cmd
-from aider.scrape import Scraper, install_playwright
+from aider.scrape import Scraper, has_playwright, install_playwright
 from aider.utils import is_image_file
 
 from .dump import dump  # noqa: F401
@@ -222,8 +222,13 @@ class Commands:
         self.io.tool_output(f"Scraping {url}...")
         if not self.scraper:
             disable_playwright = getattr(self.args, "disable_playwright", False)
+            playwright_ws_endpoint = getattr(self.args, "playwright_ws_endpoint", None)
             if disable_playwright:
                 res = False
+            elif playwright_ws_endpoint:
+                res = has_playwright(playwright_ws_endpoint)
+                if not res:
+                    self.io.tool_warning("Unable to connect to the playwright server.")
             else:
                 res = install_playwright(self.io)
                 if not res:
@@ -232,6 +237,7 @@ class Commands:
             self.scraper = Scraper(
                 print_error=self.io.tool_error,
                 playwright_available=res,
+                playwright_ws_endpoint=playwright_ws_endpoint,
                 verify_ssl=self.verify_ssl,
             )
 

--- a/aider/scrape.py
+++ b/aider/scrape.py
@@ -14,7 +14,7 @@ aider_user_agent = f"Aider/{__version__} +{urls.website}"
 # platforms.
 
 
-def check_env():
+def check_env(playwright_ws_endpoint=None):
     try:
         from playwright.sync_api import sync_playwright
 
@@ -24,7 +24,10 @@ def check_env():
 
     try:
         with sync_playwright() as p:
-            p.chromium.launch()
+            if playwright_ws_endpoint:
+                p.chromium.connect(playwright_ws_endpoint)
+            else:
+                p.chromium.launch()
             has_chromium = True
     except Exception:
         has_chromium = False
@@ -32,8 +35,8 @@ def check_env():
     return has_pip, has_chromium
 
 
-def has_playwright():
-    has_pip, has_chromium = check_env()
+def has_playwright(playwright_ws_endpoint=None):
+    has_pip, has_chromium = check_env(playwright_ws_endpoint)
     return has_pip and has_chromium
 
 
@@ -79,10 +82,12 @@ See {urls.enable_playwright} for more info.
 class Scraper:
     pandoc_available = None
     playwright_available = None
+    playwright_ws_endpoint = None
     playwright_instructions_shown = False
 
     # Public API...
-    def __init__(self, print_error=None, playwright_available=None, verify_ssl=True):
+    def __init__(self, print_error=None, playwright_available=None,
+                 playwright_ws_endpoint=None, verify_ssl=True):
         """
         `print_error` - a function to call to print error/debug info.
         `verify_ssl` - if False, disable SSL certificate verification when scraping.
@@ -93,6 +98,7 @@ class Scraper:
             self.print_error = print
 
         self.playwright_available = playwright_available
+        self.playwright_ws_endpoint = playwright_ws_endpoint
         self.verify_ssl = verify_ssl
 
     def scrape(self, url):
@@ -148,7 +154,10 @@ class Scraper:
 
         with sync_playwright() as p:
             try:
-                browser = p.chromium.launch()
+                if self.playwright_ws_endpoint:
+                    browser = p.chromium.connect(self.playwright_ws_endpoint)
+                else:
+                    browser = p.chromium.launch()
             except Exception as e:
                 self.playwright_available = False
                 self.print_error(str(e))
@@ -271,14 +280,17 @@ def slimdown_html(soup):
     return soup
 
 
-def main(url):
-    scraper = Scraper(playwright_available=has_playwright())
+def main(url, playwright_ws_endpoint=None):
+    scraper = Scraper(playwright_available=has_playwright(playwright_ws_endpoint),
+                      playwright_ws_endpoint=playwright_ws_endpoint)
     content = scraper.scrape(url)
     print(content)
 
 
 if __name__ == "__main__":
-    if len(sys.argv) < 2:
-        print("Usage: python playw.py <URL>")
+    if len(sys.argv) < 2 or len(sys.argv) > 3:
+        print("Usage: python scrape.py <URL> [playwright_ws_endpoint]")
         sys.exit(1)
-    main(sys.argv[1])
+    url = sys.argv[1]
+    playwright_ws_endpoint = sys.argv[2] if len(sys.argv) == 3 else None
+    main(url, playwright_ws_endpoint)

--- a/aider/scrape.py
+++ b/aider/scrape.py
@@ -86,8 +86,13 @@ class Scraper:
     playwright_instructions_shown = False
 
     # Public API...
-    def __init__(self, print_error=None, playwright_available=None,
-                 playwright_ws_endpoint=None, verify_ssl=True):
+    def __init__(
+        self,
+        print_error=None,
+        playwright_available=None,
+        playwright_ws_endpoint=None,
+        verify_ssl=True,
+    ):
         """
         `print_error` - a function to call to print error/debug info.
         `verify_ssl` - if False, disable SSL certificate verification when scraping.
@@ -281,8 +286,10 @@ def slimdown_html(soup):
 
 
 def main(url, playwright_ws_endpoint=None):
-    scraper = Scraper(playwright_available=has_playwright(playwright_ws_endpoint),
-                      playwright_ws_endpoint=playwright_ws_endpoint)
+    scraper = Scraper(
+        playwright_available=has_playwright(playwright_ws_endpoint),
+        playwright_ws_endpoint=playwright_ws_endpoint,
+    )
     content = scraper.scrape(url)
     print(content)
 

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -361,11 +361,17 @@
 ## Specify the input device name for voice recording
 #voice-input-device: xxx
 
-#################
-# Other settings:
+######################
+# Playwright settings:
 
 ## Never prompt for or attempt to install Playwright for web scraping (default: False).
 #disable-playwright: false
+
+## Specify the WebSocket endpoint for a Playwright browser server to connect to (default: None, use the locally installed Playwright).
+#playwright-ws-endpoint: xxx
+
+#################
+# Other settings:
 
 ## specify a file to edit (can be used multiple times)
 #file: xxx

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -342,11 +342,17 @@
 ## Specify the input device name for voice recording
 #AIDER_VOICE_INPUT_DEVICE=
 
-#################
-# Other settings:
+######################
+# Playwright settings:
 
 ## Never prompt for or attempt to install Playwright for web scraping (default: False).
 #AIDER_DISABLE_PLAYWRIGHT=false
+
+## Specify the WebSocket endpoint for a Playwright browser server to connect to (default: None, use the locally installed Playwright).
+#AIDER_PLAYWRIGHT_WS_ENDPOINT=
+
+#################
+# Other settings:
 
 ## specify a file to edit (can be used multiple times)
 #AIDER_FILE=

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -415,11 +415,17 @@ cog.outl("```")
 ## Specify the input device name for voice recording
 #voice-input-device: xxx
 
-#################
-# Other settings:
+######################
+# Playwright settings:
 
 ## Never prompt for or attempt to install Playwright for web scraping (default: False).
 #disable-playwright: false
+
+## Specify the WebSocket endpoint for a Playwright browser server to connect to (default: None, use the locally installed Playwright).
+#playwright-ws-endpoint: xxx
+
+#################
+# Other settings:
 
 ## specify a file to edit (can be used multiple times)
 #file: xxx

--- a/aider/website/docs/config/dotenv.md
+++ b/aider/website/docs/config/dotenv.md
@@ -382,11 +382,17 @@ cog.outl("```")
 ## Specify the input device name for voice recording
 #AIDER_VOICE_INPUT_DEVICE=
 
-#################
-# Other settings:
+######################
+# Playwright settings:
 
 ## Never prompt for or attempt to install Playwright for web scraping (default: False).
 #AIDER_DISABLE_PLAYWRIGHT=false
+
+## Specify the WebSocket endpoint for a Playwright browser server to connect to (default: None, use the locally installed Playwright).
+#AIDER_PLAYWRIGHT_WS_ENDPOINT=
+
+#################
+# Other settings:
 
 ## specify a file to edit (can be used multiple times)
 #AIDER_FILE=

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -75,10 +75,11 @@ usage: aider [-h] [--model] [--openai-api-key] [--anthropic-api-key]
              [--copy-paste | --no-copy-paste] [--apply]
              [--apply-clipboard-edits] [--exit] [--show-repo-map]
              [--show-prompts] [--voice-format] [--voice-language]
-             [--voice-input-device] [--disable-playwright] [--file]
-             [--read] [--vim] [--chat-language] [--commit-language]
-             [--yes-always] [-v] [--load] [--encoding]
-             [--line-endings] [-c] [--env-file]
+             [--voice-input-device] [--disable-playwright]
+             [--playwright-ws-endpoint] [--file] [--read] [--vim]
+             [--chat-language] [--commit-language] [--yes-always]
+             [-v] [--load] [--encoding] [--line-endings] [-c]
+             [--env-file]
              [--suggest-shell-commands | --no-suggest-shell-commands]
              [--fancy-input | --no-fancy-input]
              [--multiline | --no-multiline]
@@ -669,12 +670,21 @@ Environment variable: `AIDER_VOICE_LANGUAGE`
 Specify the input device name for voice recording  
 Environment variable: `AIDER_VOICE_INPUT_DEVICE`  
 
-## Other settings:
+## Playwright settings:
 
 ### `--disable-playwright`
 Never prompt for or attempt to install Playwright for web scraping (default: False).  
 Default: False  
 Environment variable: `AIDER_DISABLE_PLAYWRIGHT`  
+Aliases:
+  - `--disable-playwright`
+  - `--playwright-disable`
+
+### `--playwright-ws-endpoint URL`
+Specify the WebSocket endpoint for a Playwright browser server to connect to (default: None, use the locally installed Playwright).  
+Environment variable: `AIDER_PLAYWRIGHT_WS_ENDPOINT`  
+
+## Other settings:
 
 ### `--file FILE`
 specify a file to edit (can be used multiple times)  

--- a/aider/website/docs/install/docker.md
+++ b/aider/website/docs/install/docker.md
@@ -17,6 +17,8 @@ installed the first time you access them. Since containers are
 ephemeral, the extras will need to be reinstalled the next time you
 launch the aider core container.
 
+You can also use Docker to [only run Playwright](/docs/more/dockerized-playwright.html).
+
 ### Aider core 
 
 ```

--- a/aider/website/docs/install/optional.md
+++ b/aider/website/docs/install/optional.md
@@ -52,6 +52,8 @@ See the
 [Playwright for Python documentation](https://playwright.dev/python/docs/browsers#install-system-dependencies)
 for additional information.
 
+If your OS is not supported by Playwright, you may want to [run it using Docker](/docs/more/dockerized-playwright.html)
+or use the [full Aider Docker image](/docs/install/docker.html) that contains Playwright.
 
 ## Enable voice coding 
 

--- a/aider/website/docs/more/dockerized-playwright.md
+++ b/aider/website/docs/more/dockerized-playwright.md
@@ -1,0 +1,74 @@
+---
+parent: More info
+nav_order: 300
+---
+
+# Dockerized Playwright
+
+Aider can be configured to [use Playwright](/docs/install/optional.html#enable-playwright)
+for enhanced web scraping. Playwright only supports recent versions of Windows, macOS, Debian
+and Ubuntu.
+
+If you are unable to install Playwright or its dependencies natively, another
+option is to run a Playwright server in a Docker container. Note that this is
+different from [running the entire Aider in a container](/docs/install/docker.html)
+and avoids some limitations of that method.
+
+To do it, first make sure Aider is installed with Playwright support. If you tried
+installing Playwright from within Aider itself and it failed when installing browsers,
+you are probably good to go. Another way is to install it with the `playwright`
+[extra](https://packaging.python.org/en/latest/tutorials/installing-packages/#installing-extras)
+for the `aider-chat` Python package.
+
+The next step is to figure out which Playwright library your Aider installation uses.
+The major and minor versions of the `playwright` package MUST be the same as the major
+and minor versions of the dockerized Playwright server.
+
+Refer to the documentation for your Python package manager of choice for the instructions
+on how to install Aider with the `playwright` extra and how to check the version of the
+`playwright` Python package. Here are the example commands for `pip`.
+
+```bash
+# Install Aider with Playwright support
+python -m pip install -U --upgrade-strategy only-if-needed aider-chat[playwright]
+```
+
+```bash
+# Check Playwright version
+python -m pip show playwright
+```
+```
+Name: playwright
+Version: 1.52.0
+Summary: A high-level API to automate web browsers
+...
+```
+
+Having done that, run the corresponding Playwright server version using the official
+[Docker image](https://mcr.microsoft.com/en-us/artifact/mar/playwright/about). Assuming
+you already have Docker installed and running, the following command should work to run
+the container in the background. Replace the version (`1.52.0`) of both the container image
+and `playwright` package with the version of `playwright` used by Aider. Note that the patch
+version (the number after the second period in the version string) is allowed to differ.
+
+```bash
+docker run --name playwright_server --rm -d --init \
+    -p 3000:3000 --workdir /home/pwuser --user pwuser \
+    mcr.microsoft.com/playwright:v1.52.0 \
+    npx -y playwright@1.52.0 run-server --port 3000 --host 0.0.0.0
+```
+
+Once the container is up, configure Aider to connect to it using the [--playwright-ws-endpoint](/docs/config/options.html#--playwright-ws-endpoint-url)
+option. As with any option, you can specify it on the command line, in your YAML
+configuration file, or using the corresponding environment variable. Make sure
+you do not also have `--disable-playwright` specified.
+
+For example, if you have started the Playwright container on your local machine using the
+command above, you can use it in Aider after starting it like this:
+
+```bash
+aider --playwright-ws-endpoint ws://127.0.0.1:3000
+```
+
+Try the `/web` in-chat command, and if you don't see an error message, Aider is successfully
+scraping the web page using the Playwright server.

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-import pytest
+import pytest  # noqa: F401
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--playwright-ws-endpoint",
+        metavar="URL",
+        default=None,
+        help=(
+            "Specify the WebSocket endpoint for a Playwright browser server to connect to "
+            "(default: None, use the locally installed Playwright)."
+        ),
+    )

--- a/tests/scrape/test_scrape.py
+++ b/tests/scrape/test_scrape.py
@@ -1,7 +1,8 @@
 import time
 import unittest
-import pytest
 from unittest.mock import MagicMock
+
+import pytest
 
 from aider.commands import Commands
 from aider.io import InputOutput
@@ -26,8 +27,10 @@ class TestScrape(unittest.TestCase):
 
         # Test with SSL verification
         scraper_verify = Scraper(
-            print_error=MagicMock(), playwright_available=True,
-            playwright_ws_endpoint=self.playwright_ws_endpoint, verify_ssl=True
+            print_error=MagicMock(),
+            playwright_available=True,
+            playwright_ws_endpoint=self.playwright_ws_endpoint,
+            verify_ssl=True,
         )
         result_verify = scrape_with_retries(scraper_verify, "https://self-signed.badssl.com")
         self.assertIsNone(result_verify)
@@ -35,8 +38,10 @@ class TestScrape(unittest.TestCase):
 
         # Test without SSL verification
         scraper_no_verify = Scraper(
-            print_error=MagicMock(), playwright_available=True,
-            playwright_ws_endpoint=self.playwright_ws_endpoint, verify_ssl=False
+            print_error=MagicMock(),
+            playwright_available=True,
+            playwright_ws_endpoint=self.playwright_ws_endpoint,
+            verify_ssl=False,
         )
         result_no_verify = scrape_with_retries(scraper_no_verify, "https://self-signed.badssl.com")
         self.assertIsNotNone(result_no_verify)
@@ -80,8 +85,11 @@ class TestScrape(unittest.TestCase):
         # Create a Scraper instance with a mock print_error function
         mock_print_error = MagicMock()
 
-        scraper = Scraper(print_error=mock_print_error, playwright_available=True,
-                          playwright_ws_endpoint=self.playwright_ws_endpoint)
+        scraper = Scraper(
+            print_error=mock_print_error,
+            playwright_available=True,
+            playwright_ws_endpoint=self.playwright_ws_endpoint,
+        )
 
         # Scrape a real URL
         result = scraper.scrape("https://example.com")


### PR DESCRIPTION
Playwright only supports a few operating systems officially. Specifically, it only supports recent Debian and Ubuntu versions among Linux distributions, and I was having trouble getting it to run on Arch Linux because of the incompatible browser builds and installation scripts.

Luckily, Playwright provides official Docker images that contain all the supported browsers and their dependencies. I was able to patch Aider to connect to a Playwright server running in a container via WebSocket and successfully scrape web pages. It avoids some of the limitations associated with running the entire Aider installation in a Docker container, such as it being unable to run shell commands outside the container.

This pull request contains my patch as well as the supporting documentation. The patch adds a new configuration option `playwright-ws-endpoint`, which uses the Playwright server at the given URL and overrides the default behaviour to try using the native Playwright instance and attempt to install it if it's missing. The `playwright-ws-endpoint` option is itself overridden by `disable-playwright`, which disables any `playwright` functionality completely.

In addition to just documenting the new configuration option and behaviour, I have included a detailed guide on how to set up dockerized Playwright under **More info** and added links to it in the relevant sections of documentation.

Note that I haven't added any _new_ tests for the new functionality because that would require running another container in the CI. Instead, the existing tests in `tests/scrape` can now be run with a remote Playwright instance by passing the new `--playwright-ws-endpoint` flag to `pytest`. This new behaviour is documented in `CONTRIBUTING.md`. If desired, the CI workflow can be adapted to run the scraping tests both with local and remote Playwright instances.