### PR TITLE
Fix cleanup_pure_whitespace_lines using index instead of slice for trailing newlines

### DIFF
--- a/aider/coders/udiff_coder.py
+++ b/aider/coders/udiff_coder.py
@@ -242,7 +242,8 @@ def make_new_lines_explicit(content, hunk):
 
 def cleanup_pure_whitespace_lines(lines):
     res = [
-        line if line.strip() else line[-(len(line) - len(line.rstrip("\r\n")))] for line in lines
+        line if line.strip() else line[len(line.rstrip("\r\n")) :]
+        for line in lines
     ]
     return res
 


### PR DESCRIPTION
The expression line[-(len(line) - len(line.rstrip("\r\n")))] uses a single-character index rather than a slice, so CRLF-terminated whitespace-only lines yield only \r (dropping the \n), and whitespace-only lines with no trailing newline yield the first character instead of an empty string because -0 == 0 in Python. Replacing it with the slice line[len(line.rstrip("\r\n")):] correctly preserves all trailing newline characters in every case.