### PR TITLE
feat: enforce truecolor rendering for prompt_toolkit sessions

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -23,6 +23,7 @@ from prompt_toolkit.keys import Keys
 from prompt_toolkit.lexers import PygmentsLexer
 from prompt_toolkit.output.vt100 import is_dumb_terminal
 from prompt_toolkit.shortcuts import CompleteStyle, PromptSession
+from prompt_toolkit.output.color_depth import ColorDepth
 from prompt_toolkit.styles import Style
 from pygments.lexers import MarkdownLexer, guess_lexer_for_filename
 from pygments.token import Token
@@ -662,6 +663,7 @@ class InputOutput:
                         style=style,
                         key_bindings=kb,
                         complete_while_typing=True,
+                        color_depth=ColorDepth.TRUE_COLOR,
                         prompt_continuation=get_continuation,
                     )
                 else:


### PR DESCRIPTION
Prompt_toolkit's color_depth now explicitly set to ColorDepth.TRUE_COLOR to ensure custom hex-based color themes (e.g. "#282828") render as intended in compatible terminals.

Fixes issues with fallback to 256-color approximations.

```yml
completion-menu-color: "#D5BE99"
completion-menu-bg-color: "#292828"
completion-menu-current-color: "#292828"
completion-menu-current-bg-color: "#D5BE99"
```
**Before**
<img width="466" alt="Screenshot 2025-06-27 at 12 17 15 AM" src="https://github.com/user-attachments/assets/3ee3b785-3b2a-4924-a4e3-6d87a5120241" />
bg color #262626
fg color #D7AF87

**After**
<img width="419" alt="Screenshot 2025-06-27 at 12 16 58 AM" src="https://github.com/user-attachments/assets/43212bdd-4be5-4448-bdb5-55a03919cf3e" />

