### PR TITLE
Add Perplexity as a model provider

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -721,6 +721,7 @@ class Model(ModelSettings):
             anthropic="ANTHROPIC_API_KEY",
             groq="GROQ_API_KEY",
             fireworks_ai="FIREWORKS_API_KEY",
+            perplexity="PERPLEXITY_API_KEY",
         )
         var = None
         if model in OPENAI_MODELS:

--- a/aider/onboarding.py
+++ b/aider/onboarding.py
@@ -66,6 +66,7 @@ def try_to_select_default_model():
         ("OPENAI_API_KEY", "gpt-4o"),
         ("GEMINI_API_KEY", "gemini/gemini-2.5-pro-exp-03-25"),
         ("VERTEXAI_PROJECT", "vertex_ai/gemini-2.5-pro-exp-03-25"),
+        ("PERPLEXITY_API_KEY", "perplexity/sonar-pro"),
     ]
 
     for env_key, model_name in model_key_pairs:

--- a/aider/resources/model-settings.yml
+++ b/aider/resources/model-settings.yml
@@ -3126,3 +3126,44 @@
   use_repo_map: true
   use_temperature: false
   accepts_settings: ["reasoning_effort"]
+
+- name: perplexity/sonar-pro
+  edit_format: diff
+  weak_model_name: perplexity/sonar
+  use_repo_map: true
+  examples_as_sys_msg: true
+  editor_model_name: perplexity/sonar-pro
+  editor_edit_format: editor-diff
+
+- name: perplexity/sonar
+  edit_format: whole
+  weak_model_name: perplexity/sonar
+  use_repo_map: true
+  examples_as_sys_msg: true
+
+- name: perplexity/sonar-reasoning
+  edit_format: diff
+  weak_model_name: perplexity/sonar
+  use_repo_map: true
+  examples_as_sys_msg: true
+  use_temperature: false
+  editor_model_name: perplexity/sonar-pro
+  editor_edit_format: editor-diff
+
+- name: perplexity/sonar-reasoning-pro
+  edit_format: diff
+  weak_model_name: perplexity/sonar
+  use_repo_map: true
+  examples_as_sys_msg: true
+  use_temperature: false
+  editor_model_name: perplexity/sonar-pro
+  editor_edit_format: editor-diff
+
+- name: perplexity/sonar-deep-research
+  edit_format: diff
+  weak_model_name: perplexity/sonar
+  use_repo_map: true
+  examples_as_sys_msg: true
+  use_temperature: false
+  editor_model_name: perplexity/sonar-pro
+  editor_edit_format: editor-diff

--- a/aider/website/docs/llms/perplexity.md
+++ b/aider/website/docs/llms/perplexity.md
@@ -1,0 +1,55 @@
+---
+parent: Connecting to LLMs
+nav_order: 510
+---
+
+# Perplexity
+
+Aider can connect to [Perplexity's Sonar models](https://docs.perplexity.ai/models/model-cards)
+through Perplexity's OpenAI-compatible Agent API.
+You'll need a [Perplexity API key](https://www.perplexity.ai/settings/api).
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your API keys:
+
+```
+export PERPLEXITY_API_KEY=<key> # Mac/Linux
+setx   PERPLEXITY_API_KEY <key> # Windows, restart shell after setx
+```
+
+Start working with aider and Perplexity on your codebase:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+# Use Perplexity's default Sonar Pro model
+aider --model perplexity/sonar-pro
+
+# Or any other Perplexity model
+aider --model perplexity/sonar
+aider --model perplexity/sonar-reasoning
+aider --model perplexity/sonar-reasoning-pro
+aider --model perplexity/sonar-deep-research
+
+# List models available from Perplexity
+aider --list-models perplexity/
+```
+
+Perplexity exposes an OpenAI-compatible Agent API at
+`https://api.perplexity.ai`, so requests go through aider's standard
+OpenAI-compatible client (via LiteLLM).
+
+## Available models
+
+- `perplexity/sonar` — fast, lightweight Sonar model
+- `perplexity/sonar-pro` — flagship Sonar model (default)
+- `perplexity/sonar-reasoning` — Sonar with chain-of-thought reasoning
+- `perplexity/sonar-reasoning-pro` — high-capacity reasoning model
+- `perplexity/sonar-deep-research` — long-form research model
+
+See [Perplexity's documentation](https://docs.perplexity.ai) for the latest
+model list, pricing, and feature details.

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -596,5 +596,36 @@ class TestModels(unittest.TestCase):
                 self.assertIn("reasoning_effort", model.accepts_settings)
 
 
+    def test_perplexity_model_settings(self):
+        names = [
+            "perplexity/sonar",
+            "perplexity/sonar-pro",
+            "perplexity/sonar-reasoning",
+            "perplexity/sonar-reasoning-pro",
+            "perplexity/sonar-deep-research",
+        ]
+
+        for name in names:
+            with self.subTest(name=name):
+                model = Model(name)
+                self.assertTrue(model.use_repo_map)
+                self.assertTrue(model.examples_as_sys_msg)
+
+        # Default integration model uses diff format
+        self.assertEqual(Model("perplexity/sonar-pro").edit_format, "diff")
+        self.assertEqual(
+            Model("perplexity/sonar-pro").weak_model_name, "perplexity/sonar"
+        )
+
+        # Reasoning models should not pass temperature
+        for name in (
+            "perplexity/sonar-reasoning",
+            "perplexity/sonar-reasoning-pro",
+            "perplexity/sonar-deep-research",
+        ):
+            with self.subTest(name=name):
+                self.assertFalse(Model(name).use_temperature)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/basic/test_onboarding.py
+++ b/tests/basic/test_onboarding.py
@@ -138,6 +138,13 @@ class TestOnboarding(unittest.TestCase):
         self.assertEqual(try_to_select_default_model(), "vertex_ai/gemini-2.5-pro-exp-03-25")
         mock_check_tier.assert_not_called()
 
+    @patch("aider.onboarding.check_openrouter_tier")
+    @patch.dict(os.environ, {"PERPLEXITY_API_KEY": "pp_key"}, clear=True)
+    def test_try_select_default_model_perplexity(self, mock_check_tier):
+        """Test Perplexity model selection."""
+        self.assertEqual(try_to_select_default_model(), "perplexity/sonar-pro")
+        mock_check_tier.assert_not_called()
+
     @patch("aider.onboarding.check_openrouter_tier", return_value=False)  # Paid
     @patch.dict(
         os.environ, {"OPENROUTER_API_KEY": "or_key", "OPENAI_API_KEY": "oa_key"}, clear=True


### PR DESCRIPTION
## Summary

Adds [Perplexity](https://docs.perplexity.ai) as a first-class model provider in Aider, mirroring the OpenRouter integration pattern. Perplexity exposes an OpenAI-compatible Agent API at `https://api.perplexity.ai`, which LiteLLM already supports under the `perplexity/` provider prefix.

The default model in all examples is `perplexity/sonar-pro`.

## Files changed

- **`aider/website/docs/llms/perplexity.md`** — new provider docs page (mirrors `openrouter.md`)
- **`aider/resources/model-settings.yml`** — model entries for `sonar`, `sonar-pro`, `sonar-reasoning`, `sonar-reasoning-pro`, `sonar-deep-research`
- **`aider/onboarding.py`** — `PERPLEXITY_API_KEY` → `perplexity/sonar-pro` in default-model auto-selection
- **`aider/models.py`** — `perplexity` provider added to `fast_validate_environment` keymap
- **`tests/basic/test_onboarding.py`** — coverage for Perplexity env-var detection
- **`tests/basic/test_models.py`** — coverage for the new model-settings entries

## Available models

- `perplexity/sonar`
- `perplexity/sonar-pro` (default)
- `perplexity/sonar-reasoning`
- `perplexity/sonar-reasoning-pro`
- `perplexity/sonar-deep-research`

## Test plan

- [x] `pytest tests/basic/test_onboarding.py tests/basic/test_models.py` — all pass
- [x] Full `tests/basic/` suite passes (only the pre-existing `test_voice.py` failures from this sandbox's missing sound device are unrelated)
- [x] `aider --model perplexity/sonar-pro` resolves the new model settings

References: https://docs.perplexity.ai
