### PR TITLE
Feature request: support for Bedrock/Claude 4.5 

### DIFF
--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -1546,6 +1546,20 @@
   editor_edit_format: editor-diff
   accepts_settings: ["thinking_tokens"]
 
+- name: bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0
+  edit_format: diff
+  weak_model_name: bedrock/anthropic.claude-3-5-haiku-20241022-v1:0
+  use_repo_map: true
+  examples_as_sys_msg: false
+  extra_params:
+    extra_headers:
+      anthropic-beta: prompt-caching-2024-07-31,pdfs-2024-09-25,output-128k-2025-02-19
+    max_tokens: 64000
+  cache_control: true
+  editor_model_name: bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0
+  editor_edit_format: editor-diff
+  accepts_settings: ["thinking_tokens"]
+
 - name: bedrock_converse/anthropic.claude-sonnet-4-20250514-v1:0
   edit_format: diff
   weak_model_name: bedrock_converse/anthropic.claude-3-5-haiku-20241022-v1:0


### PR DESCRIPTION
Support for Bedrock/Claude 4.5.

Announced here:
https://aws.amazon.com/blogs/aws/introducing-claude-sonnet-4-5-in-amazon-bedrock-anthropics-most-intelligent-model-best-for-coding-and-complex-agents/

Proposed model name:
bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0

Fixes: https://github.com/Aider-AI/aider/issues/4543
#4543