### PR TITLE
Remove duplicate instruction "Always reply to the user in {language}"

### DIFF
--- a/aider/coders/editblock_prompts.py
+++ b/aider/coders/editblock_prompts.py
@@ -12,8 +12,6 @@ Respect and use existing conventions, libraries, etc that are already present in
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
-Always reply to the user in {language}.
-
 Once you understand the request you MUST:
 
 1. Decide if you need to propose *SEARCH/REPLACE* edits to any files that haven't been added to the chat. You can create new files without asking!

--- a/aider/coders/patch_prompts.py
+++ b/aider/coders/patch_prompts.py
@@ -15,8 +15,6 @@ Respect and use existing conventions, libraries, etc that are already present in
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
-Always reply to the user in {language}.
-
 Once you understand the request you MUST:
 
 1. Decide if you need to propose edits to any files that haven't been added to the chat. You can create new files without asking!

--- a/aider/coders/udiff_prompts.py
+++ b/aider/coders/udiff_prompts.py
@@ -13,8 +13,6 @@ Respect and use existing conventions, libraries, etc that are already present in
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
 
-Always reply to the user in {language}.
-
 For each file that needs to be changed, write out the changes similar to a unified diff like `diff -U0` would produce.
 """
 

--- a/aider/coders/wholefile_prompts.py
+++ b/aider/coders/wholefile_prompts.py
@@ -7,9 +7,6 @@ class WholeFilePrompts(CoderPrompts):
     main_system = """Act as an expert software developer.
 Take requests for changes to the supplied code.
 If the request is ambiguous, ask questions.
-
-Always reply to the user in {language}.
-
 {final_reminders}
 Once you understand the request you MUST:
 1. Determine if any code changes are needed.


### PR DESCRIPTION
After refactoring of the final reminders in 849a379a8cc51f94981be86cb73d311dd6eb5dac, the instruction in which language llm should respond became duplicated at the begining of the system prompt. So begining of the system prompt now looks like:
```
Act as an expert software developer.
Always use best practices when coding.
Respect and use existing conventions, libraries, etc that are already present in the code base.
You are diligent and tireless!
You NEVER leave comments describing code without implementing it!
You always COMPLETELY IMPLEMENT the needed code!


Reply in English.

Take requests for changes to the supplied code.
If the request is ambiguous, ask questions.

Always reply to the user in English.
```

The first line `Reply in English.` appears from `final_reminders` (added in `Coder.fmt_system_prompt`) and second one `Always reply to the user in English.` is specified in `main_system` prompts themselves.

In the pull request I have removed `Always reply to the user in English.` from all prompts, where `final_reminders` are used. In prompts, where `final_reminders` aren't used (ask, architect and context modes) this line left unchanged.

So after this change begining of system prompt will look like:
```
Act as an expert software developer.
Always use best practices when coding.
Respect and use existing conventions, libraries, etc that are already present in the code base.
You are diligent and tireless!
You NEVER leave comments describing code without implementing it!
You always COMPLETELY IMPLEMENT the needed code!


Reply in English.

Take requests for changes to the supplied code.
If the request is ambiguous, ask questions.
```

