### PR TITLE
fix: skip unreadable .aider.conf.yml instead of crashing

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -32,6 +32,22 @@ def default_env_file(git_root):
     return os.path.join(git_root, ".env") if git_root else ".env"
 
 
+def _safe_open_config_file(path):
+    """Open a config file for reading, skipping unreadable paths.
+
+    configargparse opens every default_config_files entry without catching
+    PermissionError/OSError (see #5466). Return a valid empty YAML mapping
+    stream for unreadable paths so startup continues instead of crashing.
+    """
+    try:
+        return open(path, "r", encoding="utf-8")
+    except (PermissionError, OSError, IsADirectoryError):
+        import io
+
+        # YAMLConfigFileParser requires a mapping, not an empty stream.
+        return io.StringIO("{}\n")
+
+
 def get_parser(default_config_files, git_root):
     parser = configargparse.ArgumentParser(
         description="aider is AI pair programming in your terminal",
@@ -39,6 +55,7 @@ def get_parser(default_config_files, git_root):
         default_config_files=default_config_files,
         config_file_parser_class=configargparse.YAMLConfigFileParser,
         auto_env_var_prefix="AIDER_",
+        config_file_open_func=_safe_open_config_file,
     )
     # List of valid edit formats for argparse validation & shtab completion.
     # Dynamically gather them from the registered coder classes so the list

--- a/aider/main.py
+++ b/aider/main.py
@@ -479,6 +479,11 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
     parser = get_parser(default_config_files, git_root)
     try:
         args, unknown = parser.parse_known_args(argv)
+    except (PermissionError, OSError) as e:
+        # Unreadable .aider.conf.yml should not crash startup (#5466).
+        print(f"Warning: could not read an aider config file: {e}")
+        parser = get_parser([], git_root)
+        args, unknown = parser.parse_known_args(argv)
     except AttributeError as e:
         if all(word in str(e) for word in ["bool", "object", "has", "no", "attribute", "strip"]):
             if check_config_files_for_yes(default_config_files):

--- a/tests/test_safe_config_open.py
+++ b/tests/test_safe_config_open.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from unittest import mock
+
+from aider.args import _safe_open_config_file, get_parser
+
+
+def test_safe_open_config_file_readable(tmp_path):
+    conf = tmp_path / ".aider.conf.yml"
+    conf.write_text("model: gpt-4o\n", encoding="utf-8")
+    with _safe_open_config_file(str(conf)) as f:
+        assert "gpt-4o" in f.read()
+
+
+def test_safe_open_config_file_permission_denied(tmp_path):
+    conf = tmp_path / ".aider.conf.yml"
+    conf.write_text("model: gpt-4o\n", encoding="utf-8")
+    real_open = open
+
+    def boom(path, *args, **kwargs):
+        if Path(path) == conf:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch("builtins.open", side_effect=boom):
+        with _safe_open_config_file(str(conf)) as f:
+            # empty YAML mapping so YAMLConfigFileParser accepts it
+            assert f.read().strip() in ("{}", "")
+
+
+def test_get_parser_skips_unreadable_default_config(tmp_path):
+    conf = tmp_path / ".aider.conf.yml"
+    conf.write_text("model: should-not-load\n", encoding="utf-8")
+    real_open = open
+
+    def selective_open(path, *args, **kwargs):
+        if Path(path) == conf:
+            raise PermissionError(13, "Permission denied", str(path))
+        return real_open(path, *args, **kwargs)
+
+    with mock.patch("builtins.open", side_effect=selective_open):
+        parser = get_parser([str(conf)], git_root=None)
+        args, _ = parser.parse_known_args([])
+        # Unreadable conf must not crash; model stays default None
+        assert getattr(args, "model", None) is None


### PR DESCRIPTION
## Summary

Unreadable `.aider.conf.yml` no longer crashes startup (`PermissionError` from configargparse when opening default config files).

- Add `_safe_open_config_file` and pass it as `config_file_open_func` so permission-denied / OSError configs become an empty YAML mapping stream.
- Defensive fallback in `main()` if parse still raises `PermissionError`/`OSError`.
- Unit tests for readable, permission-denied, and unreadable default-config paths.

Fixes #5466

## Testing

```bash
pytest tests/test_safe_config_open.py -q
# 3 passed
```
