### PR TITLE
[Feature] Resetting thinking tokens using "0"

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -143,7 +143,7 @@ def get_parser(default_config_files, git_root):
     group.add_argument(
         "--thinking-tokens",
         type=str,
-        help="Set the thinking token budget for models that support it (default: not set)",
+        help="Set the thinking token budget for models that support it. Use 0 to disable. (default: not set)",
     )
     group.add_argument(
         "--verify-ssl",

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1541,7 +1541,7 @@ class Commands:
         return self.cmd_editor(args)
 
     def cmd_think_tokens(self, args):
-        "Set the thinking token budget (supports formats like 8096, 8k, 10.5k, 0.5M)"
+        "Set the thinking token budget (supports formats like 8096, 8k, 10.5k, 0.5M, or 0 to disable)"
         model = self.coder.main_model
 
         if not args.strip():
@@ -1559,10 +1559,14 @@ class Commands:
         value = args.strip()
         model.set_thinking_tokens(value)
 
-        formatted_budget = model.get_thinking_tokens()
-        budget = model.get_raw_thinking_tokens()
+        # Handle the special case of 0 to disable thinking tokens
+        if value == "0":
+            self.io.tool_output("Thinking tokens disabled.")
+        else:
+            formatted_budget = model.get_thinking_tokens()
+            budget = model.get_raw_thinking_tokens()
+            self.io.tool_output(f"Set thinking token budget to {budget:,} tokens ({formatted_budget}).")
 
-        self.io.tool_output(f"Set thinking token budget to {budget:,} tokens ({formatted_budget}).")
         self.io.tool_output()
 
         # Output announcements

--- a/aider/models.py
+++ b/aider/models.py
@@ -794,6 +794,7 @@ class Model(ModelSettings):
         """
         Set the thinking token budget for models that support it.
         Accepts formats: 8096, "8k", "10.5k", "0.5M", "10K", etc.
+        Pass "0" to disable thinking tokens.
         """
         if value is not None:
             num_tokens = self.parse_token_value(value)
@@ -805,9 +806,17 @@ class Model(ModelSettings):
             if self.name.startswith("openrouter/"):
                 if "extra_body" not in self.extra_params:
                     self.extra_params["extra_body"] = {}
-                self.extra_params["extra_body"]["reasoning"] = {"max_tokens": num_tokens}
+                if num_tokens > 0:
+                    self.extra_params["extra_body"]["reasoning"] = {"max_tokens": num_tokens}
+                else:
+                    if "reasoning" in self.extra_params["extra_body"]:
+                        del self.extra_params["extra_body"]["reasoning"]
             else:
-                self.extra_params["thinking"] = {"type": "enabled", "budget_tokens": num_tokens}
+                if num_tokens > 0:
+                    self.extra_params["thinking"] = {"type": "enabled", "budget_tokens": num_tokens}
+                else:
+                    if "thinking" in self.extra_params:
+                        del self.extra_params["thinking"]
 
     def get_raw_thinking_tokens(self):
         """Get formatted thinking token budget if available"""

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -83,7 +83,7 @@
 ## Set the reasoning_effort API parameter (default: not set)
 #reasoning-effort: xxx
 
-## Set the thinking token budget for models that support it (default: not set)
+## Set the thinking token budget for models that support it. Use 0 to disable. (default: not set)
 #thinking-tokens: xxx
 
 ## Verify the SSL cert when connecting to models (default: True)

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -173,7 +173,7 @@ Set the reasoning_effort API parameter (default: not set)
 Environment variable: `AIDER_REASONING_EFFORT`  
 
 ### `--thinking-tokens VALUE`
-Set the thinking token budget for models that support it (default: not set)  
+Set the thinking token budget for models that support it. Use 0 to disable. (default: not set)  
 Environment variable: `AIDER_THINKING_TOKENS`  
 
 ### `--verify-ssl`

--- a/aider/website/docs/config/reasoning.md
+++ b/aider/website/docs/config/reasoning.md
@@ -25,7 +25,7 @@ aider --model r1
 ```
 
 Inside the aider chat, you can use `/thinking-tokens 4k` or `/reasoning-effort low` to change
-the amount of reasoning.
+the amount of reasoning. Use `/thinking-tokens 0` to disable thinking tokens.
 
 The rest of this document describes more advanced details which are mainly needed
 if you're configuring aider to work with a lesser known reasoning model or one served
@@ -47,6 +47,7 @@ You can use the `--thinking-tokens` switch to request
 the model use a certain number of thinking tokens.
 This switch is useful for Sonnet 3.7.
 You can specify the token budget like "1024", "1k", "8k" or "0.01M".
+Use "0" to disable thinking tokens.
 
 ### Model compatibility and settings
 

--- a/aider/website/docs/usage/commands.md
+++ b/aider/website/docs/usage/commands.md
@@ -57,7 +57,7 @@ cog.out(get_help_md())
 | **/save** | Save commands to a file that can reconstruct the current chat session's files |
 | **/settings** | Print out the current settings |
 | **/test** | Run a shell command and add the output to the chat on non-zero exit code |
-| **/think-tokens** | Set the thinking token budget (supports formats like 8096, 8k, 10.5k, 0.5M) |
+| **/think-tokens** | Set the thinking token budget (supports formats like 8096, 8k, 10.5k, 0.5M, or 0 to disable) |
 | **/tokens** | Report on the number of tokens used by the current chat context |
 | **/undo** | Undo the last git commit if it was done by aider |
 | **/voice** | Record and transcribe voice input |


### PR DESCRIPTION
Once you run `/thinking-tokens 4k` inside chat, there was no way to reset it. With this PR, `/thinking-tokens 0` does that.