### PR TITLE
Fix immediate vertex rate limits with upgrade of LiteLLM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -213,7 +213,7 @@ jsonschema-specifications==2025.4.1
     # via
     #   -c requirements/common-constraints.txt
     #   jsonschema
-litellm==1.72.4
+litellm==1.73.0rc1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -233,7 +233,7 @@ jsonschema-specifications==2025.4.1
     # via jsonschema
 kiwisolver==1.4.8
     # via matplotlib
-litellm==1.72.4
+litellm==1.73.0rc1
     # via -r requirements/requirements.in
 llama-index-core==0.12.26
     # via


### PR DESCRIPTION
LiteLLM 1.72.4 seems broken on Vertex AI, tested with the Gemini Preview models. I'm hitting immediately rate limit errors on the smallest request.

```
litellm.RateLimitError: litellm.RateLimitError: VertexAIException - b'{\n  "error": {\n    "code": 429,\n    "message":
```

LiteLLM 1.72.6 does not fix the issue (the issue remains)

What works is a bigger downgrade to

LiteLLM 1.72.1

or an upgrade to

LiteLLM 1.73.0rc1

In this PR I've opted to upgrade to the latest new RC1 version which does not break usage with LiteLLM from my limited testing.