### PR TITLE
fix: surface provider API errors instead of showing empty response

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1802,6 +1802,16 @@ class Coder:
             )
             self.chat_completion_call_hashes.append(hash_object.hexdigest())
 
+            # Surface API-level errors from the provider response (e.g., rate
+            # limits or insufficient credits from OpenRouter) that LiteLLM may
+            # wrap in a response object rather than raising as an exception.
+            if hasattr(completion, "error") and completion.error:
+                err_msg = completion.error.get(
+                    "message", str(completion.error)
+                )
+                self.io.tool_error(f"Provider error: {err_msg}")
+                return
+
             if self.stream:
                 yield from self.show_send_output_stream(completion)
             else:
@@ -1972,7 +1982,12 @@ class Coder:
                 yield text
 
         if not received_content:
-            self.io.tool_warning("Empty response received from LLM. Check your provider account?")
+            self.io.tool_warning(
+                "No content received from LLM. "
+                "This may be due to rate limits, insufficient credits, "
+                "or the provider API being temporarily unavailable. "
+                "Use --verbose to see more details."
+            )
 
     def live_incremental_response(self, final):
         show_resp = self.render_incremental_response(final)


### PR DESCRIPTION
## Summary

Fixes #3264 — When OpenRouter or other providers return rate-limit (429) or insufficient-credits (402) errors, LiteLLM may wrap the error in a response object rather than raising an exception. Previously, aider showed "0 received" with no explanation, leaving users confused about why no response was generated.

## Changes

1. **Detect API errors in completion responses** (`send()` in `base_coder.py`): After `send_completion` returns, check if the response has an `error` field (populated by LiteLLM for API-level errors). If present, display the error message via `tool_error` and return early — avoiding the misleading token report.

2. **Improve empty-response warning** (`show_send_output_stream`): Replace the generic "Empty response received from LLM. Check your provider account?" with a more actionable message that mentions rate limits, insufficient credits, and provider availability as likely causes, and suggests `--verbose` for debugging.

## Test plan

- The error path only activates when `completion.error` is populated (currently for provider errors that LiteLLM wraps in a response)
- Successful responses are unaffected — the error check returns `None`/falsy for normal completions
- The improved warning message is a string change only

## Risk

Low. The error check is defensive and only fires when the provider returns an explicit error object. All existing success paths are unchanged.