### PR TITLE
docs: fix references to non-existent /read command

### DIFF
--- a/aider/website/docs/faq.md
+++ b/aider/website/docs/faq.md
@@ -91,23 +91,23 @@ There are some things you can try if you need to work with
 multiple interrelated repos:
 
 - You can run aider in repo-A where you need to make a change
-and use `/read` to add some files read-only from another repo-B.
+and use `/read-only` to add some files read-only from another repo-B.
 This can let aider see key functions or docs from the other repo.
 - You can run `aider --show-repo-map > map.md` within each
 repo to create repo maps.
 You could then run aider in repo-A and 
-use `/read ../path/to/repo-B/map.md` to share
+use `/read-only ../path/to/repo-B/map.md` to share
 a high level map of the other repo.
 - You can use aider to write documentation about a repo.
 Inside each repo, you could run `aider docs.md`
 and work with aider to write some markdown docs.
 Then while using aider to edit repo-A
-you can `/read ../path/to/repo-B/docs.md` to
+you can `/read-only ../path/to/repo-B/docs.md` to
 read in those docs from the other repo.
 - In repo A, ask aider to write a small script that demonstrates
 the functionality you want to use in repo B.
 Then when you're using aider in repo B, you can 
-`/read` in that script.
+`/read-only` in that script.
 
 ## How do I turn on the repository map?
 

--- a/aider/website/docs/usage/conventions.md
+++ b/aider/website/docs/usage/conventions.md
@@ -23,7 +23,7 @@ We would simply create a file like `CONVENTIONS.md` with those lines
 and then we can add it to the aider chat, along with the file(s)
 that we want to edit.
 
-It's best to load the conventions file with `/read CONVENTIONS.md` 
+It's best to load the conventions file with `/read-only CONVENTIONS.md` 
 or `aider --read CONVENTIONS.md`. 
 This way it is marked as read-only, and cached if prompt caching
 is enabled.

--- a/aider/website/docs/usage/copypaste.md
+++ b/aider/website/docs/usage/copypaste.md
@@ -58,7 +58,7 @@ The `/copy-context <instructions>` command can be used in chat to copy aider's c
 It will include:
 
 - All the files which have been added to the chat via `/add`.
-- Any read only files which have been added via `/read`.
+- Any read only files which have been added via `/read-only`.
 - Aider's [repository map](https://aider.chat/docs/repomap.html) that brings in code context related to the above files from elsewhere in your git repo.
 - Some instructions to the LLM that ask it to output change instructions concisely.
 - If you include `<instructions>`, they will be copied too.
@@ -80,7 +80,7 @@ This works best if you run aider with `--edit-format editor-diff` or `--edit-for
 
 Aider has a `--copy-paste` mode that streamlines this entire process:
 
-- Whenever you `/add` or `/read` files, aider will automatically copy the entire, updated
+- Whenever you `/add` or `/read-only` files, aider will automatically copy the entire, updated
 code context to your clipboard. 
 You'll see "Copied code context to clipboard" whenever this happens.
 - When you copy the LLM reply to your clipboard outside aider, aider will automatically notice

--- a/aider/website/docs/usage/tips.md
+++ b/aider/website/docs/usage/tips.md
@@ -68,7 +68,7 @@ You can provide up-to-date documentation in a few ways:
 - Paste doc snippets into the chat.
 - Include a URL to docs in your chat message
 and aider will scrape and read it. For example: `Add a submit button like this https://ui.shadcn.com/docs/components/button`. 
-- Use the [`/read` command](commands.html) to read doc files into the chat from anywhere on your filesystem.
+- Use the [`/read-only` command](commands.html) to read doc files into the chat from anywhere on your filesystem.
 - If you have coding conventions or standing instructions you want aider to follow, consider using a [conventions file](conventions.html).
 
 ## Interrupting & inputting


### PR DESCRIPTION
The in-chat command is `/read-only` (`cmd_read_only` in `aider/commands.py`); there's no `/read` command or alias anywhere in the codebase (confirmed no `cmd_read` besides `cmd_read_only`). Several docs pages still refer to the old/nonexistent `/read` spelling, and this fixes all of them:

- `aider/website/docs/faq.md`: 4 occurrences
- `aider/website/docs/usage/copypaste.md`: 2 occurrences
- `aider/website/docs/usage/tips.md`: 1 occurrence
- `aider/website/docs/usage/conventions.md`: 1 occurrence

Docs-only, no behavior change.

Fixes #4178