### PR TITLE
Fzf reverse history search

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -849,6 +849,10 @@ def get_parser(default_config_files, git_root):
         "--editor",
         help="Specify which editor to use for the /editor command",
     )
+    group.add_argument(
+        "--fzf-history-search",
+        help="Use fuzzy find (fzf) for backwards history search",
+    )
 
     supported_shells_list = sorted(list(shtab.SUPPORTED_SHELLS))
     group.add_argument(

--- a/aider/main.py
+++ b/aider/main.py
@@ -575,6 +575,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             multiline_mode=args.multiline,
             notifications=args.notifications,
             notifications_command=args.notifications_command,
+            fzf_history_search=args.fzf_history_search,
         )
 
     io = get_io(args.pretty)


### PR DESCRIPTION
This PR implements https://github.com/Aider-AI/aider/issues/3575

I find fzf a very convenient way to search shell history and was missing that functionality in aider.

Demo showcasing fzf based reverse history search in aider with ctrl-r: 

https://github.com/user-attachments/assets/4efd83b2-2097-4ba3-ad20-a26f470cb353

