### PR TITLE
fix: pass --no-verify-ssl to version check, fix SSL_VERIFY, add AIDER_TAGS_CACHE_DIR

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -519,7 +519,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     if not args.verify_ssl:
         import httpx
 
-        os.environ["SSL_VERIFY"] = ""
+        os.environ["SSL_VERIFY"] = "false"
         litellm._load_litellm()
         litellm._lazy_module.client_session = httpx.Client(verify=False)
         litellm._lazy_module.aclient_session = httpx.AsyncClient(verify=False)
@@ -720,7 +720,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             return main(argv, input, output, right_repo_root, return_coder=return_coder)
 
     if args.just_check_update:
-        update_available = check_version(io, just_check=True, verbose=args.verbose)
+        update_available = check_version(
+            io, just_check=True, verbose=args.verbose, verify_ssl=args.verify_ssl
+        )
         analytics.event("exit", reason="Just checking update")
         return 0 if not update_available else 1
 
@@ -735,7 +737,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         return 0 if success else 1
 
     if args.check_update:
-        check_version(io, verbose=args.verbose)
+        check_version(io, verbose=args.verbose, verify_ssl=args.verify_ssl)
 
     if args.git:
         git_root = setup_git(git_root, io)

--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -42,6 +42,14 @@ UPDATING_REPO_MAP_MESSAGE = "Updating repo map"
 class RepoMap:
     TAGS_CACHE_DIR = f".aider.tags.cache.v{CACHE_VERSION}"
 
+    @classmethod
+    def get_tags_cache_dir(cls, root):
+        """Return the tags cache directory, respecting AIDER_TAGS_CACHE_DIR."""
+        custom = os.environ.get("AIDER_TAGS_CACHE_DIR")
+        if custom:
+            return Path(custom)
+        return Path(root) / cls.TAGS_CACHE_DIR
+
     warned_files = set()
 
     def __init__(
@@ -183,7 +191,7 @@ class RepoMap:
         if isinstance(getattr(self, "TAGS_CACHE", None), dict):
             return
 
-        path = Path(self.root) / self.TAGS_CACHE_DIR
+        path = self.get_tags_cache_dir(self.root)
 
         # Try to recreate the cache
         try:
@@ -215,7 +223,7 @@ class RepoMap:
         self.TAGS_CACHE = dict()
 
     def load_tags_cache(self):
-        path = Path(self.root) / self.TAGS_CACHE_DIR
+        path = self.get_tags_cache_dir(self.root)
         try:
             self.TAGS_CACHE = Cache(path)
         except SQLITE_ERRORS as e:

--- a/aider/versioncheck.py
+++ b/aider/versioncheck.py
@@ -61,7 +61,7 @@ def install_upgrade(io, latest_version=None):
     return
 
 
-def check_version(io, just_check=False, verbose=False):
+def check_version(io, just_check=False, verbose=False, verify_ssl=True):
     if not just_check and VERSION_CHECK_FNAME.exists():
         day = 60 * 60 * 24
         since = time.time() - os.path.getmtime(VERSION_CHECK_FNAME)
@@ -75,7 +75,10 @@ def check_version(io, just_check=False, verbose=False):
     import requests
 
     try:
-        response = requests.get("https://pypi.org/pypi/aider-chat/json")
+        response = requests.get(
+            "https://pypi.org/pypi/aider-chat/json",
+            verify=verify_ssl,
+        )
         data = response.json()
         latest_version = data["info"]["version"]
         current_version = aider.__version__

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -4,6 +4,7 @@ import re
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import git
 
@@ -17,6 +18,13 @@ from aider.utils import GitTemporaryDirectory, IgnorantTemporaryDirectory
 class TestRepoMap(unittest.TestCase):
     def setUp(self):
         self.GPT35 = Model("gpt-3.5-turbo")
+
+    def test_get_tags_cache_dir_respects_env(self):
+        with IgnorantTemporaryDirectory() as root, IgnorantTemporaryDirectory() as custom:
+            with patch.dict(os.environ, {"AIDER_TAGS_CACHE_DIR": custom}):
+                self.assertEqual(RepoMap.get_tags_cache_dir(root), Path(custom))
+
+            self.assertEqual(RepoMap.get_tags_cache_dir(root), Path(root) / RepoMap.TAGS_CACHE_DIR)
 
     def test_get_repo_map(self):
         # Create a temporary directory with sample files for testing

--- a/tests/basic/test_ssl_verification.py
+++ b/tests/basic/test_ssl_verification.py
@@ -64,8 +64,8 @@ class TestSSLVerification(TestCase):
                 mock_client.assert_called_once_with(verify=False)
                 mock_async_client.assert_called_once_with(verify=False)
 
-                # Verify SSL_VERIFY environment variable was set to empty string
-                self.assertEqual(os.environ.get("SSL_VERIFY"), "")
+                # Verify SSL_VERIFY environment variable was set for LiteLLM
+                self.assertEqual(os.environ.get("SSL_VERIFY"), "false")
 
     @patch("aider.io.InputOutput.offer_url")
     @patch("aider.models.model_info_manager.set_verify_ssl")

--- a/tests/basic/test_ssl_verification.py
+++ b/tests/basic/test_ssl_verification.py
@@ -1,4 +1,6 @@
 import os
+import tempfile
+from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
@@ -6,6 +8,7 @@ from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
 
 from aider.main import main
+from aider.versioncheck import check_version
 
 
 class TestSSLVerification(TestCase):
@@ -82,3 +85,17 @@ class TestSSLVerification(TestCase):
 
                 # Verify SSL_VERIFY environment variable was not set
                 self.assertNotIn("SSL_VERIFY", os.environ)
+
+    @patch("requests.get")
+    def test_version_check_respects_ssl_setting(self, mock_get):
+        mock_get.return_value.json.return_value = {"info": {"version": "0.0.0"}}
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            version_check_file = Path(temp_dir) / "versioncheck"
+            with patch("aider.versioncheck.VERSION_CHECK_FNAME", version_check_file):
+                check_version(MagicMock(), just_check=True, verify_ssl=False)
+
+        mock_get.assert_called_once_with(
+            "https://pypi.org/pypi/aider-chat/json",
+            verify=False,
+        )


### PR DESCRIPTION
## Summary

Three focused fixes for enterprise and custom-environment users:

- Propagate `--no-verify-ssl` to the PyPI version check (Fixes #664).
- Set LiteLLM's `SSL_VERIFY` environment variable to `false` instead of an empty string.
- Support `AIDER_TAGS_CACHE_DIR` for relocating `.aider.tags.cache.v3` outside the repository (Fixes #2325).

Default behavior is unchanged when these options are not used.

## Changes

- `aider/versioncheck.py`: accept `verify_ssl` and pass it to `requests.get`.
- `aider/main.py`: forward the CLI setting to version checks and configure LiteLLM consistently.
- `aider/repomap.py`: resolve the tags-cache path from `AIDER_TAGS_CACHE_DIR` when set.
- Add focused regression coverage for SSL propagation and cache-directory selection.

## Test plan

- `python -m pytest -q --timeout=60 tests/basic/test_ssl_verification.py tests/basic/test_repomap.py::TestRepoMap::test_get_tags_cache_dir_respects_env` — 4 passed.
- `python -m compileall -q` on all changed Python files — passed.
- `flake8` on all changed Python files — passed.

## Risk

Low. The changes only affect explicitly configured SSL verification and tags-cache paths.
