### PR TITLE
fix: add missing output for clear command

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -412,6 +412,7 @@ class Commands:
         "Clear the chat history"
 
         self._clear_chat_history()
+        self.io.tool_output("All chat history cleared.")
 
     def _drop_all_files(self):
         self.coder.abs_fnames = set()


### PR DESCRIPTION
This small PR adds output for the `/clear` in-chat command.
Currently, all other commands produce output, but `/clear` does not.

```console
> /drop                                                                      

Dropping all files from the chat session.
─────────────────────────────────────────────────────────────────────────────
> /clear                                                                     

─────────────────────────────────────────────────────────────────────────────
```