### PR TITLE
add MATLAB tags to enable repo map support

### DIFF
--- a/aider/queries/tree-sitter-language-pack/matlab-tags.scm
+++ b/aider/queries/tree-sitter-language-pack/matlab-tags.scm
@@ -1,0 +1,10 @@
+(class_definition
+  name: (identifier) @name.definition.class) @definition.class
+
+(function_definition
+  name: (identifier) @name.definition.function) @definition.function
+
+(function_call
+  name: (identifier) @name.reference.call) @reference.call
+
+(command (command_name) @name.reference.call) @reference.call

--- a/aider/queries/tree-sitter-languages/matlab-tags.scm
+++ b/aider/queries/tree-sitter-languages/matlab-tags.scm
@@ -1,0 +1,10 @@
+(class_definition
+  name: (identifier) @name.definition.class) @definition.class
+
+(function_definition
+  name: (identifier) @name.definition.function) @definition.function
+
+(function_call
+  name: (identifier) @name.reference.call) @reference.call
+
+(command (command_name) @name.reference.call) @reference.call

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -388,6 +388,9 @@ class TestRepoMapAllLanguages(unittest.TestCase):
     def test_language_ocaml_interface(self):
         self._test_language_repo_map("ocaml_interface", "mli", "Greeter")
 
+    def test_language_matlab(self):
+        self._test_language_repo_map("matlab", "m", "Person")
+
     def _test_language_repo_map(self, lang, key, symbol):
         """Helper method to test repo map generation for a specific language."""
         # Get the fixture file path and name based on language

--- a/tests/fixtures/languages/matlab/test.m
+++ b/tests/fixtures/languages/matlab/test.m
@@ -1,0 +1,42 @@
+classdef Person
+    properties
+        name    (1,1) string
+        age     (1,1) double
+    end
+
+    methods
+        function obj = Person(name, age)
+            arguments
+                name    (1,1) string
+                age     (1,1) double = NaN
+            end
+            % Constructor for Person class
+            obj.name = name;
+            obj.age  = age;
+        end
+
+        function greeting = greet(obj,formal)
+            arguments
+                obj
+                formal  (1,1) logical = false
+            end
+            if formal
+                prefix = "Good day";
+            else
+                prefix = "Hello";
+            end
+            greeting = sprintf("%s, %s!", prefix, obj.name);
+        end
+    end
+end
+
+function greetings = create_greeting_list(people)
+    arguments
+        people  (1,:) Person
+    end
+    % Create greetings for a list of people.
+    greetings = string(numel(people), 0);
+    for i = 1:numel(people)
+        greetings(i) = people(i).greet();
+    end
+end  


### PR DESCRIPTION
### Description

This PR adds support for MATLAB repo maps. I added in `matlab-tags.scm` files, and added a test case for these changes.