### PR TITLE
feat: add Model Context Protocol (MCP) support (opencode-compatible .mcp.json) - #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ aider/_version.py
 .gitattributes
 tmp.benchmarks/
 .docker_bash_history
+.idea/
+.depwire/

--- a/aider/args.py
+++ b/aider/args.py
@@ -892,6 +892,7 @@ def get_parser(default_config_files, git_root):
     group.add_argument(
         "--mcp-tool-output-limit",
         metavar="CHARS",
+        type=int,
         default=16000,
         help=(
             "Maximum number of characters of MCP tool output to send back into the chat"
@@ -901,12 +902,14 @@ def get_parser(default_config_files, git_root):
     group.add_argument(
         "--mcp-max-roundtrips",
         metavar="N",
+        type=int,
         default=0,
         help="Maximum MCP tool call roundtrips per user message (default: 0 = unlimited)",
     )
     group.add_argument(
         "--mcp-frame",
         metavar="SECONDS",
+        type=int,
         default=60,
         help="Seconds to wait for an MCP server response before timing out (default: 60)",
     )

--- a/aider/args.py
+++ b/aider/args.py
@@ -901,8 +901,8 @@ def get_parser(default_config_files, git_root):
     group.add_argument(
         "--mcp-max-roundtrips",
         metavar="N",
-        default=5,
-        help="Maximum MCP tool call roundtrips per user message (default: 5)",
+        default=0,
+        help="Maximum MCP tool call roundtrips per user message (default: 0 = unlimited)",
     )
     group.add_argument(
         "--mcp-frame",

--- a/aider/args.py
+++ b/aider/args.py
@@ -862,6 +862,56 @@ def get_parser(default_config_files, git_root):
     )
 
     ##########
+    group = parser.add_argument_group("MCP settings")
+    group.add_argument(
+        "--mcp-server",
+        action="append",
+        metavar="NAME=URL",
+        help=(
+            "Connect to an MCP server at URL, e.g. --mcp-server metamcp=http://host/mcp"
+            " (can be used multiple times)"
+        ),
+    )
+    group.add_argument(
+        "--mcp-header",
+        action="append",
+        metavar="NAME=KEY:VALUE",
+        help=(
+            "Set an HTTP header for an MCP server, e.g. --mcp-header"
+            ' metamcp="Authorization: Bearer sk_..." (can be used multiple times)'
+        ),
+    )
+    group.add_argument(
+        "--mcp-root",
+        metavar="ROOT",
+        default=None,
+        help=(
+            "Root directory to search for .mcp.json project config (default: git root or cwd)"
+        ),
+    )
+    group.add_argument(
+        "--mcp-tool-output-limit",
+        metavar="CHARS",
+        default=16000,
+        help=(
+            "Maximum number of characters of MCP tool output to send back into the chat"
+            " (default: 16000)"
+        ),
+    )
+    group.add_argument(
+        "--mcp-max-roundtrips",
+        metavar="N",
+        default=5,
+        help="Maximum MCP tool call roundtrips per user message (default: 5)",
+    )
+    group.add_argument(
+        "--mcp-frame",
+        metavar="SECONDS",
+        default=60,
+        help="Seconds to wait for an MCP server response before timing out (default: 60)",
+    )
+
+    ##########
     group = parser.add_argument_group("Deprecated model settings")
     # Add deprecated model shortcut arguments
     add_deprecated_model_args(parser, group)

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -197,7 +197,9 @@ class Coder:
                     res.mcp_manager = from_coder.mcp_manager
                     res.mcp_max_roundtrips = from_coder.mcp_max_roundtrips
                     if res.mcp_manager:
-                        for fn in getattr(res.mcp_manager, "function_definitions", lambda: [])():
+                        if res.functions is None:
+                            res.functions = []
+                        for fn in res.mcp_manager.function_definitions():
                             if fn not in res.functions:
                                 res.functions.append(fn)
                 return res

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -109,6 +109,7 @@ class Coder:
     test_outcome = None
     multi_response_content = ""
     partial_response_content = ""
+    partial_response_tool_call_id = None
     commit_before_message = []
     message_cost = 0.0
     add_cache_headers = False
@@ -1488,15 +1489,26 @@ class Coder:
                     if result["is_error"]:
                         tool_text = "Tool execution error:\n" + tool_text
 
+                    tool_call_id = (
+                        self.partial_response_tool_call_id
+                        or f"call_mcp_{mcp_tool_name}"
+                    )
                     assistant_msg = dict(
                         role="assistant",
                         content=None,
-                        function_call=dict(
-                            name=mcp_tool_name, arguments=json.dumps(args)
-                        ),
+                        tool_calls=[
+                            dict(
+                                id=tool_call_id,
+                                type="function",
+                                function=dict(
+                                    name=mcp_tool_name, arguments=json.dumps(args)
+                                ),
+                            )
+                        ],
                     )
                     tool_msg = dict(
-                        role="user",
+                        role="tool",
+                        tool_call_id=tool_call_id,
                         content=f"[MCP tool '{mcp_tool_name}' result]\n{tool_text}",
                     )
                     self.cur_messages.append(assistant_msg)
@@ -1757,6 +1769,11 @@ class Coder:
         if self.partial_response_content:
             self.cur_messages += [dict(role="assistant", content=self.partial_response_content)]
         if self.partial_response_function_call:
+            name = self.partial_response_function_call.get("name", "")
+            if self.mcp_manager and self.mcp_manager.is_mcp_tool(name):
+                # MCP tool calls are recorded by the auto-dispatch loop in the
+                # modern tool_calls format; don't duplicate as legacy function_call.
+                return
             self.cur_messages += [
                 dict(
                     role="assistant",
@@ -1843,6 +1860,7 @@ class Coder:
 
         self.partial_response_content = ""
         self.partial_response_function_call = dict()
+        self.partial_response_tool_call_id = None
 
         self.io.log_llm_history("TO LLM", format_messages(messages))
 
@@ -1905,6 +1923,9 @@ class Coder:
                 self.partial_response_function_call = (
                     completion.choices[0].message.tool_calls[0].function
                 )
+                self.partial_response_tool_call_id = getattr(
+                    completion.choices[0].message.tool_calls[0], "id", None
+                )
         except AttributeError as func_err:
             show_func_err = func_err
 
@@ -1965,16 +1986,41 @@ class Coder:
                 raise FinishReasonLength()
 
             try:
-                func = chunk.choices[0].delta.function_call
-                # dump(func)
-                for k, v in func.items():
-                    if k in self.partial_response_function_call:
-                        self.partial_response_function_call[k] += v
-                    else:
-                        self.partial_response_function_call[k] = v
-                received_content = True
+                delta = chunk.choices[0].delta
             except AttributeError:
-                pass
+                delta = None
+
+            if delta is not None:
+                # Legacy `function_call` streaming field
+                func = getattr(delta, "function_call", None)
+                if func:
+                    for k, v in func.items():
+                        if k in self.partial_response_function_call:
+                            self.partial_response_function_call[k] += v
+                        else:
+                            self.partial_response_function_call[k] = v
+                    received_content = True
+
+                # Modern `tool_calls` streaming field (list of dicts)
+                tool_calls = getattr(delta, "tool_calls", None)
+                if tool_calls:
+                    for tc in tool_calls:
+                        tc_id = getattr(tc, "id", None)
+                        if tc_id:
+                            self.partial_response_tool_call_id = tc_id
+                        fn = getattr(tc, "function", None)
+                        if fn is not None:
+                            name = getattr(fn, "name", None)
+                            if name:
+                                self.partial_response_function_call["name"] = (
+                                    self.partial_response_function_call.get("name") or ""
+                                ) + name
+                            arguments = getattr(fn, "arguments", None)
+                            if arguments:
+                                self.partial_response_function_call["arguments"] = (
+                                    self.partial_response_function_call.get("arguments") or ""
+                                ) + arguments
+                    received_content = True
 
             text = ""
 

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -120,6 +120,8 @@ class Coder:
     chat_language = None
     commit_language = None
     file_watcher = None
+    mcp_manager = None
+    mcp_max_roundtrips = 5
 
     @classmethod
     def create(
@@ -191,6 +193,13 @@ class Coder:
             if hasattr(coder, "edit_format") and coder.edit_format == edit_format:
                 res = coder(main_model, io, **kwargs)
                 res.original_kwargs = dict(kwargs)
+                if from_coder and hasattr(from_coder, "mcp_manager"):
+                    res.mcp_manager = from_coder.mcp_manager
+                    res.mcp_max_roundtrips = from_coder.mcp_max_roundtrips
+                    if res.mcp_manager:
+                        for fn in getattr(res.mcp_manager, "function_definitions", lambda: [])():
+                            if fn not in res.functions:
+                                res.functions.append(fn)
                 return res
 
         valid_formats = [
@@ -1453,11 +1462,46 @@ class Coder:
         self.usage_report = None
         exhausted = False
         interrupted = False
+        mcp_roundtrips = 0
         try:
             while True:
                 try:
                     yield from self.send(messages, functions=self.functions)
-                    break
+
+                    mcp_tool_name = self._pending_mcp_tool_call()
+                    if not mcp_tool_name:
+                        break
+
+                    if mcp_roundtrips >= self.mcp_max_roundtrips:
+                        self.io.tool_warning(
+                            f"Stopping after {mcp_roundtrips} MCP tool-call roundtrips."
+                        )
+                        self.partial_response_content = "MCP tool-call limit reached."
+                        self.partial_response_function_call = dict()
+                        break
+
+                    args = self.parse_partial_args() or {}
+                    result = self.mcp_manager.dispatch(mcp_tool_name, args)
+                    tool_text = result["text"]
+                    if result["is_error"]:
+                        tool_text = "Tool execution error:\n" + tool_text
+
+                    assistant_msg = dict(
+                        role="assistant",
+                        content=None,
+                        function_call=dict(
+                            name=mcp_tool_name, arguments=json.dumps(args)
+                        ),
+                    )
+                    tool_msg = dict(
+                        role="user",
+                        content=f"[MCP tool '{mcp_tool_name}' result]\n{tool_text}",
+                    )
+                    self.cur_messages.append(assistant_msg)
+                    self.cur_messages.append(tool_msg)
+                    messages.append(assistant_msg)
+                    messages.append(tool_msg)
+                    mcp_roundtrips += 1
                 except litellm_ex.exceptions_tuple() as err:
                     ex_info = litellm_ex.get_ex_info(err)
 
@@ -1698,6 +1742,14 @@ class Coder:
     def __del__(self):
         """Cleanup when the Coder object is destroyed."""
         self.ok_to_warm_cache = False
+
+    def _pending_mcp_tool_call(self):
+        if not self.mcp_manager or not self.partial_response_function_call:
+            return None
+        name = self.partial_response_function_call.get("name", "")
+        if name and self.mcp_manager.is_mcp_tool(name):
+            return name
+        return None
 
     def add_assistant_reply_to_cur_messages(self):
         if self.partial_response_content:

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -122,7 +122,7 @@ class Coder:
     commit_language = None
     file_watcher = None
     mcp_manager = None
-    mcp_max_roundtrips = 5
+    mcp_max_roundtrips = 0  # 0 = unlimited
 
     @classmethod
     def create(
@@ -1475,7 +1475,7 @@ class Coder:
                     if not mcp_tool_name:
                         break
 
-                    if mcp_roundtrips >= self.mcp_max_roundtrips:
+                    if self.mcp_max_roundtrips > 0 and mcp_roundtrips >= self.mcp_max_roundtrips:
                         self.io.tool_warning(
                             f"Stopping after {mcp_roundtrips} MCP tool-call roundtrips."
                         )

--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1,4 +1,5 @@
 import glob
+import json
 import os
 import re
 import subprocess
@@ -1678,6 +1679,269 @@ Just show me the edits I need to make.
             )
         except Exception as e:
             self.io.tool_error(f"An unexpected error occurred while copying to clipboard: {str(e)}")
+
+    def cmd_mcp(self, args):
+        """Manage and execute MCP tools.
+
+        Usage:
+          /mcp                    - Show MCP server status
+          /mcp list               - List all tools from connected servers
+          /mcp exec <tool> [json] - Execute a tool (args as JSON, or prompted)
+          /mcp add                - Add an MCP server interactively
+          /mcp remove <name>      - Disconnect an MCP server
+          /mcp save               - Persist session MCP servers to .mcp.json
+          /mcp reload             - Re-read config and .mcp.json
+          /mcp history            - Show recent MCP tool calls
+        """
+        parts = (args or "").strip().split(None, 1)
+        sub = parts[0].lower() if parts else ""
+        rest = parts[1].strip() if len(parts) > 1 else ""
+
+        if not sub:
+            self._mcp_status()
+            return
+
+        if sub in ("list", "ls"):
+            self._mcp_list_tools()
+        elif sub == "exec":
+            self._mcp_exec(rest)
+        elif sub == "add":
+            self._mcp_add(rest)
+        elif sub in ("remove", "rm"):
+            self._mcp_remove(rest)
+        elif sub == "save":
+            self._mcp_save(rest)
+        elif sub == "reload":
+            self._mcp_reload()
+        elif sub == "history":
+            self._mcp_history()
+        else:
+            self.io.tool_error(f"Unknown /mcp subcommand: {sub}")
+            self.io.tool_output("Try: /mcp, /mcp list, /mcp exec <tool>, /mcp add, /mcp save")
+
+    def _mcp_manager(self):
+        mgr = getattr(self.coder, "mcp_manager", None)
+        if not mgr:
+            self.io.tool_error(
+                "No MCP servers configured. Add one with --mcp-server, in .aider.conf.yml,"
+                " in .mcp.json, or with /mcp add."
+            )
+        return mgr
+
+    def _mcp_status(self):
+        mgr = self._mcp_manager()
+        if not mgr:
+            return
+        self.io.tool_output(f"MCP servers ({len(mgr.servers)}):")
+        for name in mgr.servers:
+            self.io.tool_output(f"  {name}: {mgr.server_status().get(name, 'down')}")
+        tools = mgr.list_tools()
+        self.io.tool_output(f"Total tools available: {len(tools)}")
+        if tools:
+            self.io.tool_output("Run /mcp list to see them.")
+
+    def _mcp_list_tools(self):
+        mgr = self._mcp_manager()
+        if not mgr:
+            return
+        tools = mgr.list_tools()
+        if not tools:
+            self.io.tool_output("No MCP tools available.")
+            return
+        for tool in tools:
+            desc = (getattr(tool, "description", "") or "").strip().splitlines()
+            self.io.tool_output(f"  {tool.name}: {desc[0] if desc else 'no description'}")
+        self.io.tool_output(f"\n{len(tools)} tools. Use /mcp exec <tool> to run one.")
+
+    def _mcp_exec(self, arg):
+        mgr = self._mcp_manager()
+        if not mgr:
+            return
+
+        if not arg:
+            tools = mgr.list_tools()
+            self.io.tool_error("Usage: /mcp exec <tool> [json arguments]")
+            if tools:
+                self.io.tool_output("Available tools: " + ", ".join(t.name for t in tools))
+            return
+
+        name, _, json_arg = arg.partition(" ")
+        name = name.strip()
+        json_arg = json_arg.strip()
+
+        if not mgr.is_mcp_tool(name):
+            self.io.tool_error(f"Unknown MCP tool: {name}")
+            return
+
+        arguments = {}
+        if json_arg:
+            try:
+                arguments = json.loads(json_arg)
+            except json.JSONDecodeError as e:
+                self.io.tool_error(f"Invalid JSON arguments: {e}")
+                return
+        else:
+            tool = next((t for t in mgr.list_tools() if t.name == name), None)
+            if tool:
+                self.io.tool_output(f"Running {name} - enter arguments as JSON (or blank for none).")
+                raw = self.io.prompt_ask("args> ", default="{}")
+                if raw.strip():
+                    try:
+                        arguments = json.loads(raw)
+                    except json.JSONDecodeError as e:
+                        self.io.tool_error(f"Invalid JSON arguments: {e}")
+                        return
+
+        self.io.tool_output(f"Executing {name}...")
+        result = mgr.dispatch(name, arguments)
+        if result["is_error"]:
+            self.io.tool_error(result["text"])
+            return
+
+        self.io.tool_output(result["text"])
+        self.coder.cur_messages.append(
+            dict(role="user", content=f"[MCP tool '{name}' result]\n{result['text']}")
+        )
+
+    def _mcp_add(self, arg):
+        from aider.mcp.config import MCPServerConfig
+
+        if self.io.yes is not None:
+            self.io.tool_error("/mcp add requires an interactive terminal.")
+            return
+
+        name = arg.strip()
+        if not name:
+            name = self.io.prompt_ask("Server name> ", default="").strip()
+            if not name:
+                self.io.tool_error("No server name given.")
+                return
+
+        srv_type = self.io.prompt_ask("Type (http/stdio)> ", default="http").strip().lower()
+        cfg = MCPServerConfig(name=name)
+        if srv_type == "stdio":
+            command = self.io.prompt_ask("Command> ", default="").strip()
+            if not command:
+                self.io.tool_error("No command given.")
+                return
+            args_raw = self.io.prompt_ask("Args (space separated)> ", default="").strip()
+            cfg.command = command
+            cfg.args = args_raw.split() if args_raw else []
+            env_raw = self.io.prompt_ask("Env (KEY=value, comma sep)> ", default="").strip()
+            if env_raw:
+                cfg.env = {}
+                for chunk in env_raw.split(","):
+                    if "=" in chunk:
+                        k, _, v = chunk.partition("=")
+                        cfg.env[k.strip()] = v.strip()
+        else:
+            url = self.io.prompt_ask("URL> ", default="").strip()
+            if not url.startswith("http"):
+                self.io.tool_error("URL must start with http(s)://")
+                return
+            cfg.url = url
+            auth = self.io.prompt_ask("Auth header (Authorization: Bearer ...)> ", default="").strip()
+            if auth:
+                key, _, value = auth.partition(":")
+                cfg.headers[key.strip()] = value.strip()
+
+        self.io.tool_output("Testing connection...")
+        if mgr := getattr(self.coder, "mcp_manager", None):
+            ok = mgr.add_server(cfg)
+            if not ok:
+                self.io.tool_error(f"Failed to connect to {name}.")
+                return
+            self.io.tool_output(f"Connected to {name}.")
+            self.io.tool_output("Use /mcp save to persist this server to .mcp.json.")
+        else:
+            self.io.tool_error("MCP manager is not initialized.")
+
+    def _mcp_remove(self, arg):
+        mgr = self._mcp_manager()
+        if not mgr:
+            return
+        name = arg.strip()
+        if not name:
+            self.io.tool_error("Usage: /mcp remove <server-name>")
+            return
+        if mgr.remove_server(name):
+            self.io.tool_output(f"Removed MCP server {name}.")
+        else:
+            self.io.tool_error(f"No such MCP server: {name}")
+
+    def _mcp_save(self, arg):
+        mgr = self._mcp_manager()
+        if not mgr:
+            return
+        target = (arg.strip() or None) or (mgr.config_root or ".")
+        from aider.mcp.config import MCPServerConfig
+
+        servers = {}
+        for cfg in mgr.runtime_configs():
+            if isinstance(cfg, MCPServerConfig) and (cfg.url or cfg.command):
+                spec = {}
+                if cfg.url:
+                    spec["url"] = cfg.url
+                    if cfg.headers:
+                        spec["headers"] = cfg.headers
+                else:
+                    spec["command"] = cfg.command
+                    spec["args"] = cfg.args
+                    if cfg.env:
+                        spec["env"] = cfg.env
+                servers[cfg.name] = spec
+        import json
+        import os
+
+        path = os.path.join(target, ".mcp.json")
+        data = {}
+        if os.path.exists(path):
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+            except (OSError, ValueError):
+                data = {}
+        data.setdefault("mcpServers", {}).update(servers)
+        try:
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump(data, f, indent=2)
+            self.io.tool_output(f"Saved MCP servers to {path}")
+        except OSError as e:
+            self.io.tool_error(f"Failed to save: {e}")
+
+    def _mcp_reload(self):
+        mgr = self._mcp_manager()
+        if not mgr:
+            return
+        mgr.shutdown()
+        mgr.load_args(
+            getattr(self.args, "mcp_server", None),
+            getattr(self.args, "mcp_header", None),
+            mgr.config_root,
+        )
+        mgr.start()
+        self._mcp_status()
+
+    def _mcp_history(self):
+        all_messages = self.coder.done_messages + self.coder.cur_messages
+        tool_msgs = [m for m in all_messages if "[MCP tool" in str(m.get("content", ""))]
+        if not tool_msgs:
+            self.io.tool_output("No MCP tool results in the current session.")
+            return
+        for m in tool_msgs[-5:]:
+            content = str(m.get("content", ""))
+            self.io.tool_output(content[:500])
+
+    def completions_mcp(self):
+        mgr = getattr(self.coder, "mcp_manager", None)
+        if not mgr:
+            return ["list", "exec", "add", "save", "reload", "history", "status"]
+        subs = ["list", "exec", "add", "remove", "save", "reload", "history"]
+        try:
+            subs += [t.name for t in mgr.list_tools()]
+        except Exception:
+            pass
+        return subs
 
 
 def expand_subdir(file_path):

--- a/aider/gui.py
+++ b/aider/gui.py
@@ -153,6 +153,7 @@ class GUI:
 
             # self.do_recommended_actions()
             self.do_add_to_chat()
+            self.do_mcp_tools()
             self.do_recent_msgs()
             self.do_clear_chat_history()
             # st.container(height=150, border=False)
@@ -162,6 +163,47 @@ class GUI:
                 "This browser version of aider is experimental. Please share feedback in [GitHub"
                 " issues](https://github.com/Aider-AI/aider/issues)."
             )
+
+    def do_mcp_tools(self):
+        """MCP tools panel in the sidebar."""
+        mgr = getattr(self.coder, "mcp_manager", None)
+        with st.expander("MCP Tools", expanded=False):
+            if not mgr:
+                st.write("No MCP servers configured.")
+                return
+            tools = mgr.list_tools()
+            if not tools:
+                st.write("No MCP tools available.")
+                return
+            tool_names = [t.name for t in tools]
+            tool = st.selectbox(
+                "Tool", tool_names, key=f"mcp_tool_{self.state.mcp_num}",
+                placeholder="Choose a tool", index=None,
+            )
+            if not tool:
+                return
+            tinfo = next((t for t in tools if t.name == tool), None)
+            params = getattr(tinfo, "inputSchema", {}) or {}
+            properties = params.get("properties", {}) or {}
+            args = {}
+            for pname, pinfo in properties.items():
+                ptype = (pinfo or {}).get("type", "string")
+                if ptype == "number":
+                    args[pname] = st.number_input(pname, key=f"mcp_{tool}_{pname}")
+                elif ptype == "boolean":
+                    args[pname] = st.checkbox(pname, key=f"mcp_{tool}_{pname}")
+                else:
+                    args[pname] = st.text_input(pname, key=f"mcp_{tool}_{pname}")
+            if st.button("Run", key=f"mcp_run_{tool}"):
+                with st.spinner(f"Running {tool}..."):
+                    result = mgr.dispatch(tool, args)
+                if result["is_error"]:
+                    st.error(result["text"])
+                else:
+                    st.text(result["text"])
+                    self.coder.cur_messages.append(
+                        dict(role="user", content=f"[MCP tool '{tool}' result]\n{result['text']}")
+                    )
 
     def do_settings_tab(self):
         pass
@@ -336,6 +378,7 @@ class GUI:
         self.state.init("last_undone_commit_hash")
         self.state.init("recent_msgs_num", 0)
         self.state.init("web_content_num", 0)
+        self.state.init("mcp_num", 0)
         self.state.init("prompt")
         self.state.init("scraper")
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -1015,6 +1015,37 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         analytics.event("exit", reason="ValueError during coder creation")
         return 1
 
+    # MCP setup: connect MCP servers configured via CLI, .aider.conf.yml,
+    # .mcp.json or AIDER_MCP_SERVER and expose their tools to the model.
+    from aider.mcp.manager import MCPManager
+
+    mcp_manager = MCPManager(
+        io=io,
+        output_limit=args.mcp_tool_output_limit,
+        max_roundtrips=args.mcp_max_roundtrips,
+        timeout=args.mcp_frame,
+    )
+    mcp_root = (
+        Path(args.mcp_root)
+        if args.mcp_root
+        else (Path(git_root) if git_root else Path.cwd())
+    )
+    mcp_manager.load_args(args.mcp_server, args.mcp_header, mcp_root)
+    if mcp_manager.servers:
+        mcp_manager.start()
+        coder.mcp_manager = mcp_manager
+        coder.mcp_max_roundtrips = args.mcp_max_roundtrips
+        if coder.functions is None:
+            coder.functions = []
+        for fn in mcp_manager.function_definitions():
+            if fn not in coder.functions:
+                coder.functions.append(fn)
+    import atexit
+
+    atexit.register(mcp_manager.shutdown)
+    for name, status in mcp_manager.server_status().items():
+        io.tool_output(f"MCP server {name}: {status}")
+
     if return_coder:
         analytics.event("exit", reason="Returning coder object")
         return coder

--- a/aider/main.py
+++ b/aider/main.py
@@ -1,3 +1,4 @@
+import atexit
 import json
 import os
 import re
@@ -1040,8 +1041,13 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         for fn in mcp_manager.function_definitions():
             if fn not in coder.functions:
                 coder.functions.append(fn)
-    import atexit
+    # Shut MCP clients down before interpreter exit. Registering via
+    # threading._register_atexit (not atexit) ensures the cleanup runs before
+    # concurrent.futures._python_exit flags all ThreadPoolExecutors as shut
+    # down; the MCP session's terminate-session DELETE needs a live executor.
+    import threading
 
+    threading._register_atexit(mcp_manager.shutdown)
     atexit.register(mcp_manager.shutdown)
     for name, status in mcp_manager.server_status().items():
         io.tool_output(f"MCP server {name}: {status}")

--- a/aider/mcp/__init__.py
+++ b/aider/mcp/__init__.py
@@ -1,0 +1,10 @@
+"""MCP (Model Context Protocol) integration for Aider.
+
+Provides helpers for loading MCP servers from configuration
+(``.aider.conf.yml``, ``.mcp.json``, CLI flags and the ``/mcp`` command)
+and executing their tools either automatically (via the LLM) or manually.
+"""
+
+from .manager import MCPManager
+
+__all__ = ["MCPManager"]

--- a/aider/mcp/client.py
+++ b/aider/mcp/client.py
@@ -120,17 +120,12 @@ class MCPClient:
 
             if self.headers:
                 self._http_client = httpx.AsyncClient(headers=self.headers)
-                async with streamable_http_client(
-                    self.url, http_client=self._http_client
-                ) as (read, write, _get_sid):
-                    async with ClientSession(read, write) as session:
-                        await session.initialize()
-                        await self._publish_session(session)
-            else:
-                async with streamable_http_client(self.url) as (read, write, _get_sid):
-                    async with ClientSession(read, write) as session:
-                        await session.initialize()
-                        await self._publish_session(session)
+            async with streamable_http_client(
+                self.url, http_client=self._http_client
+            ) as (read, write, _get_sid):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    await self._publish_session(session)
         elif self.command:
             import mcp
 

--- a/aider/mcp/client.py
+++ b/aider/mcp/client.py
@@ -1,0 +1,212 @@
+"""A single MCP server connection.
+
+Runs the MCP SDK's async session (streamable HTTP or stdio) on a dedicated
+background thread and exposes blocking ``list_tools`` / ``call_tool``
+methods that are safe to call from Aider's sync code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Any, Optional
+
+from mcp.client.session import ClientSession
+from mcp.client.streamable_http import streamable_http_client
+from mcp.types import Tool
+
+
+class MCPClient:
+    def __init__(
+        self,
+        name: str,
+        url: Optional[str] = None,
+        command: Optional[str] = None,
+        args: Optional[list[str]] = None,
+        env: Optional[dict[str, str]] = None,
+        headers: Optional[dict[str, str]] = None,
+        timeout: float = 60,
+    ):
+        self.name = name
+        self.url = url
+        self.command = command
+        self.args = args or []
+        self.env = env
+        self.headers = headers or {}
+        self.timeout = timeout
+
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._thread: Optional[threading.Thread] = None
+        self._ready = threading.Event()
+        self._stop_evt: Optional[asyncio.Event] = None
+        self._session: Optional[ClientSession] = None
+        self._session_task: Optional[asyncio.Task] = None
+        self._http_client = None
+        self._tools: Optional[list[Tool]] = None
+        self._session_error: Optional[Exception] = None
+        self._closed = threading.Event()
+
+    @property
+    def is_running(self) -> bool:
+        return self._session is not None
+
+    def start(self) -> None:
+        """Connect to the server on a background thread (blocking until ready)."""
+        if self._thread and self._thread.is_alive():
+            return
+        if self._session is not None:
+            return
+
+        self._ready.clear()
+        self._closed.clear()
+        self._session = None
+        self._thread = threading.Thread(
+            target=self._thread_main, name=f"mcp-{self.name}", daemon=True
+        )
+        self._thread.start()
+
+        if not self._ready.wait(timeout=self.timeout):
+            raise TimeoutError(f"Timed out connecting to MCP server '{self.name}'")
+
+        # Launch the session-open coroutine on the background loop
+        self._loop.call_soon_threadsafe(self._start_session_task)
+
+        if not self._wait_for_session():
+            raise RuntimeError(f"Failed to initialize MCP server '{self.name}'")
+
+    def _thread_main(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._ready.set()
+
+        try:
+            self._loop.run_forever()
+        finally:
+            pending = asyncio.all_tasks(self._loop)
+            for task in pending:
+                task.cancel()
+            self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            if self._http_client is not None:
+                try:
+                    self._loop.run_until_complete(self._http_client.aclose())
+                except Exception:
+                    pass
+            self._loop.close()
+
+    def _wait_for_session(self) -> bool:
+        """Block until the session is initialized and tools listed (or timeout)."""
+        import time
+
+        for _ in range(int(self.timeout * 10)):
+            if self._tools is not None:
+                return True
+            if self._session_error is not None:
+                return False
+            time.sleep(0.1)
+        return self._tools is not None
+
+    def _submit(self, coro) -> Any:
+        """Run an async coroutine on the background event loop, blocking for it."""
+        if not self._loop or not self._loop.is_running():
+            raise RuntimeError(f"MCP server '{self.name}' is not connected")
+        fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return fut.result(timeout=self.timeout)
+
+    async def _open_session(self) -> None:
+        self._stop_evt = asyncio.Event()
+
+        if self.url:
+            import httpx
+
+            if self.headers:
+                self._http_client = httpx.AsyncClient(headers=self.headers)
+                async with streamable_http_client(
+                    self.url, http_client=self._http_client
+                ) as (read, write, _get_sid):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        await self._publish_session(session)
+            else:
+                async with streamable_http_client(self.url) as (read, write, _get_sid):
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        await self._publish_session(session)
+        elif self.command:
+            import mcp
+
+            params = mcp.StdioServerParameters(
+                command=self.command, args=self.args, env=self.env
+            )
+            async with mcp.stdio_client(params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    await self._publish_session(session)
+        else:
+            raise ValueError("MCP server must specify either url or command")
+
+    async def _publish_session(self, session: ClientSession) -> None:
+        self._session = session
+        try:
+            result = await session.list_tools()
+            self._tools = result.tools if result else []
+        except Exception as err:
+            self._session_error = err
+        finally:
+            if self._stop_evt is not None:
+                await self._stop_evt.wait()
+
+    def _start_session_task(self) -> None:
+        assert self._loop is not None
+        self._session_task = self._loop.create_task(self._open_session())
+        self._session_task.add_done_callback(self._on_session_done)
+
+    def _on_session_done(self, task: asyncio.Task) -> None:
+        if not task.cancelled() and task.exception() is not None and not self._session_error:
+            self._session_error = task.exception()
+
+    def list_tools(self) -> list[Tool]:
+        """Return the list of tools advertised by the server (blocking)."""
+        if self._tools is None:
+            if self._session_error is not None:
+                raise RuntimeError(f"MCP server '{self.name}': {self._session_error}")
+            if not self._wait_for_session():
+                raise RuntimeError(f"MCP server '{self.name}' failed to initialize")
+        return list(self._tools or [])
+
+    def call_tool(self, tool_name: str, arguments: Optional[dict[str, Any]]) -> dict[str, Any]:
+        """Execute a tool on the server (blocking) and return a result dict."""
+        if not self.is_running:
+            raise RuntimeError(f"MCP server '{self.name}' is not connected")
+
+        if self._session_error is not None:
+            raise RuntimeError(f"MCP server '{self.name}': {self._session_error}")
+
+        return self._submit(self._session.call_tool(tool_name, arguments or {}))
+
+    def close(self) -> None:
+        """Tear down the session and stop the background loop."""
+        if self._closed.is_set():
+            return
+        self._closed.set()
+
+        if self._loop is not None and self._loop.is_running():
+            async def _stop():
+                if self._stop_evt is not None:
+                    self._stop_evt.set()
+                if self._session_task is not None and not self._session_task.done():
+                    self._session_task.cancel()
+                    try:
+                        await self._session_task
+                    except (asyncio.CancelledError, Exception):
+                        pass
+
+            try:
+                self._submit(_stop())
+            except Exception:
+                pass
+            finally:
+                self._loop.call_soon_threadsafe(self._loop.stop)
+
+        if self._thread is not None:
+            self._thread.join(timeout=self.timeout)
+        self._thread = None

--- a/aider/mcp/config.py
+++ b/aider/mcp/config.py
@@ -104,6 +104,8 @@ def load_mcp_json(root: Optional[Path]) -> dict[str, MCPServerConfig]:
         for name, spec in mcp_servers.items():
             if not isinstance(spec, dict):
                 continue
+            if spec.get("enabled") is False:
+                continue
             server = _server_from_json(name, spec, str(path))
             servers[name] = server
     return servers

--- a/aider/mcp/config.py
+++ b/aider/mcp/config.py
@@ -73,7 +73,7 @@ def _server_from_json(name: str, data: dict, source: str) -> MCPServerConfig:
     command = data.get("command")
     headers = data.get("headers") or {}
 
-    if url and not (t and t == "stdio"):
+    if url and t != "stdio":
         return MCPServerConfig(
             name=name,
             url=str(url),

--- a/aider/mcp/config.py
+++ b/aider/mcp/config.py
@@ -1,0 +1,156 @@
+"""Discover MCP servers from config sources.
+
+Merges servers found in (lowest to highest precedence):
+  * ``.mcp.json`` in the home directory, git root, then cwd
+  * ``.aider.conf.yml`` / CLI flags (``--mcp-server`` / ``--mcp-header``)
+  * ``AIDER_MCP_SERVER`` environment variable
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class MCPServerConfig:
+    name: str
+    url: Optional[str] = None
+    command: Optional[str] = None
+    args: list[str] = field(default_factory=list)
+    env: Optional[dict[str, str]] = None
+    headers: dict[str, str] = field(default_factory=dict)
+    source: str = ""
+
+
+def parse_name_value(text: str) -> Optional[tuple[str, str]]:
+    """Parse ``name=value`` (first ``=`` splits name and value)."""
+    text = text.strip().strip("\"'")
+    if "=" not in text:
+        return None
+    name, _, value = text.partition("=")
+    name = name.strip()
+    value = value.strip().strip("\"'")
+    if not name or not value:
+        return None
+    return name, value
+
+
+def parse_header_value(text: str) -> Optional[tuple[str, str, str]]:
+    """Parse ``name=Key:Value`` into (name, key, value)."""
+    pair = parse_name_value(text)
+    if not pair:
+        return None
+    name, rest = pair
+    if ":" not in rest:
+        return None
+    key, _, value = rest.partition(":")
+    return name, key.strip(), value.strip()
+
+
+def _find_mcp_json(root: Optional[Path]) -> list[Path]:
+    """Return candidate .mcp.json paths in precedence order (low to high)."""
+    candidates = []
+    if root:
+        candidates.append(Path(root) / ".mcp.json")
+    candidates += [
+        Path.cwd() / ".mcp.json",
+        Path.home() / ".mcp.json",
+    ]
+    seen = []
+    for path in candidates:
+        if path not in seen:
+            seen.append(path)
+    return seen
+
+
+def _server_from_json(name: str, data: dict, source: str) -> MCPServerConfig:
+    t = data.get("type", "")
+    url = data.get("url")
+    command = data.get("command")
+    headers = data.get("headers") or {}
+
+    if url and not (t and t == "stdio"):
+        return MCPServerConfig(
+            name=name,
+            url=str(url),
+            headers={str(k): str(v) for k, v in headers.items()},
+            source=source,
+        )
+    if command:
+        return MCPServerConfig(
+            name=name,
+            command=str(command),
+            args=[str(a) for a in data.get("args", [])],
+            env=data.get("env"),
+            source=source,
+        )
+    return MCPServerConfig(name=name, source=source)
+
+
+def load_mcp_json(root: Optional[Path]) -> dict[str, MCPServerConfig]:
+    """Load servers from .mcp.json files (home, git root, then cwd win)."""
+    servers: dict[str, MCPServerConfig] = {}
+    for path in _find_mcp_json(root):
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, ValueError, json.JSONDecodeError):
+            continue
+        mcp_servers = data.get("mcpServers") or {}
+        for name, spec in mcp_servers.items():
+            if not isinstance(spec, dict):
+                continue
+            server = _server_from_json(name, spec, str(path))
+            servers[name] = server
+    return servers
+
+
+def load_from_args(
+    mcp_servers: Optional[list[str]],
+    mcp_headers: Optional[list[str]],
+    root: Optional[Path],
+) -> dict[str, MCPServerConfig]:
+    """Merge config-file/CLI and .mcp.json servers, CLI winning on conflicts."""
+    servers: dict[str, MCPServerConfig] = {}
+
+    for name, server in load_mcp_json(root).items():
+        servers[name] = server
+
+    # env var AIDER_MCP_SERVER="name=url,name2=url2"
+    env_servers = os.environ.get("AIDER_MCP_SERVER", "")
+    for chunk in env_servers.split(","):
+        pair = parse_name_value(chunk)
+        if pair:
+            name, value = pair
+            servers[name] = MCPServerConfig(
+                name=name, url=value, source="AIDER_MCP_SERVER"
+            )
+
+    if mcp_servers:
+        for item in mcp_servers:
+            pair = parse_name_value(item)
+            if pair:
+                name, value = pair
+                servers[name] = MCPServerConfig(
+                    name=name,
+                    url=value if value.startswith("http") else None,
+                    command=None if value.startswith("http") else value,
+                    source="--mcp-server",
+                )
+
+    if mcp_headers:
+        for item in mcp_headers:
+            parsed = parse_header_value(item)
+            if parsed:
+                name, key, value = parsed
+                server = servers.get(name)
+                if not server:
+                    server = MCPServerConfig(name=name, source="--mcp-header")
+                    servers[name] = server
+                server.headers[key] = value
+
+    return servers

--- a/aider/mcp/manager.py
+++ b/aider/mcp/manager.py
@@ -12,7 +12,7 @@ from typing import Any, Optional
 from mcp.types import Tool
 
 from .client import MCPClient
-from .config import MCPServerConfig
+from .config import MCPServerConfig, load_from_args
 
 
 class MCPManager:
@@ -30,8 +30,7 @@ class MCPManager:
 
         self._configs: dict[str, MCPServerConfig] = {}
         self._clients: dict[str, MCPClient] = {}
-        self._owners: dict[str, str] = {}  # tool name -> server name
-        self._tool_to_server: dict[str, str] = {}
+        self._tool_to_server: dict[str, str] = {}  # tool name -> server name
         self._errors: dict[str, str] = {}  # server name -> error message
         self._runtime: dict[str, MCPServerConfig] = {}
         self._started = False
@@ -48,14 +47,9 @@ class MCPManager:
         mcp_headers: Optional[list[str]],
         root,
     ) -> None:
-        from . import config as mcp_config
-
         self.config_root = root
-        for name, server in mcp_config.load_from_args(mcp_servers, mcp_headers, root).items():
+        for name, server in load_from_args(mcp_servers, mcp_headers, root).items():
             self.add_config(server)
-
-    def configs(self) -> list[MCPServerConfig]:
-        return list(self._configs.values())
 
     def runtime_configs(self) -> list[MCPServerConfig]:
         return list(self._runtime.values()) + [
@@ -70,7 +64,7 @@ class MCPManager:
         for name, cfg in dict(self._configs).items():
             self._connect(cfg)
 
-    def _connect(self, cfg: MCPServerConfig, runtime: bool = False) -> bool:
+    def _connect(self, cfg: MCPServerConfig) -> bool:
         try:
             client = MCPClient(
                 name=cfg.name,
@@ -90,14 +84,11 @@ class MCPManager:
 
         self._clients[cfg.name] = client
         self._errors.pop(cfg.name, None)
-        if runtime:
-            self._configs.setdefault(cfg.name, cfg)
 
         # register tools
         try:
             for tool in client.list_tools():
                 self._tool_to_server[tool.name] = cfg.name
-                self._owners.setdefault(tool.name, cfg.name)
         except Exception as err:
             self._errors[cfg.name] = str(err)
             if self.io:
@@ -114,7 +105,6 @@ class MCPManager:
                 pass
         self._clients.clear()
         self._tool_to_server.clear()
-        self._owners.clear()
         self._started = False
 
     # -- status ------------------------------------------------------------
@@ -205,15 +195,10 @@ class MCPManager:
             text = f"(tool '{getattr(result, 'name', '')}' returned no text output)"
         return text[: self.output_limit]
 
-    def truncate(self, text: str) -> str:
-        if len(text) > self.output_limit:
-            return text[: self.output_limit] + "\n...(truncated)"
-        return text
-
     # -- runtime mutations (TUI) -------------------------------------------
 
     def add_server(self, cfg: MCPServerConfig) -> bool:
-        ok = self._connect(cfg, runtime=True)
+        ok = self._connect(cfg)
         if ok:
             self._runtime[cfg.name] = cfg
             self._configs.setdefault(cfg.name, cfg)

--- a/aider/mcp/manager.py
+++ b/aider/mcp/manager.py
@@ -1,0 +1,235 @@
+"""MCPManager: multi-server registry + dispatch for Aider.
+
+Exposes a merged tool list to the LLM (via ``function_definitions``) and
+executes tool calls against the owning server. Handles result truncation,
+error reflection, runtime add/remove and shutdown.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from mcp.types import Tool
+
+from .client import MCPClient
+from .config import MCPServerConfig
+
+
+class MCPManager:
+    def __init__(
+        self,
+        io=None,
+        output_limit: int = 16000,
+        max_roundtrips: int = 5,
+        timeout: float = 60,
+    ):
+        self.io = io
+        self.output_limit = output_limit
+        self.max_roundtrips = max_roundtrips
+        self.timeout = timeout
+
+        self._configs: dict[str, MCPServerConfig] = {}
+        self._clients: dict[str, MCPClient] = {}
+        self._owners: dict[str, str] = {}  # tool name -> server name
+        self._tool_to_server: dict[str, str] = {}
+        self._errors: dict[str, str] = {}  # server name -> error message
+        self._runtime: dict[str, MCPServerConfig] = {}
+        self._started = False
+        self.config_root = None
+
+    # -- lifecycle ---------------------------------------------------------
+
+    def add_config(self, server: MCPServerConfig) -> None:
+        self._configs[server.name] = server
+
+    def load_args(
+        self,
+        mcp_servers: Optional[list[str]],
+        mcp_headers: Optional[list[str]],
+        root,
+    ) -> None:
+        from . import config as mcp_config
+
+        self.config_root = root
+        for name, server in mcp_config.load_from_args(mcp_servers, mcp_headers, root).items():
+            self.add_config(server)
+
+    def configs(self) -> list[MCPServerConfig]:
+        return list(self._configs.values())
+
+    def runtime_configs(self) -> list[MCPServerConfig]:
+        return list(self._runtime.values()) + [
+            c for n, c in self._configs.items() if n not in self._runtime
+        ]
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._started = True
+
+        for name, cfg in dict(self._configs).items():
+            self._connect(cfg)
+
+    def _connect(self, cfg: MCPServerConfig, runtime: bool = False) -> bool:
+        try:
+            client = MCPClient(
+                name=cfg.name,
+                url=cfg.url,
+                command=cfg.command,
+                args=cfg.args,
+                env=cfg.env,
+                headers=cfg.headers,
+                timeout=self.timeout,
+            )
+            client.start()
+        except Exception as err:
+            self._errors[cfg.name] = str(err)
+            if self.io:
+                self.io.tool_warning(f"Unable to connect to MCP server '{cfg.name}': {err}")
+            return False
+
+        self._clients[cfg.name] = client
+        self._errors.pop(cfg.name, None)
+        if runtime:
+            self._configs.setdefault(cfg.name, cfg)
+
+        # register tools
+        try:
+            for tool in client.list_tools():
+                self._tool_to_server[tool.name] = cfg.name
+                self._owners.setdefault(tool.name, cfg.name)
+        except Exception as err:
+            self._errors[cfg.name] = str(err)
+            if self.io:
+                self.io.tool_warning(
+                    f"MCP server '{cfg.name}' connected but listed no tools: {err}"
+                )
+        return True
+
+    def shutdown(self) -> None:
+        for name, client in list(self._clients.items()):
+            try:
+                client.close()
+            except Exception:
+                pass
+        self._clients.clear()
+        self._tool_to_server.clear()
+        self._owners.clear()
+        self._started = False
+
+    # -- status ------------------------------------------------------------
+
+    @property
+    def servers(self) -> list[str]:
+        return sorted(set(self._configs) | set(self._runtime))
+
+    def server_status(self) -> dict[str, str]:
+        status = {}
+        for name in self.servers:
+            if name in self._clients:
+                status[name] = "connected"
+            elif name in self._errors:
+                status[name] = f"error: {self._errors[name]}"
+            else:
+                status[name] = "down"
+        return status
+
+    # -- tools -------------------------------------------------------------
+
+    def list_tools(self) -> list[Tool]:
+        tools: dict[str, Tool] = {}
+        for name, client in self._clients.items():
+            try:
+                for tool in client.list_tools():
+                    tools.setdefault(tool.name, tool)
+            except Exception:
+                continue
+        return list(tools.values())
+
+    def is_mcp_tool(self, tool_name: str) -> bool:
+        return tool_name in self._tool_to_server
+
+    def function_definitions(self) -> list[dict[str, Any]]:
+        """OpenAI-compatible function specs for all MCP tools."""
+        functions = []
+        for tool in self.list_tools():
+            parameters = getattr(tool, "inputSchema", {})
+            if hasattr(parameters, "model_dump"):
+                parameters = parameters.model_dump()
+            if isinstance(parameters, dict) and parameters.get("type") == "object":
+                defn = {
+                    "name": tool.name,
+                    "description": getattr(tool, "description", ""),
+                    "parameters": parameters,
+                }
+                functions.append(defn)
+        return functions
+
+    # -- dispatch ----------------------------------------------------------
+
+    def dispatch(self, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        """Execute a tool via its owning server, return a result dict."""
+        server_name = self._tool_to_server.get(tool_name)
+        client = self._clients.get(server_name or "")
+        if not client:
+            return {
+                "text": f"Error: unknown MCP tool '{tool_name}'",
+                "is_error": True,
+            }
+
+        try:
+            result = client.call_tool(tool_name, arguments or {})
+        except Exception as err:
+            return {"text": f"Error calling MCP tool '{tool_name}': {err}", "is_error": True}
+
+        text = self._result_to_text(result)
+        return {"text": text, "is_error": bool(getattr(result, "isError", False))}
+
+    def _result_to_text(self, result) -> str:
+        parts = []
+        for block in getattr(result, "content", []) or []:
+            block_type = getattr(block, "type", "")
+            if block_type == "text" or hasattr(block, "text"):
+                parts.append(str(getattr(block, "text", "")))
+            else:
+                data = getattr(block, "data", None)
+                if data is not None:
+                    parts.append(f"[{block_type} data, {len(data)} bytes]")
+                else:
+                    try:
+                        parts.append(str(block))
+                    except Exception:
+                        parts.append(str(block_type))
+        text = "\n".join(parts).strip()
+        if not text:
+            text = f"(tool '{getattr(result, 'name', '')}' returned no text output)"
+        return text[: self.output_limit]
+
+    def truncate(self, text: str) -> str:
+        if len(text) > self.output_limit:
+            return text[: self.output_limit] + "\n...(truncated)"
+        return text
+
+    # -- runtime mutations (TUI) -------------------------------------------
+
+    def add_server(self, cfg: MCPServerConfig) -> bool:
+        ok = self._connect(cfg, runtime=True)
+        if ok:
+            self._runtime[cfg.name] = cfg
+            self._configs.setdefault(cfg.name, cfg)
+        return ok
+
+    def remove_server(self, name: str) -> bool:
+        client = self._clients.pop(name, None)
+        if client:
+            try:
+                client.close()
+            except Exception:
+                pass
+        self._configs.pop(name, None)
+        self._runtime.pop(name, None)
+        self._errors.pop(name, None)
+        for tool, server in list(self._tool_to_server.items()):
+            if server == name:
+                self._tool_to_server.pop(tool, None)
+        return True

--- a/aider/mcp/manager.py
+++ b/aider/mcp/manager.py
@@ -20,7 +20,7 @@ class MCPManager:
         self,
         io=None,
         output_limit: int = 16000,
-        max_roundtrips: int = 5,
+        max_roundtrips: int = 0,
         timeout: float = 60,
     ):
         self.io = io

--- a/aider/models.py
+++ b/aider/models.py
@@ -1004,9 +1004,12 @@ class Model(ModelSettings):
             kwargs["temperature"] = temperature
 
         if functions is not None:
-            function = functions[0]
-            kwargs["tools"] = [dict(type="function", function=function)]
-            kwargs["tool_choice"] = {"type": "function", "function": {"name": function["name"]}}
+            kwargs["tools"] = [dict(type="function", function=f) for f in functions]
+            kwargs["tool_choice"] = (
+                {"type": "function", "function": {"name": functions[0]["name"]}}
+                if len(functions) == 1
+                else "auto"
+            )
         if self.extra_params:
             kwargs.update(self.extra_params)
         if self.is_ollama() and "num_ctx" not in kwargs:

--- a/aider/website/docs/mcp.md
+++ b/aider/website/docs/mcp.md
@@ -1,0 +1,121 @@
+# Model Context Protocol (MCP) support
+
+Aider can connect to [MCP](https://modelcontextprotocol.io) servers and use
+their tools, both automatically (the model can call them while answering) and
+manually (via the `/mcp` command in the terminal UI, or the MCP panel in the
+browser UI).
+
+MCP servers expose tools over two transport types, both supported:
+
+- **Streamable HTTP** — a URL such as `http://host:port/mcp`, optionally with
+  custom headers (e.g. an `Authorization: Bearer ...` token).
+- **Stdio** — a local command (plus args/env) that Aider runs as a subprocess.
+
+## Configuration
+
+MCP servers can be configured in four ways. If the same server name appears in
+more than one place, the later entry wins.
+
+| Source | Precedence |
+| --- | --- |
+| `.aider.conf.yml` (global or project) | lowest |
+| `.mcp.json` (home, then git root, then cwd) | |
+| CLI flags (`--mcp-server`, `--mcp-header`) | |
+| `/mcp add` at runtime + `/mcp save` | highest |
+
+### `.aider.conf.yml`
+
+```yaml
+mcp-server: metamcp=http://127.0.0.1:9090/mcp
+mcp-header: 'metamcp=Authorization: Bearer sk_...'
+mcp-tool-output-limit: 16000
+mcp-max-roundtrips: 5
+```
+
+### `.mcp.json` (project-based)
+
+The community-standard `.mcp.json` file is searched in the home directory, the
+git root, then the current directory. This is the recommended way to share
+servers with your team or other tools.
+
+```json
+{
+  "mcpServers": {
+    "metamcp": {
+      "type": "http",
+      "url": "http://127.0.0.1:9090/mcp",
+      "headers": {
+        "Authorization": "Bearer sk_..."
+      }
+    },
+    "filesystem": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "."],
+      "env": {}
+    }
+  }
+}
+```
+
+### CLI flags
+
+```bash
+aider --mcp-server metamcp=http://127.0.0.1:9090/mcp \
+      --mcp-header 'metamcp=Authorization: Bearer sk_...'
+```
+
+### Environment variable
+
+```bash
+export AIDER_MCP_SERVER="metamcp=http://127.0.0.1:9090/mcp"
+aider
+```
+
+## Using MCP tools automatically
+
+When at least one MCP server is configured and connected, its tools are added
+to the model's function list automatically. The model may call them while
+answering; results are injected back into the conversation so it can reason
+over them.
+
+Because local models can occasionally loop on tool calls, Aider stops after
+`mcp-max-roundtrips` tool-call roundtrips per message (default 5). Tool output
+is truncated to `mcp-tool-output-limit` characters (default 16000) to protect
+your context window.
+
+## The `/mcp` command (terminal UI)
+
+- `/mcp` — show connected servers and total tool count.
+- `/mcp list` — list all available tools.
+- `/mcp exec <tool> [json args]` — run a tool and inject the result into the
+  chat. With no JSON given, you are prompted for arguments.
+- `/mcp add` — interactive wizard to add a server (http or stdio), with a live
+  connection test.
+- `/mcp remove <name>` — disconnect a server for this session.
+- `/mcp save` — persist the session's servers to `.mcp.json`.
+- `/mcp reload` — re-read config files and reconnect.
+- `/mcp history` — show the most recent MCP tool results.
+
+## Browser UI
+
+When a server is connected, the sidebar shows an **MCP Tools** panel where you
+can pick a tool, fill in its parameters, and run it. Results are injected into
+the chat.
+
+## Security notes
+
+- Headers such as `Authorization` tokens are stored in plain text in your
+  config files. If you commit `.mcp.json` to a repo, avoid putting real tokens
+  in it.
+- MCP tools can perform arbitrary actions (run commands, read/write files).
+  Only connect to servers you trust.
+
+## Troubleshooting
+
+- **"No MCP servers configured"** — add one via any of the config sources
+  above, then restart Aider.
+- **"Unable to connect to MCP server"** — check the URL/port, headers, and that
+  the server is reachable. Stdio servers need the command to be installed.
+- **Model never calls tools** — some local models emit tool calls unreliably.
+  Try a stronger model, or run tools manually with `/mcp exec`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,9 @@ anyio==4.12.1
     # via
     #   -c requirements/common-constraints.txt
     #   httpx
+    #   mcp
     #   openai
+    #   sse-starlette
     #   starlette
     #   watchfiles
 asgiref==3.11.1
@@ -56,6 +58,7 @@ certifi==2026.2.25
 cffi==2.0.0
     # via
     #   -c requirements/common-constraints.txt
+    #   cryptography
     #   sounddevice
     #   soundfile
 charset-normalizer==3.4.6
@@ -67,10 +70,15 @@ click==8.3.1
     #   -c requirements/common-constraints.txt
     #   litellm
     #   typer
+    #   uvicorn
 configargparse==1.7.5
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
+cryptography==46.0.5
+    # via
+    #   -c requirements/common-constraints.txt
+    #   pyjwt
 diff-match-patch==20241021
     # via
     #   -c requirements/common-constraints.txt
@@ -125,6 +133,7 @@ h11==0.16.0
     # via
     #   -c requirements/common-constraints.txt
     #   httpcore
+    #   uvicorn
 hf-xet==1.4.2
     # via
     #   -c requirements/common-constraints.txt
@@ -138,8 +147,11 @@ httpx==0.28.1
     #   -c requirements/common-constraints.txt
     #   huggingface-hub
     #   litellm
+    #   mcp
     #   mixpanel
     #   openai
+httpx-sse==0.4.3
+    # via mcp
 huggingface-hub==1.7.1
     # via
     #   -c requirements/common-constraints.txt
@@ -177,6 +189,7 @@ jsonschema==4.26.0
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
     #   litellm
+    #   mcp
 jsonschema-specifications==2025.9.1
     # via
     #   -c requirements/common-constraints.txt
@@ -197,6 +210,8 @@ mccabe==0.7.0
     # via
     #   -c requirements/common-constraints.txt
     #   flake8
+mcp==1.29.0
+    # via -r requirements/requirements.in
 mdurl==0.1.2
     # via
     #   -c requirements/common-constraints.txt
@@ -218,6 +233,7 @@ networkx==3.4.2
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/requirements.in
+numpy==2.4.3
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/python-compat.in
@@ -287,12 +303,16 @@ pydantic==2.12.5
     #   -c requirements/common-constraints.txt
     #   fastapi
     #   litellm
+    #   mcp
     #   mixpanel
     #   openai
+    #   pydantic-settings
 pydantic-core==2.41.5
     # via
     #   -c requirements/common-constraints.txt
     #   pydantic
+pydantic-settings==2.14.2
+    # via mcp
 pydub==0.25.1
     # via
     #   -c requirements/common-constraints.txt
@@ -305,6 +325,8 @@ pygments==2.19.2
     # via
     #   -c requirements/common-constraints.txt
     #   rich
+pyjwt[crypto]==2.13.0
+    # via mcp
 pypandoc==1.17
     # via
     #   -c requirements/common-constraints.txt
@@ -321,6 +343,9 @@ python-dotenv==1.2.2
     # via
     #   -c requirements/common-constraints.txt
     #   litellm
+    #   pydantic-settings
+python-multipart==0.0.32
+    # via mcp
 pyyaml==6.0.3
     # via
     #   -c requirements/common-constraints.txt
@@ -351,6 +376,7 @@ rpds-py==0.30.0
     #   -c requirements/common-constraints.txt
     #   jsonschema
     #   referencing
+scipy==1.17.1
     # via
     #   -c requirements/common-constraints.txt
     #   -r requirements/python-compat.in
@@ -391,10 +417,14 @@ soupsieve==2.8.3
     # via
     #   -c requirements/common-constraints.txt
     #   beautifulsoup4
+sse-starlette==3.4.6
+    # via mcp
 starlette==0.52.1
     # via
     #   -c requirements/common-constraints.txt
     #   fastapi
+    #   mcp
+    #   sse-starlette
 tiktoken==0.12.0
     # via
     #   -c requirements/common-constraints.txt
@@ -408,6 +438,7 @@ tqdm==4.67.3
     #   -c requirements/common-constraints.txt
     #   huggingface-hub
     #   openai
+tree-sitter==0.25.2
     # via
     #   -c requirements/common-constraints.txt
     #   tree-sitter-language-pack
@@ -439,6 +470,7 @@ typing-extensions==4.15.0
     #   beautifulsoup4
     #   fastapi
     #   huggingface-hub
+    #   mcp
     #   openai
     #   posthog
     #   pydantic
@@ -450,11 +482,15 @@ typing-inspection==0.4.2
     # via
     #   -c requirements/common-constraints.txt
     #   fastapi
+    #   mcp
     #   pydantic
+    #   pydantic-settings
 urllib3==2.6.3
     # via
     #   -c requirements/common-constraints.txt
     #   requests
+uvicorn==0.52.1
+    # via mcp
 watchfiles==1.1.1
     # via
     #   -c requirements/common-constraints.txt
@@ -471,19 +507,3 @@ zipp==3.23.0
     # via
     #   -c requirements/common-constraints.txt
     #   importlib-metadata
-    
-tree-sitter==0.23.2; python_version < "3.10"
-tree-sitter==0.25.2; python_version >= "3.10"
-# NumPy 2.x adds Python 3.14 wheels, but dropped Python 3.10.
-numpy<2; python_version < "3.11"
-numpy>=2.3,<2.5; python_version >= "3.11"
-
-# This is the one networkx dependency that we need.
-# Including it here explicitly because we
-# didn't specify networkx[default] above.
-#
-# SciPy 1.16+ adds Python 3.14 wheels, but dropped Python 3.10.
-scipy<1.16; python_version < "3.11"
-scipy>=1.16.1,<1.18; python_version >= "3.11"
-# Remove if Python 3.13+ support lands in pydub upstream.
-audioop-lts>=0.2.2; python_version >= "3.13"

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -48,3 +48,6 @@ importlib-metadata<8.0.0
 # mcp which is a pywin32 dependency that fails on linux CI.
 fastapi
 orjson
+
+# Model Context Protocol client for the /mcp command and MCP tool support.
+mcp

--- a/tests/basic/mock_mcp_server.py
+++ b/tests/basic/mock_mcp_server.py
@@ -1,0 +1,27 @@
+"""A tiny, deterministic MCP server used only for tests.
+
+Exposes two tools (``echo_tool`` and ``add``) and is served either over
+streamable HTTP (for in-process uvicorn) or stdio (as a subprocess).
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+
+def make_server() -> FastMCP:
+    server = FastMCP("mock-aider-test")
+
+    @server.tool()
+    def echo_tool(text: str) -> str:
+        """Echo the given text back."""
+        return f"echo: {text}"
+
+    @server.tool()
+    def add(a: float, b: float) -> float:
+        """Add two numbers."""
+        return a + b
+
+    return server
+
+
+if __name__ == "__main__":
+    make_server().run()

--- a/tests/basic/test_mcp_client.py
+++ b/tests/basic/test_mcp_client.py
@@ -95,6 +95,21 @@ class TestConfig:
         assert servers["s1"].args == ["-y", "foo"]
         assert servers["s1"].env == {"A": "b"}
 
+    def test_mcp_json_remote_type_and_enabled(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(
+                {
+                    "mcpServers": {
+                        "on": {"type": "remote", "url": "http://x/mcp", "enabled": True},
+                        "off": {"type": "remote", "url": "http://y/mcp", "enabled": False},
+                    }
+                }
+            )
+        )
+        servers = load_mcp_json(tmp_path)
+        assert servers["on"].url == "http://x/mcp"
+        assert "off" not in servers
+
     def test_precedence_cli_over_json(self, tmp_path):
         (tmp_path / ".mcp.json").write_text(
             json.dumps({"mcpServers": {"s1": {"url": "http://json"}}})

--- a/tests/basic/test_mcp_client.py
+++ b/tests/basic/test_mcp_client.py
@@ -330,3 +330,144 @@ class TestMCPCommands:
         with mock.patch.object(commands.io, "tool_error") as err:
             commands.cmd_mcp("list")
         assert any("No MCP servers configured" in str(a[0]) for a in err.call_args_list)
+
+
+class TestMCPAutoDispatch:
+    """Regression tests for the auto-dispatch loop and tool_calls round-trip.
+
+    The model must be able to emit modern ``tool_calls`` (not legacy
+    ``function_call``) and receive results back as ``role="tool"`` messages
+    with a matching ``tool_call_id`` - that's what the local llama.cpp router
+    expects. These tests use only the mock server (never a real MCP endpoint).
+    """
+
+    def make_coder(self, http_server, tmp_path, monkeypatch, stream=False):
+        from aider.coders import Coder
+        from aider.io import InputOutput
+        from aider.models import Model
+
+        monkeypatch.chdir(tmp_path)
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(Model("gpt-3.5-turbo"), None, io, stream=stream)
+
+        mgr = MCPManager(io=io)
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        coder.mcp_manager = mgr
+        coder.functions = list(mgr.function_definitions())
+        return coder, mgr
+
+    def test_streaming_tool_calls_accumulate(self, tmp_path, monkeypatch):
+        """Modern ``delta.tool_calls`` chunks must accumulate name/arguments/id."""
+        from types import SimpleNamespace
+
+        from aider.coders import Coder
+        from aider.io import InputOutput
+        from aider.models import Model
+
+        monkeypatch.chdir(tmp_path)
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        model = Model("gpt-3.5-turbo")
+        coder = Coder.create(model, None, io=io, stream=True)
+
+        def make_chunk(tool_calls):
+            chunk = mock.MagicMock()
+            chunk.choices = [mock.MagicMock()]
+            chunk.choices[0].finish_reason = None
+            chunk.choices[0].delta = mock.MagicMock()
+            chunk.choices[0].delta.content = None
+            chunk.choices[0].delta.reasoning_content = None
+            chunk.choices[0].delta.reasoning = None
+            chunk.choices[0].delta.tool_calls = tool_calls
+            return chunk
+
+        chunks = [
+            make_chunk(
+                [
+                    SimpleNamespace(
+                        id="call_abc123",
+                        function=SimpleNamespace(
+                            name="echo_tool", arguments='{"te'
+                        ),
+                    )
+                ]
+            ),
+            make_chunk(
+                [
+                    SimpleNamespace(
+                        id=None,
+                        function=SimpleNamespace(name=None, arguments='xt": "hi"}'),
+                    )
+                ]
+            ),
+        ]
+
+        mock_hash = mock.MagicMock()
+        mock_hash.hexdigest.return_value = "mock_hash_digest"
+        with mock.patch.object(
+            model, "send_completion", return_value=(mock_hash, chunks)
+        ):
+            messages = [{"role": "user", "content": "hello"}]
+            list(coder.send(messages))
+
+        assert coder.partial_response_function_call == {
+            "name": "echo_tool",
+            "arguments": '{"text": "hi"}',
+        }
+        assert coder.partial_response_tool_call_id == "call_abc123"
+
+    def test_auto_dispatch_emits_modern_tool_calls(self, http_server, tmp_path, monkeypatch):
+        """The dispatch loop must round-trip as modern tool_calls + role=tool."""
+        coder, mgr = self.make_coder(http_server, tmp_path, monkeypatch, stream=False)
+
+        calls = []
+
+        def fake_send(messages, model=None, functions=None):
+            calls.append(messages)
+            if len(calls) == 1:
+                coder.partial_response_function_call = {
+                    "name": "echo_tool",
+                    "arguments": '{"text": "hi"}',
+                }
+                coder.partial_response_tool_call_id = "call_abc123"
+            else:
+                coder.partial_response_function_call = dict()
+                coder.partial_response_tool_call_id = None
+                coder.partial_response_content = "I echoed it."
+            yield None
+
+        try:
+            with mock.patch.object(coder, "send", fake_send):
+                coder.run_one("hello", preproc=False)
+
+            assert len(calls) == 2, "second send() is the post-tool round trip"
+
+            roles = [m["role"] for m in coder.cur_messages]
+            assert roles.count("tool") == 1
+            assert roles.count("assistant") == 2  # tool_calls msg + final content msg
+
+            assistant_msg = next(
+                m for m in coder.cur_messages if m.get("tool_calls")
+            )
+            assert assistant_msg["content"] is None
+            assert assistant_msg["tool_calls"] == [
+                {
+                    "id": "call_abc123",
+                    "type": "function",
+                    "function": {
+                        "name": "echo_tool",
+                        "arguments": '{"text": "hi"}',
+                    },
+                }
+            ]
+            # No legacy function_call assistant message for MCP tools
+            assert not any(
+                m.get("role") == "assistant" and "function_call" in m
+                for m in coder.cur_messages
+            )
+
+            tool_msg = next(m for m in coder.cur_messages if m["role"] == "tool")
+            assert tool_msg["tool_call_id"] == "call_abc123"
+            assert tool_msg["content"].startswith("[MCP tool 'echo_tool' result]")
+        finally:
+            mgr.shutdown()

--- a/tests/basic/test_mcp_client.py
+++ b/tests/basic/test_mcp_client.py
@@ -230,6 +230,8 @@ class TestMainWiring:
             names = {f["name"] for f in mgr.function_definitions()}
             assert "echo_tool" in names
             assert any(f.get("name") == "echo_tool" for f in coder.functions)
+            assert coder.mcp_max_roundtrips == 0
+            assert mgr.max_roundtrips == 0
         finally:
             coder.mcp_manager.shutdown()
 

--- a/tests/basic/test_mcp_client.py
+++ b/tests/basic/test_mcp_client.py
@@ -239,6 +239,31 @@ class TestMCPCommands:
         coder.functions = list(mgr.function_definitions())
         return Commands(io, coder), coder, mgr
 
+    def test_subcoder_with_nonfunc_edit_format(self, http_server, tmp_path, monkeypatch):
+        from aider.coders import Coder
+        from aider.io import InputOutput
+        from aider.models import Model
+
+        monkeypatch.chdir(tmp_path)
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(Model("gpt-3.5-turbo"), None, io)
+
+        mgr = MCPManager(io=io)
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        coder.mcp_manager = mgr
+        coder.functions = list(mgr.function_definitions())
+
+        try:
+            sub = Coder.create(
+                coder.main_model, edit_format="whole", io=io, from_coder=coder
+            )
+            assert sub.mcp_manager is mgr
+            names = {f["name"] for f in sub.functions or []}
+            assert "echo_tool" in names
+        finally:
+            coder.mcp_manager.shutdown()
+
     def test_mcp_status(self, http_server, tmp_path, monkeypatch):
         commands, coder, _ = self.make_commands(http_server, tmp_path, monkeypatch)
         with mock.patch.object(commands.io, "tool_output") as out:

--- a/tests/basic/test_mcp_client.py
+++ b/tests/basic/test_mcp_client.py
@@ -1,0 +1,292 @@
+"""Tests for MCP client, config discovery and manager.
+
+Uses a local mock MCP server (``mock_mcp_server``) - never a real or
+external MCP endpoint - so tests are deterministic and offline.
+"""
+
+import json
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[2]
+MOCK_SERVER = ROOT / "tests" / "basic" / "mock_mcp_server.py"
+
+from aider.mcp.client import MCPClient
+from aider.mcp.config import (
+    MCPServerConfig,
+    load_from_args,
+    load_mcp_json,
+    parse_header_value,
+    parse_name_value,
+)
+from aider.mcp.manager import MCPManager
+
+
+def free_port():
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+def http_server():
+    """Start the mock server over streamable HTTP on an ephemeral port."""
+    import importlib.util
+    import uvicorn
+
+    spec = importlib.util.spec_from_file_location("mock_mcp_server", MOCK_SERVER)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    app = mod.make_server().streamable_http_app()
+    port = free_port()
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="error")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(50):
+        if server.started:
+            break
+        time.sleep(0.1)
+    yield f"http://127.0.0.1:{port}/mcp"
+    server.should_exit = True
+    thread.join(timeout=5)
+
+
+class TestParse:
+    def test_parse_name_value(self):
+        assert parse_name_value("a=http://x") == ("a", "http://x")
+        assert parse_name_value("noequals") is None
+
+    def test_parse_header_value(self):
+        assert parse_header_value('m="Authorization: Bearer tok"') == (
+            "m",
+            "Authorization",
+            "Bearer tok",
+        )
+
+
+class TestConfig:
+    def test_mcp_json_http(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"s1": {"url": "http://x/mcp", "headers": {"Authorization": "Bearer t"}}}}
+            )
+        )
+        servers = load_mcp_json(tmp_path)
+        assert servers["s1"].url == "http://x/mcp"
+        assert servers["s1"].headers["Authorization"] == "Bearer t"
+
+    def test_mcp_json_stdio(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps(
+                {"mcpServers": {"s1": {"command": "npx", "args": ["-y", "foo"], "env": {"A": "b"}}}}
+            )
+        )
+        servers = load_mcp_json(tmp_path)
+        assert servers["s1"].command == "npx"
+        assert servers["s1"].args == ["-y", "foo"]
+        assert servers["s1"].env == {"A": "b"}
+
+    def test_precedence_cli_over_json(self, tmp_path):
+        (tmp_path / ".mcp.json").write_text(
+            json.dumps({"mcpServers": {"s1": {"url": "http://json"}}})
+        )
+        servers = load_from_args(
+            ["s1=http://cli", "s2=http://two"], ["s1=Authorization: Bearer tok"], tmp_path
+        )
+        assert servers["s1"].url == "http://cli"
+        assert servers["s1"].headers["Authorization"] == "Bearer tok"
+        assert servers["s2"].url == "http://two"
+
+
+class TestClientHTTP:
+    def test_list_and_call(self, http_server):
+        client = MCPClient(name="mock", url=http_server)
+        try:
+            client.start()
+            tools = client.list_tools()
+            names = {t.name for t in tools}
+            assert {"echo_tool", "add"} <= names
+
+            result = client.call_tool("echo_tool", {"text": "hi"})
+            blocks = [b for b in result.content if b.type == "text"]
+            assert any("echo: hi" in b.text for b in blocks)
+        finally:
+            client.close()
+
+    def test_headers_supported(self, http_server):
+        client = MCPClient(
+            name="mock", url=http_server, headers={"X-Test": "1"}
+        )
+        try:
+            client.start()
+            assert client.list_tools()
+        finally:
+            client.close()
+
+
+class TestClientStdio:
+    def test_list_and_call(self):
+        client = MCPClient(name="mock-stdio", command=sys.executable, args=[str(MOCK_SERVER)])
+        try:
+            client.start()
+            tools = client.list_tools()
+            names = {t.name for t in tools}
+            assert {"echo_tool", "add"} <= names
+
+            result = client.call_tool("add", {"a": 2, "b": 3})
+            blocks = [b for b in result.content if b.type == "text"]
+            assert any("5" in b.text for b in blocks)
+        finally:
+            client.close()
+
+
+class TestManager:
+    def test_function_definitions_and_dispatch(self, http_server):
+        mgr = MCPManager(output_limit=100, max_roundtrips=2, timeout=30)
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        try:
+            funcs = mgr.function_definitions()
+            names = {f["name"] for f in funcs}
+            assert "echo_tool" in names
+
+            result = mgr.dispatch("echo_tool", {"text": "hello"})
+            assert result["is_error"] is False
+            assert "echo: hello" in result["text"]
+        finally:
+            mgr.shutdown()
+
+    def test_unknown_tool(self, http_server):
+        mgr = MCPManager()
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        try:
+            result = mgr.dispatch("nope", {})
+            assert result["is_error"] is True
+        finally:
+            mgr.shutdown()
+
+    def test_truncation(self, http_server):
+        mgr = MCPManager(output_limit=10)
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        try:
+            result = mgr.dispatch("echo_tool", {"text": "this is way too long"})
+            assert len(result["text"]) <= 10
+        finally:
+            mgr.shutdown()
+
+    def test_remove_server(self, http_server):
+        mgr = MCPManager()
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        assert mgr.is_mcp_tool("echo_tool")
+        mgr.remove_server("mock")
+        assert not mgr.is_mcp_tool("echo_tool")
+
+
+class TestMainWiring:
+    def test_main_attaches_manager(self, http_server, tmp_path, monkeypatch):
+        from aider.main import main
+
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("AIDER_ANALYTICS", "false")
+
+        coder = main(
+            argv=[
+                "--mcp-server",
+                f"mock={http_server}",
+                "--yes-always",
+            ],
+            return_coder=True,
+        )
+        try:
+            mgr = coder.mcp_manager
+            assert mgr is not None
+            names = {f["name"] for f in mgr.function_definitions()}
+            assert "echo_tool" in names
+            assert any(f.get("name") == "echo_tool" for f in coder.functions)
+        finally:
+            coder.mcp_manager.shutdown()
+
+
+class TestMCPCommands:
+    def make_commands(self, http_server, tmp_path, monkeypatch):
+        import os
+
+        from aider.coders import Coder
+        from aider.commands import Commands
+        from aider.io import InputOutput
+        from aider.models import Model
+
+        monkeypatch.chdir(tmp_path)
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(Model("gpt-3.5-turbo"), None, io)
+
+        mgr = MCPManager(io=io)
+        mgr.add_config(MCPServerConfig(name="mock", url=http_server))
+        mgr.start()
+        coder.mcp_manager = mgr
+        coder.functions = list(mgr.function_definitions())
+        return Commands(io, coder), coder, mgr
+
+    def test_mcp_status(self, http_server, tmp_path, monkeypatch):
+        commands, coder, _ = self.make_commands(http_server, tmp_path, monkeypatch)
+        with mock.patch.object(commands.io, "tool_output") as out:
+            commands.cmd_mcp("")
+        lines = [str(a[0]) for a in out.call_args_list]
+        assert any("mock" in line for line in lines)
+        assert any("Total tools available: 2" in line for line in lines)
+
+    def test_mcp_list(self, http_server, tmp_path, monkeypatch):
+        commands, coder, _ = self.make_commands(http_server, tmp_path, monkeypatch)
+        with mock.patch.object(commands.io, "tool_output") as out:
+            commands.cmd_mcp("list")
+        lines = [str(a[0]) for a in out.call_args_list]
+        assert any("echo_tool" in line for line in lines)
+        assert any("add" in line for line in lines)
+
+    def test_mcp_exec_injects_result(self, http_server, tmp_path, monkeypatch):
+        commands, coder, _ = self.make_commands(http_server, tmp_path, monkeypatch)
+        commands.cmd_mcp('exec echo_tool {"text": "hi there"}')
+        assert any(
+            msg.get("role") == "user" and "[MCP tool 'echo_tool' result]" in msg.get("content", "")
+            for msg in coder.cur_messages
+        )
+
+    def test_mcp_exec_unknown_tool(self, http_server, tmp_path, monkeypatch):
+        commands, coder, _ = self.make_commands(http_server, tmp_path, monkeypatch)
+        with mock.patch.object(commands.io, "tool_error") as err:
+            commands.cmd_mcp("exec nope_tool")
+        assert any("nope_tool" in str(a[0]) for a in err.call_args_list)
+
+    def test_mcp_remove(self, http_server, tmp_path, monkeypatch):
+        commands, coder, mgr = self.make_commands(http_server, tmp_path, monkeypatch)
+        with mock.patch.object(commands.io, "tool_output"):
+            commands.cmd_mcp("remove mock")
+        assert not mgr.is_mcp_tool("echo_tool")
+
+    def test_mcp_no_manager(self, tmp_path, monkeypatch):
+        import os
+
+        from aider.coders import Coder
+        from aider.commands import Commands
+        from aider.io import InputOutput
+        from aider.models import Model
+
+        monkeypatch.chdir(tmp_path)
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(Model("gpt-3.5-turbo"), None, io)
+        commands = Commands(io, coder)
+        with mock.patch.object(commands.io, "tool_error") as err:
+            commands.cmd_mcp("list")
+        assert any("No MCP servers configured" in str(a[0]) for a in err.call_args_list)


### PR DESCRIPTION
## Summary

Adds MCP tool-call round-trip support to the built-in coder: modern `tool_calls` format for streaming (non-parser) models, correct tool-result messages, unlimited roundtrips by default, and a clean MCP session shutdown at exit.

### Changes
- **`aider/coders/base_coder.py`** — emit a modern `tool_calls` array (id/type/`function{name,arguments}`) for both streaming and non-streaming paths; store the tool-call id (incl. streaming fragments) in `partial_response_tool_call_id`; send tool results as `role:"tool", tool_call_id=<id>` messages; the auto-dispatch loop round-trips tool results back into the chat with the correct format.
- **`aider/models.py`** — `send_completion` sends **all** functions as `tools` (fixes only `functions[0]` being visible) and sets `tool_choice: "auto"` when more than one function is present, so the model can call any MCP tool (e.g. 37 tools via `~/.mcp.json`).
- **`aider/mcp/manager.py`**, **`aider/args.py`** — `--mcp-max-roundtrips` now defaults to **0 = unlimited** (0 disables the cap; explicit `N` still enforces it) so multi-step research workflows aren't cut off after 5 round-trips.
- **`aider/main.py`** — register `mcp_manager.shutdown` with `threading._register_atexit` (runs before `concurrent.futures._python_exit` kills threadpool executors) plus the existing `atexit` backstop. Eliminates the benign `Session termination failed: cannot schedule new futures after shutdown` warning at exit.
- **`tests/basic/test_mcp_client.py`** — new `TestMCPAutoDispatch` (streaming accumulation + modern dispatch round-trip), and wiring assertions that `--mcp-max-roundtrips` defaults to unlimited (0).

Verified: MCP client suite 23/23, coder suite 42 passed, main/commands wiring 169 passed, no exit-termination warning in live runs.