### PR TITLE
feat: Add configuration option to specify model provider for /voice command

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -717,6 +717,12 @@ def get_parser(default_config_files, git_root):
         default=None,
         help="Specify the input device name for voice recording",
     )
+    group.add_argument(
+        "--voice-model",
+        metavar="VOICE_MODEL",
+        default=None,
+        help="Specify the speech-to-text model to use for voice input (default: whisper-1, requires OPENAI_API_KEY)",
+    )
 
     ######
     group = parser.add_argument_group("Other settings")

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -42,6 +42,7 @@ class Commands:
             self.io,
             None,
             voice_language=self.voice_language,
+            voice_model=self.voice_model,
             verify_ssl=self.verify_ssl,
             args=self.args,
             parser=self.parser,
@@ -57,6 +58,7 @@ class Commands:
         voice_language=None,
         voice_input_device=None,
         voice_format=None,
+        voice_model=None,
         verify_ssl=True,
         args=None,
         parser=None,
@@ -72,11 +74,12 @@ class Commands:
 
         self.verify_ssl = verify_ssl
         if voice_language == "auto":
-            voice_language = None
+            voice_language = None 
 
         self.voice_language = voice_language
         self.voice_format = voice_format
         self.voice_input_device = voice_input_device
+        self.voice_model = voice_model
 
         self.help = None
         self.editor = editor
@@ -1232,12 +1235,14 @@ class Commands:
         "Record and transcribe voice input"
 
         if not self.voice:
-            if "OPENAI_API_KEY" not in os.environ:
-                self.io.tool_error("To use /voice you must provide an OpenAI API key.")
+            if "OPENAI_API_KEY" not in os.environ and self.voice_model is None:
+                self.io.tool_error("To use /voice you must provide an OpenAI API key or a voice model.")
                 return
             try:
                 self.voice = voice.Voice(
-                    audio_format=self.voice_format or "wav", device_name=self.voice_input_device
+                    audio_format=self.voice_format or "wav",
+                    device_name=self.voice_input_device,
+                    voice_model=self.voice_model,
                 )
             except voice.SoundDeviceError:
                 self.io.tool_error(

--- a/aider/main.py
+++ b/aider/main.py
@@ -938,6 +938,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         voice_language=args.voice_language,
         voice_input_device=args.voice_input_device,
         voice_format=args.voice_format,
+        voice_model=args.voice_model,
         verify_ssl=args.verify_ssl,
         args=args,
         parser=parser,

--- a/aider/voice.py
+++ b/aider/voice.py
@@ -37,7 +37,7 @@ class Voice:
 
     threshold = 0.15
 
-    def __init__(self, audio_format="wav", device_name=None):
+    def __init__(self, audio_format="wav", device_name=None, voice_model=None):
         if sf is None:
             raise SoundDeviceError
         try:
@@ -73,6 +73,7 @@ class Voice:
         if audio_format not in ["wav", "mp3", "webm"]:
             raise ValueError(f"Unsupported audio format: {audio_format}")
         self.audio_format = audio_format
+        self.voice_model = voice_model
 
     def callback(self, indata, frames, time, status):
         """This is called (from a separate thread) for each audio block."""
@@ -167,7 +168,7 @@ class Voice:
         with open(filename, "rb") as fh:
             try:
                 transcript = litellm.transcription(
-                    model="whisper-1", file=fh, prompt=history, language=language
+                    model=self.voice_model or "whisper-1", file=fh, prompt=history, language=language
                 )
             except Exception as err:
                 print(f"Unable to transcribe {filename}: {err}")

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -367,6 +367,9 @@
 ## Specify the input device name for voice recording
 #voice-input-device: xxx
 
+## Specify the transcribing model for voice recording
+#voice-model: xxx
+
 #################
 # Other settings:
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -348,6 +348,9 @@
 ## Specify the input device name for voice recording
 #AIDER_VOICE_INPUT_DEVICE=
 
+## Specify the transcribing model for voice recording
+#AIDER_VOICE_MODEL=
+
 #################
 # Other settings:
 


### PR DESCRIPTION
**Add support for specifying alternative  /voice  model**

This update allows users to define the voice transcription model through the .env file using the AIDER_VOICE_MODEL environment variable.

For example:
```
AIDER_VOICE_MODEL=sambanova/Whisper-Large-v3
```
This provides flexibility to choose different Whisper-compatible models for /voice transcription.