### PR TITLE
Add test results for GLM 4.5 (thinking & non-thinking modes) model to polyglot leaderboard

### DIFF
--- a/aider/website/_data/polyglot_leaderboard.yml
+++ b/aider/website/_data/polyglot_leaderboard.yml
@@ -1683,3 +1683,31 @@
   versions: 0.85.3.dev
   seconds_per_case: 67.6
   total_cost: 1.2357
+
+- dirname: 2025-08-03-13-07-25--glm-4.5-polyglot
+  test_cases: 225
+  model: openrouter/z-ai/glm-4.5
+  edit_format: diff
+  commit_hash: f38200c
+  pass_rate_1: 15.1
+  pass_rate_2: 38.7
+  pass_num_1: 34
+  pass_num_2: 87
+  percent_cases_well_formed: 96.9
+  error_outputs: 25
+  num_malformed_responses: 9
+  num_with_malformed_responses: 7
+  user_asks: 83
+  lazy_comments: 0
+  syntax_errors: 0
+  indentation_errors: 0
+  exhausted_context_windows: 0
+  prompt_tokens: 2352344
+  completion_tokens: 354322
+  test_timeouts: 7
+  total_tests: 225
+  command: aider --model openrouter/z-ai/glm-4.5
+  date: 2025-08-03
+  versions: 0.85.3.dev
+  seconds_per_case: 38.8
+  total_cost: 0.5413

--- a/aider/website/_data/polyglot_leaderboard.yml
+++ b/aider/website/_data/polyglot_leaderboard.yml
@@ -1711,3 +1711,31 @@
   versions: 0.85.3.dev
   seconds_per_case: 38.8
   total_cost: 0.5413
+
+- dirname: 2025-08-03-11-33-59--glm-4.5-thinking-polyglot
+  test_cases: 225
+  model: openrouter/z-ai/glm-4.5
+  edit_format: diff
+  commit_hash: f38200c
+  pass_rate_1: 20.4
+  pass_rate_2: 50.2
+  pass_num_1: 46
+  pass_num_2: 113
+  percent_cases_well_formed: 97.8
+  error_outputs: 417
+  num_malformed_responses: 7
+  num_with_malformed_responses: 5
+  user_asks: 54
+  lazy_comments: 0
+  syntax_errors: 0
+  indentation_errors: 0
+  exhausted_context_windows: 0
+  prompt_tokens: 2037070
+  completion_tokens: 1357681
+  test_timeouts: 2
+  total_tests: 225
+  command: aider --model openrouter/z-ai/glm-4.5
+  date: 2025-08-03
+  versions: 0.85.3.dev
+  seconds_per_case: 318.0
+  total_cost: 0.6790


### PR DESCRIPTION
The 2 commits add the evaluation results for the `GLM 4.5` model in both thinking and non-thinking modes.

The tests were done in diff editing format. There were many errors in tool output formatting in thinking mode (due to poor structured output adherence) but it should not affect the test results as those were retried but the costs reported are not accurate.

model settings used for non-thinking mode:
```yaml
- name: openrouter/z-ai/glm-4.5
  extra_params:
    extra_body:
      reasoning:
        enabled: false
      provider:
        ignore:
          - novita
    max_tokens: 96000
```

for thinking mode, `reasoning.enabled` was set to `true`.

The benchmark exercise folders are attached for reference

[2025-08-03-11-33-59--glm-4.5-thinking-polyglot.zip](https://github.com/user-attachments/files/21566144/2025-08-03-11-33-59--glm-4.5-thinking-polyglot.zip)
[2025-08-03-13-07-25--glm-4.5-polyglot.zip](https://github.com/user-attachments/files/21566145/2025-08-03-13-07-25--glm-4.5-polyglot.zip)