### PR TITLE
fix: handle missing litellm exception classes gracefully

### DIFF
--- a/aider/exceptions.py
+++ b/aider/exceptions.py
@@ -76,7 +76,9 @@ class LiteLLMExceptions:
                     raise ValueError(f"{var} is in litellm but not in aider's exceptions list")
 
         for var in self.exception_info:
-            ex = getattr(litellm, var)
+            ex = getattr(litellm, var, None)
+            if ex is None:
+                continue
             self.exceptions[ex] = self.exception_info[var]
 
     def exceptions_tuple(self):

--- a/tests/basic/test_exceptions.py
+++ b/tests/basic/test_exceptions.py
@@ -102,3 +102,31 @@ def test_openrouter_error():
     assert "OpenRouter" in ex_info.description
     assert "overloaded" in ex_info.description
     assert "rate" in ex_info.description
+
+
+def test_missing_litellm_exception_does_not_crash():
+    """Regression test for issue #4957.
+
+    When a litellm version removes or renames an exception class,
+    LiteLLMExceptions() should not raise AttributeError.
+    """
+    import litellm
+
+    # Temporarily remove an exception class to simulate a litellm upgrade
+    # that drops or renames it
+    # Save and clear shared class state so previous tests don't interfere
+    saved_exceptions = LiteLLMExceptions.exceptions
+    LiteLLMExceptions.exceptions = {}
+
+    original = litellm.APIConnectionError
+    delattr(litellm, "APIConnectionError")
+    try:
+        # Should not raise — this is the core regression assertion
+        exc = LiteLLMExceptions()
+        # APIConnectionError should be skipped, others loaded
+        loaded_names = {info.name for info in exc.exceptions.values()}
+        assert "APIConnectionError" not in loaded_names
+        assert len(exc.exceptions) > 0
+    finally:
+        litellm.APIConnectionError = original
+        LiteLLMExceptions.exceptions = saved_exceptions


### PR DESCRIPTION
## Problem
When a litellm version removes or renames an exception class, `LiteLLMExceptions._load()` crashes with an uncaught `AttributeError` because `getattr(litellm, var)` is called without a default value.

## Root Cause
In `aider/exceptions.py` line 78, the code iterates over `self.exception_info` and calls `getattr(litellm, var)` — if the attribute doesn't exist (e.g., litellm dropped or renamed it), this raises `AttributeError`.

## Fix
Use `getattr(litellm, var, None)` with a `continue` to gracefully skip missing exception classes instead of crashing. This is a 2-line change.

## Tests
- Added `test_missing_litellm_exception_does_not_crash` regression test that temporarily removes `litellm.APIConnectionError` and verifies `LiteLLMExceptions()` still loads without error

Fixes #4957