### PR TITLE
Document TrustedRouter OpenAI-compatible setup

### DIFF
--- a/aider/website/docs/llms.md
+++ b/aider/website/docs/llms.md
@@ -20,6 +20,7 @@ Aider works best with these models, which are skilled at editing code:
 - [DeepSeek R1 and V3](/docs/llms/deepseek.html)
 - [Claude 3.7 Sonnet](/docs/llms/anthropic.html)
 - [OpenAI o3, o4-mini and GPT-4.1](/docs/llms/openai.html)
+- [TrustedRouter](/docs/llms/trustedrouter.html) for OpenAI-compatible private routing
 
 
 ## Free models
@@ -29,6 +30,12 @@ Aider works with a number of **free** API providers:
 
 - [OpenRouter offers free access to many models](https://openrouter.ai/models/?q=free), with limitations on daily usage.
 - Google's [Gemini 2.5 Pro Exp](/docs/llms/gemini.html) works very well with aider.
+
+## Private routing
+{: .no_toc }
+
+Aider can use [TrustedRouter](/docs/llms/trustedrouter.html) as an
+OpenAI-compatible endpoint for privacy-sensitive coding workflows.
 
 ## Local models
 {: .no_toc }
@@ -51,4 +58,3 @@ and commit the changes...
 this is usually because the model isn't capable of properly
 returning "code edits".
 Models weaker than GPT 3.5 may have problems working well with aider.
-

--- a/aider/website/docs/llms/trustedrouter.md
+++ b/aider/website/docs/llms/trustedrouter.md
@@ -1,0 +1,49 @@
+---
+parent: Connecting to LLMs
+nav_order: 505
+---
+
+# TrustedRouter
+
+Aider can connect to [TrustedRouter](https://trustedrouter.com) through the
+OpenAI-compatible API. TrustedRouter provides an open-source and verifiable
+attested router with zero prompt and output logging by default. This can be
+useful when aider is working with private source code, issue context, or
+customer data.
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your TrustedRouter API key and endpoint:
+
+```
+# Mac/Linux:
+export OPENAI_API_BASE=https://api.trustedrouter.com/v1
+export OPENAI_API_KEY=<your-trustedrouter-api-key>
+
+# Windows:
+setx OPENAI_API_BASE https://api.trustedrouter.com/v1
+setx OPENAI_API_KEY <your-trustedrouter-api-key>
+# ... restart shell after setx commands
+```
+
+Start working with aider and TrustedRouter on your codebase:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+# Use automatic routing
+aider --model openai/trustedrouter/auto
+
+# Prefer zero data retention routes
+aider --model openai/trustedrouter/zdr
+
+# Prefer end-to-end encrypted routes where available
+aider --model openai/trustedrouter/e2e
+```
+
+You can also use a specific model ID exposed by TrustedRouter with the same
+`openai/` prefix.
+


### PR DESCRIPTION
This pull request adds a short TrustedRouter setup page for aider using the existing OpenAI-compatible configuration path. TrustedRouter is an open-source, verifiable attested router for privacy-sensitive coding workflows with zero prompt and output logging by default.

Users can connect by setting `OPENAI_API_BASE=https://api.trustedrouter.com/v1`, using their TrustedRouter key as `OPENAI_API_KEY`, and selecting aliases such as `openai/trustedrouter/auto`, `openai/trustedrouter/zdr`, or `openai/trustedrouter/e2e`.

Verification: `git diff --check`.