### PR TITLE
feat: add Kyma API models (via OpenAI-compatible endpoint)

### DIFF
--- a/aider/resources/model-metadata.json
+++ b/aider/resources/model-metadata.json
@@ -711,5 +711,102 @@
   "together_ai/Qwen/Qwen3-235B-A22B-fp8-tput": {
         "input_cost_per_token": 0.0000002,
         "output_cost_per_token": 0.0000006,
-  }
+  },
+    "openai/qwen-3.6-plus": {
+        "max_tokens": 8192,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000439,
+        "output_cost_per_token": 0.000002633,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    },
+    "openai/deepseek-v3": {
+        "max_tokens": 8192,
+        "max_input_tokens": 160000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000810,
+        "output_cost_per_token": 0.000002295,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    },
+    "openai/deepseek-r1": {
+        "max_tokens": 8192,
+        "max_input_tokens": 64000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000675,
+        "output_cost_per_token": 0.000002903,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": false,
+        "supports_tool_choice": false,
+        "supports_system_messages": true
+    },
+    "openai/kimi-k2.5": {
+        "max_tokens": 8192,
+        "max_input_tokens": 262144,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000675,
+        "output_cost_per_token": 0.000003780,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    },
+    "openai/gemma-4-31b": {
+        "max_tokens": 8192,
+        "max_input_tokens": 128000,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000189,
+        "output_cost_per_token": 0.000000540,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_vision": true,
+        "supports_system_messages": true
+    },
+    "openai/qwen-3-32b": {
+        "max_tokens": 8192,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000392,
+        "output_cost_per_token": 0.000000810,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    },
+    "openai/llama-3.3-70b": {
+        "max_tokens": 8192,
+        "max_input_tokens": 131072,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000001188,
+        "output_cost_per_token": 0.000001188,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    },
+    "openai/minimax-m2.5": {
+        "max_tokens": 8192,
+        "max_input_tokens": 196608,
+        "max_output_tokens": 8192,
+        "input_cost_per_token": 0.000000405,
+        "output_cost_per_token": 0.000001620,
+        "litellm_provider": "openai",
+        "mode": "chat",
+        "supports_function_calling": true,
+        "supports_tool_choice": true,
+        "supports_system_messages": true
+    }
 }

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -2957,3 +2957,60 @@
   use_repo_map: true
   use_temperature: false
   accepts_settings: ["reasoning_effort"]
+
+# Kyma API models (OpenAI-compatible gateway, set --openai-api-base https://kymaapi.com/v1)
+- name: openai/qwen-3.6-plus
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/deepseek-v3
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/deepseek-r1
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/kimi-k2.5
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/gemma-4-31b
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/qwen-3-32b
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/llama-3.3-70b
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192
+
+- name: openai/minimax-m2.5
+  edit_format: diff
+  use_repo_map: true
+  examples_as_sys_msg: true
+  extra_params:
+    max_tokens: 8192


### PR DESCRIPTION
## Summary

[Kyma API](https://kymaapi.com) is an OpenAI-compatible LLM gateway that serves open-source models under a single unified endpoint. Users can access it by setting:

```
--openai-api-base https://kymaapi.com/v1
--openai-api-key <your-kyma-api-key>
```

This PR adds model metadata and behavioral settings for 8 top Kyma models so that Aider can correctly price tokens, set context limits, and use optimal edit formats.

## Models added

| Model | Context | Input $/1M | Output $/1M | Notes |
|---|---|---|---|---|
| `openai/qwen-3.6-plus` | 131K | $0.439 | $2.633 | Top-tier coding/reasoning |
| `openai/deepseek-v3` | 160K | $0.810 | $2.295 | GPT-4-class, high throughput |
| `openai/deepseek-r1` | 64K | $0.675 | $2.903 | Reasoning model (no tool calling) |
| `openai/kimi-k2.5` | 262K | $0.675 | $3.780 | Long-context, agentic |
| `openai/gemma-4-31b` | 128K | $0.189 | $0.540 | Multimodal (vision supported) |
| `openai/qwen-3-32b` | 131K | $0.392 | $0.810 | Fast coding model |
| `openai/llama-3.3-70b` | 131K | $1.188 | $1.188 | Popular open-weight baseline |
| `openai/minimax-m2.5` | 196K | $0.405 | $1.620 | SWE-bench top performer |

## Files changed

- `aider/resources/model-metadata.json` — token costs, context limits, capability flags
- `aider/resources/model-settings.yml` — `diff` edit format, `use_repo_map: true`, `examples_as_sys_msg: true`, `max_tokens: 8192`

All models use `diff` edit format and repo map, matching the pattern used for similar-tier models in the file.

## References

- Kyma API docs: https://kymaapi.com
- Models are accessed via OpenAI-compatible `/v1/chat/completions` endpoint