### PR TITLE
chore: bump deps to bump LiteLLM

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
@@ -41,7 +41,7 @@ cachetools==5.5.2
     # via
     #   -c requirements/common-constraints.txt
     #   google-auth
-certifi==2025.6.15
+certifi==2025.7.14
     # via
     #   -c requirements/common-constraints.txt
     #   httpcore
@@ -90,7 +90,7 @@ frozenlist==1.7.0
     #   -c requirements/common-constraints.txt
     #   aiohttp
     #   aiosignal
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   huggingface-hub
@@ -98,7 +98,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/common-constraints.txt
     #   gitpython
-gitpython==3.1.44
+gitpython==3.1.45
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -112,7 +112,7 @@ google-api-core[grpc]==2.25.1
     #   google-ai-generativelanguage
     #   google-api-python-client
     #   google-generativeai
-google-api-python-client==2.174.0
+google-api-python-client==2.177.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-generativeai
@@ -141,12 +141,12 @@ grep-ast==0.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-grpcio==1.73.0
+grpcio==1.74.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.71.0
+grpcio-status==1.71.2
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
@@ -172,7 +172,7 @@ httpx==0.28.1
     #   -c requirements/common-constraints.txt
     #   litellm
     #   openai
-huggingface-hub==0.33.1
+huggingface-hub==0.34.3
     # via
     #   -c requirements/common-constraints.txt
     #   tokenizers
@@ -204,7 +204,7 @@ json5==0.12.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -213,7 +213,7 @@ jsonschema-specifications==2025.4.1
     # via
     #   -c requirements/common-constraints.txt
     #   jsonschema
-litellm==1.73.1
+litellm==1.74.9.post1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -241,7 +241,7 @@ mslex==1.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   oslex
-multidict==6.5.1
+multidict==6.6.3
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
@@ -255,7 +255,7 @@ numpy==1.26.4
     #   -c requirements/common-constraints.txt
     #   scipy
     #   soundfile
-openai==1.91.0
+openai==1.97.1
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
@@ -277,11 +277,11 @@ pexpect==4.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-posthog==5.4.0
+posthog==6.3.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
@@ -385,7 +385,7 @@ referencing==0.36.2
     #   -c requirements/common-constraints.txt
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.11.6
+regex==2025.7.31
     # via
     #   -c requirements/common-constraints.txt
     #   tiktoken
@@ -397,11 +397,11 @@ requests==2.32.4
     #   mixpanel
     #   posthog
     #   tiktoken
-rich==14.0.0
+rich==14.1.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   -c requirements/common-constraints.txt
     #   jsonschema
@@ -453,7 +453,7 @@ tiktoken==0.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
-tokenizers==0.21.2
+tokenizers==0.21.4
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
@@ -463,6 +463,7 @@ tqdm==4.67.1
     #   google-generativeai
     #   huggingface-hub
     #   openai
+tree-sitter==0.25.0
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack
@@ -474,7 +475,7 @@ tree-sitter-embedded-template==0.23.2
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack
-tree-sitter-language-pack==0.8.0
+tree-sitter-language-pack==0.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   grep-ast
@@ -482,14 +483,16 @@ tree-sitter-yaml==0.7.1
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -c requirements/common-constraints.txt
+    #   aiosignal
     #   anyio
     #   beautifulsoup4
     #   google-generativeai
     #   huggingface-hub
     #   openai
+    #   posthog
     #   pydantic
     #   pydantic-core
     #   referencing
@@ -523,6 +526,3 @@ zipp==3.23.0
     # via
     #   -c requirements/common-constraints.txt
     #   importlib-metadata
-    
-tree-sitter==0.23.2; python_version < "3.10"
-tree-sitter==0.24.0; python_version >= "3.10"

--- a/requirements/common-constraints.txt
+++ b/requirements/common-constraints.txt
@@ -2,12 +2,12 @@
 #    uv pip compile --no-strip-extras --output-file=requirements/common-constraints.txt requirements/requirements.in requirements/requirements-browser.in requirements/requirements-dev.in requirements/requirements-help.in requirements/requirements-playwright.in
 aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   huggingface-hub
     #   litellm
     #   llama-index-core
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via aiohttp
 altair==5.5.0
     # via streamlit
@@ -27,7 +27,7 @@ backoff==2.2.1
     # via
     #   -r requirements/requirements.in
     #   posthog
-banks==2.1.2
+banks==2.2.0
     # via llama-index-core
 beautifulsoup4==4.13.4
     # via -r requirements/requirements.in
@@ -39,7 +39,7 @@ cachetools==5.5.2
     # via
     #   google-auth
     #   streamlit
-certifi==2025.6.15
+certifi==2025.7.14
     # via
     #   httpcore
     #   httpx
@@ -67,7 +67,7 @@ colorama==0.4.6
     # via griffe
 configargparse==1.7.1
     # via -r requirements/requirements.in
-contourpy==1.3.2
+contourpy==1.3.3
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
@@ -87,7 +87,7 @@ dirtyjson==1.0.8
     # via llama-index-core
 diskcache==5.6.3
     # via -r requirements/requirements.in
-distlib==0.3.9
+distlib==0.4.0
     # via virtualenv
 distro==1.9.0
     # via
@@ -98,25 +98,26 @@ filelock==3.18.0
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
     #   virtualenv
 filetype==1.2.0
     # via llama-index-core
 flake8==7.3.0
     # via -r requirements/requirements.in
-fonttools==4.58.4
+fonttools==4.59.0
     # via matplotlib
 frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via
     #   huggingface-hub
     #   llama-index-core
     #   torch
 gitdb==4.0.12
     # via gitpython
-gitpython==3.1.44
+gitpython==3.1.45
     # via
     #   -r requirements/requirements.in
     #   streamlit
@@ -129,7 +130,7 @@ google-api-core[grpc]==2.25.1
     #   google-cloud-bigquery
     #   google-cloud-core
     #   google-generativeai
-google-api-python-client==2.174.0
+google-api-python-client==2.177.0
     # via google-generativeai
 google-auth==2.40.3
     # via
@@ -142,7 +143,7 @@ google-auth==2.40.3
     #   google-generativeai
 google-auth-httplib2==0.2.0
     # via google-api-python-client
-google-cloud-bigquery==3.34.0
+google-cloud-bigquery==3.35.1
     # via -r requirements/requirements-dev.in
 google-cloud-core==2.4.3
     # via google-cloud-bigquery
@@ -162,13 +163,13 @@ greenlet==3.2.3
     #   sqlalchemy
 grep-ast==0.9.0
     # via -r requirements/requirements.in
-griffe==1.7.3
+griffe==1.9.0
     # via banks
-grpcio==1.73.0
+grpcio==1.74.0
     # via
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.71.0
+grpcio-status==1.71.2
     # via google-api-core
 h11==0.16.0
     # via httpcore
@@ -185,7 +186,7 @@ httpx==0.28.1
     #   litellm
     #   llama-index-core
     #   openai
-huggingface-hub[inference]==0.33.1
+huggingface-hub[inference]==0.34.3
     # via
     #   llama-index-embeddings-huggingface
     #   sentence-transformers
@@ -224,7 +225,7 @@ joblib==1.5.1
     #   scikit-learn
 json5==0.12.0
     # via -r requirements/requirements.in
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   -r requirements/requirements.in
     #   altair
@@ -233,7 +234,7 @@ jsonschema-specifications==2025.4.1
     # via jsonschema
 kiwisolver==1.4.8
     # via matplotlib
-litellm==1.73.1
+litellm==1.74.9.post1
     # via -r requirements/requirements.in
 llama-index-core==0.12.26
     # via
@@ -261,7 +262,7 @@ mpmath==1.3.0
     # via sympy
 mslex==1.3.0
     # via oslex
-multidict==6.5.1
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl
@@ -269,7 +270,7 @@ multiprocess==0.70.18
     # via pathos
 mypy-extensions==1.1.0
     # via typing-inspect
-narwhals==1.44.0
+narwhals==2.0.1
     # via altair
 nest-asyncio==1.6.0
     # via llama-index-core
@@ -295,7 +296,38 @@ numpy==1.26.4
     #   soundfile
     #   streamlit
     #   transformers
-openai==1.91.0
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via torch
+nvidia-cufft-cu12==11.0.2.54
+    # via torch
+nvidia-curand-cu12==10.3.2.106
+    # via torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.19.3
+    # via torch
+nvidia-nvjitlink-cu12==12.9.86
+    # via
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via torch
+openai==1.97.1
     # via litellm
 oslex==0.1.3
     # via -r requirements/requirements.in
@@ -311,7 +343,7 @@ packaging==25.0
     #   pytest
     #   streamlit
     #   transformers
-pandas==2.3.0
+pandas==2.3.1
     # via
     #   -r requirements/requirements-dev.in
     #   streamlit
@@ -323,7 +355,7 @@ pathspec==0.12.1
     #   grep-ast
 pexpect==4.9.0
     # via -r requirements/requirements.in
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -r requirements/requirements.in
     #   llama-index-core
@@ -338,11 +370,11 @@ platformdirs==4.3.8
     # via
     #   banks
     #   virtualenv
-playwright==1.52.0
+playwright==1.54.0
     # via -r requirements/requirements-playwright.in
 pluggy==1.6.0
     # via pytest
-posthog==5.4.0
+posthog==6.3.1
     # via -r requirements/requirements.in
 pox==0.3.6
     # via pathos
@@ -373,7 +405,7 @@ psutil==7.0.0
     # via -r requirements/requirements.in
 ptyprocess==0.7.0
     # via pexpect
-pyarrow==20.0.0
+pyarrow==21.0.0
     # via streamlit
 pyasn1==0.6.1
     # via
@@ -445,7 +477,7 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2024.11.6
+regex==2025.7.31
     # via
     #   nltk
     #   tiktoken
@@ -461,11 +493,11 @@ requests==2.32.4
     #   streamlit
     #   tiktoken
     #   transformers
-rich==14.0.0
+rich==14.1.0
     # via
     #   -r requirements/requirements.in
     #   typer
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   jsonschema
     #   referencing
@@ -473,7 +505,7 @@ rsa==4.9.1
     # via google-auth
 safetensors==0.5.3
     # via transformers
-scikit-learn==1.7.0
+scikit-learn==1.7.1
     # via sentence-transformers
 scipy==1.15.3
     # via
@@ -482,7 +514,7 @@ scipy==1.15.3
     #   sentence-transformers
 semver==3.0.4
     # via -r requirements/requirements-dev.in
-sentence-transformers==4.1.0
+sentence-transformers==5.0.0
     # via llama-index-embeddings-huggingface
 setuptools==80.9.0
     # via pip-tools
@@ -509,9 +541,9 @@ soundfile==0.13.1
     # via -r requirements/requirements.in
 soupsieve==2.7
     # via beautifulsoup4
-sqlalchemy[asyncio]==2.0.41
+sqlalchemy[asyncio]==2.0.42
     # via llama-index-core
-streamlit==1.46.0
+streamlit==1.47.1
     # via -r requirements/requirements-browser.in
 sympy==1.14.0
     # via torch
@@ -525,7 +557,7 @@ tiktoken==0.9.0
     # via
     #   litellm
     #   llama-index-core
-tokenizers==0.21.2
+tokenizers==0.21.4
     # via
     #   litellm
     #   transformers
@@ -546,22 +578,25 @@ tqdm==4.67.1
     #   openai
     #   sentence-transformers
     #   transformers
-transformers==4.52.4
+transformers==4.54.1
     # via sentence-transformers
-tree-sitter==0.24.0
+tree-sitter==0.25.0
     # via tree-sitter-language-pack
 tree-sitter-c-sharp==0.23.1
     # via tree-sitter-language-pack
 tree-sitter-embedded-template==0.23.2
     # via tree-sitter-language-pack
-tree-sitter-language-pack==0.8.0
+tree-sitter-language-pack==0.9.0
     # via grep-ast
 tree-sitter-yaml==0.7.1
     # via tree-sitter-language-pack
+triton==2.2.0
+    # via torch
 typer==0.16.0
     # via -r requirements/requirements-dev.in
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
+    #   aiosignal
     #   altair
     #   anyio
     #   beautifulsoup4
@@ -569,6 +604,7 @@ typing-extensions==4.14.0
     #   huggingface-hub
     #   llama-index-core
     #   openai
+    #   posthog
     #   pydantic
     #   pydantic-core
     #   pyee
@@ -594,10 +630,12 @@ urllib3==2.5.0
     # via
     #   mixpanel
     #   requests
-uv==0.7.15
+uv==0.8.3
     # via -r requirements/requirements-dev.in
-virtualenv==20.31.2
+virtualenv==20.32.0
     # via pre-commit
+watchdog==6.0.0
+    # via streamlit
 watchfiles==1.1.0
     # via -r requirements/requirements.in
 wcwidth==0.2.13

--- a/requirements/requirements-browser.txt
+++ b/requirements/requirements-browser.txt
@@ -17,7 +17,7 @@ cachetools==5.5.2
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-certifi==2025.6.15
+certifi==2025.7.14
     # via
     #   -c requirements/common-constraints.txt
     #   requests
@@ -33,7 +33,7 @@ gitdb==4.0.12
     # via
     #   -c requirements/common-constraints.txt
     #   gitpython
-gitpython==3.1.44
+gitpython==3.1.45
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
@@ -46,7 +46,7 @@ jinja2==3.1.6
     #   -c requirements/common-constraints.txt
     #   altair
     #   pydeck
-jsonschema==4.24.0
+jsonschema==4.25.0
     # via
     #   -c requirements/common-constraints.txt
     #   altair
@@ -58,7 +58,7 @@ markupsafe==3.0.2
     # via
     #   -c requirements/common-constraints.txt
     #   jinja2
-narwhals==1.44.0
+narwhals==2.0.1
     # via
     #   -c requirements/common-constraints.txt
     #   altair
@@ -73,11 +73,11 @@ packaging==25.0
     #   -c requirements/common-constraints.txt
     #   altair
     #   streamlit
-pandas==2.3.0
+pandas==2.3.1
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
@@ -85,7 +85,7 @@ protobuf==5.29.5
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-pyarrow==20.0.0
+pyarrow==21.0.0
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
@@ -110,7 +110,7 @@ requests==2.32.4
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-rpds-py==0.25.1
+rpds-py==0.26.0
     # via
     #   -c requirements/common-constraints.txt
     #   jsonschema
@@ -123,7 +123,7 @@ smmap==5.0.2
     # via
     #   -c requirements/common-constraints.txt
     #   gitdb
-streamlit==1.46.0
+streamlit==1.47.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-browser.in
@@ -139,7 +139,7 @@ tornado==6.5.1
     # via
     #   -c requirements/common-constraints.txt
     #   streamlit
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -c requirements/common-constraints.txt
     #   altair
@@ -153,3 +153,7 @@ urllib3==2.5.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests
+watchdog==6.0.0
+    # via
+    #   -c requirements/common-constraints.txt
+    #   streamlit

--- a/requirements/requirements-dev.txt
+++ b/requirements/requirements-dev.txt
@@ -8,7 +8,7 @@ cachetools==5.5.2
     # via
     #   -c requirements/common-constraints.txt
     #   google-auth
-certifi==2025.6.15
+certifi==2025.7.14
     # via
     #   -c requirements/common-constraints.txt
     #   requests
@@ -33,7 +33,7 @@ cogapp==3.5.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
-contourpy==1.3.2
+contourpy==1.3.3
     # via
     #   -c requirements/common-constraints.txt
     #   matplotlib
@@ -46,7 +46,7 @@ dill==0.4.0
     #   -c requirements/common-constraints.txt
     #   multiprocess
     #   pathos
-distlib==0.3.9
+distlib==0.4.0
     # via
     #   -c requirements/common-constraints.txt
     #   virtualenv
@@ -54,7 +54,7 @@ filelock==3.18.0
     # via
     #   -c requirements/common-constraints.txt
     #   virtualenv
-fonttools==4.58.4
+fonttools==4.59.0
     # via
     #   -c requirements/common-constraints.txt
     #   matplotlib
@@ -69,7 +69,7 @@ google-auth==2.40.3
     #   google-api-core
     #   google-cloud-bigquery
     #   google-cloud-core
-google-cloud-bigquery==3.34.0
+google-cloud-bigquery==3.35.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
@@ -90,12 +90,12 @@ googleapis-common-protos==1.70.0
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio==1.73.0
+grpcio==1.74.0
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   grpcio-status
-grpcio-status==1.71.0
+grpcio-status==1.71.2
     # via
     #   -c requirements/common-constraints.txt
     #   google-api-core
@@ -156,7 +156,7 @@ packaging==25.0
     #   google-cloud-bigquery
     #   matplotlib
     #   pytest
-pandas==2.3.0
+pandas==2.3.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
@@ -164,7 +164,7 @@ pathos==0.3.4
     # via
     #   -c requirements/common-constraints.txt
     #   lox
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   matplotlib
@@ -258,7 +258,7 @@ requests==2.32.4
     #   -c requirements/common-constraints.txt
     #   google-api-core
     #   google-cloud-bigquery
-rich==14.0.0
+rich==14.1.0
     # via
     #   -c requirements/common-constraints.txt
     #   typer
@@ -286,7 +286,7 @@ typer==0.16.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -c requirements/common-constraints.txt
     #   typer
@@ -298,11 +298,11 @@ urllib3==2.5.0
     # via
     #   -c requirements/common-constraints.txt
     #   requests
-uv==0.7.15
+uv==0.8.3
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-dev.in
-virtualenv==20.31.2
+virtualenv==20.32.0
     # via
     #   -c requirements/common-constraints.txt
     #   pre-commit

--- a/requirements/requirements-help.txt
+++ b/requirements/requirements-help.txt
@@ -4,12 +4,12 @@ aiohappyeyeballs==2.6.1
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
-aiohttp==3.12.13
+aiohttp==3.12.15
     # via
     #   -c requirements/common-constraints.txt
     #   huggingface-hub
     #   llama-index-core
-aiosignal==1.3.2
+aiosignal==1.4.0
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
@@ -25,11 +25,11 @@ attrs==25.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
-banks==2.1.2
+banks==2.2.0
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
-certifi==2025.6.15
+certifi==2025.7.14
     # via
     #   -c requirements/common-constraints.txt
     #   httpcore
@@ -66,6 +66,7 @@ filelock==3.18.0
     #   huggingface-hub
     #   torch
     #   transformers
+    #   triton
 filetype==1.2.0
     # via
     #   -c requirements/common-constraints.txt
@@ -75,7 +76,7 @@ frozenlist==1.7.0
     #   -c requirements/common-constraints.txt
     #   aiohttp
     #   aiosignal
-fsspec==2025.5.1
+fsspec==2025.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   huggingface-hub
@@ -85,7 +86,7 @@ greenlet==3.2.3
     # via
     #   -c requirements/common-constraints.txt
     #   sqlalchemy
-griffe==1.7.3
+griffe==1.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   banks
@@ -105,7 +106,7 @@ httpx==0.28.1
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
-huggingface-hub[inference]==0.33.1
+huggingface-hub[inference]==0.34.3
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-embeddings-huggingface
@@ -150,7 +151,7 @@ mpmath==1.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   sympy
-multidict==6.5.1
+multidict==6.6.3
     # via
     #   -c requirements/common-constraints.txt
     #   aiohttp
@@ -180,13 +181,65 @@ numpy==1.26.4
     #   scikit-learn
     #   scipy
     #   transformers
+nvidia-cublas-cu12==12.1.3.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cudnn-cu12
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-cuda-cupti-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cuda-nvrtc-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cuda-runtime-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cudnn-cu12==8.9.2.26
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cufft-cu12==11.0.2.54
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-curand-cu12==10.3.2.106
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cusolver-cu12==11.4.5.107
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-cusparse-cu12==12.1.0.106
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cusolver-cu12
+    #   torch
+nvidia-nccl-cu12==2.19.3
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
+nvidia-nvjitlink-cu12==12.9.86
+    # via
+    #   -c requirements/common-constraints.txt
+    #   nvidia-cusolver-cu12
+    #   nvidia-cusparse-cu12
+nvidia-nvtx-cu12==12.1.105
+    # via
+    #   -c requirements/common-constraints.txt
+    #   torch
 packaging==25.0
     # via
     #   -c requirements/common-constraints.txt
     #   huggingface-hub
     #   marshmallow
     #   transformers
-pillow==11.2.1
+pillow==11.3.0
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
@@ -215,7 +268,7 @@ pyyaml==6.0.2
     #   huggingface-hub
     #   llama-index-core
     #   transformers
-regex==2024.11.6
+regex==2025.7.31
     # via
     #   -c requirements/common-constraints.txt
     #   nltk
@@ -232,7 +285,7 @@ safetensors==0.5.3
     # via
     #   -c requirements/common-constraints.txt
     #   transformers
-scikit-learn==1.7.0
+scikit-learn==1.7.1
     # via
     #   -c requirements/common-constraints.txt
     #   sentence-transformers
@@ -241,7 +294,7 @@ scipy==1.15.3
     #   -c requirements/common-constraints.txt
     #   scikit-learn
     #   sentence-transformers
-sentence-transformers==4.1.0
+sentence-transformers==5.0.0
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-embeddings-huggingface
@@ -249,7 +302,7 @@ sniffio==1.3.1
     # via
     #   -c requirements/common-constraints.txt
     #   anyio
-sqlalchemy[asyncio]==2.0.41
+sqlalchemy[asyncio]==2.0.42
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
@@ -269,7 +322,7 @@ tiktoken==0.9.0
     # via
     #   -c requirements/common-constraints.txt
     #   llama-index-core
-tokenizers==0.21.2
+tokenizers==0.21.4
     # via
     #   -c requirements/common-constraints.txt
     #   transformers
@@ -286,13 +339,18 @@ tqdm==4.67.1
     #   nltk
     #   sentence-transformers
     #   transformers
-transformers==4.52.4
+transformers==4.54.1
     # via
     #   -c requirements/common-constraints.txt
     #   sentence-transformers
-typing-extensions==4.14.0
+triton==2.2.0
     # via
     #   -c requirements/common-constraints.txt
+    #   torch
+typing-extensions==4.14.1
+    # via
+    #   -c requirements/common-constraints.txt
+    #   aiosignal
     #   anyio
     #   huggingface-hub
     #   llama-index-core

--- a/requirements/requirements-playwright.txt
+++ b/requirements/requirements-playwright.txt
@@ -4,7 +4,7 @@ greenlet==3.2.3
     # via
     #   -c requirements/common-constraints.txt
     #   playwright
-playwright==1.52.0
+playwright==1.54.0
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements-playwright.in
@@ -12,7 +12,7 @@ pyee==13.0.0
     # via
     #   -c requirements/common-constraints.txt
     #   playwright
-typing-extensions==4.14.0
+typing-extensions==4.14.1
     # via
     #   -c requirements/common-constraints.txt
     #   pyee


### PR DESCRIPTION
LiteLLM needs a bump because of #4382 - the dependency is unconstrained in `requirements/requirements.in`, so it seems the best way was to just run the pip compile script with `--upgrade`.

Draft PR as I need to run CI in GH, as it is difficult to run locally.