### PR TITLE
Support the GitHub Models provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ aider --model sonnet --api-key anthropic=<key>
 
 # o3-mini
 aider --model o3-mini --api-key openai=<key>
+
+# GitHub Models
+aider --model openai/gpt-4o --api-key github=<github_token>
 ```
 
 See the [installation instructions](https://aider.chat/docs/install.html) and [usage documentation](https://aider.chat/docs/usage.html) for more details.

--- a/aider/main.py
+++ b/aider/main.py
@@ -615,6 +615,11 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if args.openai_api_key:
         os.environ["OPENAI_API_KEY"] = args.openai_api_key
 
+    # Set GitHub Models API base when GitHub API key is present
+    if os.environ.get("GITHUB_API_KEY"):
+        os.environ["OPENAI_API_BASE"] = "https://models.github.ai/inference"
+        os.environ["OPENAI_API_KEY"] = os.environ["GITHUB_API_KEY"]
+
     # Handle deprecated model shortcut args
     handle_deprecated_model_args(args, io)
     if args.openai_api_base:

--- a/aider/models.py
+++ b/aider/models.py
@@ -683,6 +683,7 @@ class Model(ModelSettings):
             anthropic="ANTHROPIC_API_KEY",
             groq="GROQ_API_KEY",
             fireworks_ai="FIREWORKS_API_KEY",
+            github="GITHUB_API_KEY",
         )
         var = None
         if model in OPENAI_MODELS:
@@ -987,6 +988,12 @@ class Model(ModelSettings):
                 }
 
             self.github_copilot_token_to_open_ai_key(kwargs["extra_headers"])
+
+        # Are we using GitHub Models?
+        if "GITHUB_API_KEY" in os.environ:
+            kwargs["api_base"] = "https://models.github.ai/inference"
+            # litellm requires an "openai/" prefix for OpenAI-compatible APIs, so let's add it in
+            kwargs["model"] = "openai/" + kwargs["model"]
 
         res = litellm.completion(**kwargs)
         return hash_object, res

--- a/aider/onboarding.py
+++ b/aider/onboarding.py
@@ -64,6 +64,7 @@ def try_to_select_default_model():
         ("ANTHROPIC_API_KEY", "sonnet"),
         ("DEEPSEEK_API_KEY", "deepseek"),
         ("OPENAI_API_KEY", "gpt-4o"),
+        ("GITHUB_API_KEY", "openai/gpt-4.1"),
         ("GEMINI_API_KEY", "gemini/gemini-2.5-pro-exp-03-25"),
         ("VERTEXAI_PROJECT", "vertex_ai/gemini-2.5-pro-exp-03-25"),
     ]

--- a/aider/website/docs/llms/github.md
+++ b/aider/website/docs/llms/github.md
@@ -3,22 +3,99 @@ parent: Connecting to LLMs
 nav_order: 510
 ---
 
-# GitHub Copilot
+# GitHub
 
-Aider can connect to GitHub Copilot’s LLMs because Copilot exposes a standard **OpenAI-style**
-endpoint at:
+Aider can connect to both GitHub Models and GitHub Copilot, which are different GitHub services
+that expose **OpenAI-style** endpoints.
+
+---
+
+## GitHub Models
+
+GitHub Models provides access to AI models through a simple API using your GitHub Personal Access Token.
+GitHub Models uses the endpoint:
 
 ```
-https://api.githubcopilot.com
+https://models.github.ai/inference
 ```
 
 First, install aider:
 
 {% include install.md %}
 
+### Configure your environment
+
+You can set up GitHub Models in two ways:
+
+**Option 1: Using --api-key (recommended)**
+```bash
+aider --api-key github=<your_github_pat> --model openai/gpt-4.1
+```
+
+**Option 2: Using environment variables**
+```bash
+# macOS/Linux
+export GITHUB_API_KEY=<your_github_pat>
+
+# Windows (PowerShell)
+setx GITHUB_API_KEY <your_github_pat>
+# …restart the shell after setx commands
+```
+
+When you set `GITHUB_API_KEY`, aider automatically configures the GitHub Models endpoint.
+
+### Where do I get the GitHub Personal Access Token?
+
+1. Go to [GitHub Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens)
+2. Click "Generate new token (classic)" or "Fine-grained personal access token"
+3. For classic tokens: Select the `models:read` scope
+4. For fine-grained tokens: Grant "Models" repository permissions
+5. Copy the generated token
+
+### Available models
+
+GitHub Models provides access to various AI models with their publisher prefixes:
+
+```bash
+# OpenAI models
+aider --model openai/gpt-4.1
+aider --model deepseek/deepseek-r1
+aider --model mistral-ai/codestral-2501
+aider --model microsoft/phi-4-mini-reasoning
+```
+
+### Quick start
+
+```bash
+# Using --api-key
+aider --api-key github=ghp_your_token_here --model openai/gpt-4o
+
+# Or with environment variable
+export GITHUB_API_KEY=ghp_your_token_here
+aider --model openai/gpt-4o
+```
+
+### Optional config file (`~/.aider.conf.yml`)
+
+```yaml
+api-key:
+  - github=<your_github_pat>
+model: openai/gpt-4o
+weak-model: openai/gpt-4o-mini
+```
+
 ---
 
-## Configure your environment
+## GitHub Copilot
+
+Aider can connect to GitHub Copilot's LLMs because Copilot exposes a standard **OpenAI-style**
+endpoint at:
+
+```
+https://api.githubcopilot.com
+```
+
+### Configure your environment
 
 ```bash
 # macOS/Linux
@@ -30,8 +107,6 @@ setx OPENAI_API_BASE https://api.githubcopilot.com
 setx OPENAI_API_KEY  <oauth_token>
 # …restart the shell after setx commands
 ```
-
----
 
 ### Where do I get the token?
 The easiest path is to sign in to Copilot from any JetBrains IDE (PyCharm, GoLand, etc).
@@ -50,12 +125,10 @@ On Windows the config can be found in:
 Copy the `oauth_token` value – that string is your `OPENAI_API_KEY`.
 
 *Note:* tokens created by the Neovim **copilot.lua** plugin (old `hosts.json`) sometimes lack the
-needed scopes. If you see “access to this endpoint is forbidden”, regenerate the token with a
+needed scopes. If you see "access to this endpoint is forbidden", regenerate the token with a
 JetBrains IDE.
 
----
-
-## Discover available models
+### Discover available models
 
 Copilot hosts many models (OpenAI, Anthropic, Google, etc).  
 List the models your subscription allows with:
@@ -75,9 +148,7 @@ aider --model openai/gpt-4o
 aider --model openai/claude-3.7-sonnet-thought
 ```
 
----
-
-## Quick start
+### Quick start
 
 ```bash
 # change into your project
@@ -87,9 +158,7 @@ cd /to/your/project
 aider --model openai/gpt-4o
 ```
 
----
-
-## Optional config file (`~/.aider.conf.yml`)
+### Optional config file (`~/.aider.conf.yml`)
 
 ```yaml
 openai-api-base: https://api.githubcopilot.com
@@ -101,11 +170,92 @@ show-model-warnings: false
 
 ---
 
+## GitHub Models
+
+GitHub Models provides access to AI models through a simple API using your GitHub Personal Access Token.
+Unlike Copilot, GitHub Models uses the endpoint:
+
+```
+https://models.github.ai/inference
+```
+
+### Configure your environment
+
+You can set up GitHub Models in two ways:
+
+**Option 1: Using --api-key (recommended)**
+```bash
+aider --api-key github=<your_github_pat> --model openai/gpt-4o
+```
+
+**Option 2: Using environment variables**
+```bash
+# macOS/Linux
+export GITHUB_API_KEY=<your_github_pat>
+
+# Windows (PowerShell)
+setx GITHUB_API_KEY <your_github_pat>
+# …restart the shell after setx commands
+```
+
+When you set `GITHUB_API_KEY`, aider automatically configures the GitHub Models endpoint.
+
+### Where do I get the GitHub Personal Access Token?
+
+1. Go to [GitHub Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens)
+2. Click "Generate new token (classic)" or "Fine-grained personal access token"
+3. For classic tokens: Select the `models:read` scope
+4. For fine-grained tokens: Grant "Models" repository permissions
+5. Copy the generated token
+
+### Available models
+
+GitHub Models provides access to various AI models with their publisher prefixes:
+
+```bash
+# OpenAI models
+aider --model openai/gpt-4o
+aider --model openai/gpt-4o-mini
+aider --model openai/o1-preview
+aider --model openai/o1-mini
+
+# Other providers may be available
+# Check the GitHub Models documentation for the latest list
+```
+
+### Quick start
+
+```bash
+# Using --api-key
+aider --api-key github=ghp_your_token_here --model openai/gpt-4o
+
+# Or with environment variable
+export GITHUB_API_KEY=ghp_your_token_here
+aider --model openai/gpt-4o
+```
+
+### Optional config file (`~/.aider.conf.yml`)
+
+```yaml
+api-key:
+  - github=<your_github_pat>
+model: openai/gpt-4o
+weak-model: openai/gpt-4o-mini
+```
+
+---
+
 ## FAQ
 
+### GitHub Models
+* GitHub Models provides free tier access to various AI models, plus an optional paid tier for higher rate limits
+* Models are referenced with their publisher prefix (e.g., `openai/gpt-4o`)
+* Requires a GitHub Personal Access Token with `models:read` permission
+
+### GitHub Copilot
 * Calls made through aider are billed through your Copilot subscription  
   (aider will still print *estimated* costs).
-* The Copilot docs explicitly allow third-party “agents” that hit this API – aider is playing by
+* The Copilot docs explicitly allow third-party "agents" that hit this API – aider is playing by
   the rules.
 * Aider talks directly to the REST endpoint—no web-UI scraping or browser automation.
 


### PR DESCRIPTION
This PR adds support for GitHub's own inference provider, [GitHub Models](https://docs.github.com/en/rest/models/inference). Like other providers, I use the existence of a `GITHUB_API_KEY` as an indicator about which provider to use.

GitHub Models supports many publishers, so its models are prefixed with `openai/` or `deepseek/`. That means we've got to add `openai/` to the model name as well, to tell `litellm` that we're talking to an OpenAI-compatible endpoint.

Happy to make any changes, just let me know 😄 