### PR TITLE
Add openrouter kimi-k2 model to `aider/resources`.

### DIFF
--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -121,7 +121,8 @@
         "litellm_provider": "openrouter",
         "mode": "chat",
         "supports_tool_choice": true,
-        "supports_system_messages": true
+        "supports_system_messages": true,
+        "source": "https://openrouter.ai/moonshotai/kimi-k2"
     },
     "openrouter/openai/gpt-4o-mini": {
         "max_tokens": 16384,

--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -112,6 +112,17 @@
         "litellm_provider": "openrouter",
         "mode": "chat"
     },
+    "openrouter/moonshotai/kimi-k2": {
+        "max_tokens" : 131072,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 131072,
+        "input_cost_per_token": 0.000000057,
+        "output_cost_per_token": 0.00000023,
+        "litellm_provider": "openrouter",
+        "mode": "chat",
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    },
     "openrouter/openai/gpt-4o-mini": {
         "max_tokens": 16384,
         "max_input_tokens": 128000,

--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -113,7 +113,7 @@
         "mode": "chat"
     },
     "openrouter/moonshotai/kimi-k2": {
-        "max_tokens" : 131072,
+        "max_tokens": 131072,
         "max_input_tokens": 131072,
         "max_output_tokens": 131072,
         "input_cost_per_token": 0.000000057,

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -803,8 +803,9 @@
 - name: openrouter/moonshotai/kimi-k2
   edit_format: diff
   use_repo_map: true
-  reminder: sys
   examples_as_sys_msg: true
+  extra_params:
+    temperature: 0.6
 
 - name: fireworks_ai/accounts/fireworks/models/deepseek-r1
   edit_format: diff

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -800,6 +800,12 @@
   editor_model_name: openrouter/deepseek/deepseek-chat
   editor_edit_format: editor-diff
 
+- name: openrouter/moonshotai/kimi-k2
+  edit_format: diff
+  use_repo_map: true
+  reminder: sys
+  examples_as_sys_msg: true
+
 - name: fireworks_ai/accounts/fireworks/models/deepseek-r1
   edit_format: diff
   weak_model_name: fireworks_ai/accounts/fireworks/models/deepseek-v3


### PR DESCRIPTION
Overall documentation is quite light for this new model.

Max token information is from https://openrouter.ai/moonshotai/kimi-k2.

Information regarding the ideal temperature (0.6) and use of system prompt is from https://platform.moonshot.ai/docs/guide/agent-support ; although this is fairly standard. 

**Moonshot AI mention poor performance on one-shot style prompts, might be worth tweaking settings based on this.**

Using:
```
  examples_as_sys_msg: true
```
is a best guess on my part based on a guessed similarity to R1.

Partially addresses #4341 , however adding Moonshot AI platform API support will probably need to be addressed by litellm.
