### PR TITLE
docs: Add nvim-aider to NeoVim plugins list

### DIFF
--- a/aider/website/docs/install/optional.md
+++ b/aider/website/docs/install/optional.md
@@ -85,6 +85,10 @@ aider in a terminal alongside your editor and use `--watch-files`.
 
 [https://github.com/joshuavial/aider.nvim](https://github.com/joshuavial/aider.nvim)
 
+[GeorgesAlkhouri](https://github.com/GeorgesAlkhouri) has also created a NeoVim plugin for aider:
+
+[https://github.com/GeorgesAlkhouri/nvim-aider](https://github.com/GeorgesAlkhouri/nvim-aider)
+
 ### VS Code
 
 You can run aider inside a VS Code terminal window.


### PR DESCRIPTION
This pull request adds `nvim-aider`, a new community plugin for NeoVim, to the editor integration list on the "Optional steps" documentation page.

This helps other NeoVim users discover more ways to integrate Aider into their workflow.