### PR TITLE
Skip non-dict entries in fuzzy_match_models

### DIFF
--- a/aider/models.py
+++ b/aider/models.py
@@ -1233,6 +1233,11 @@ def fuzzy_match_models(name):
 
     for orig_model, attrs in model_metadata:
         model = orig_model.lower()
+        # litellm.model_cost holds a few non-dict entries (e.g. a list under
+        # "sample_spec"); skip anything that is not a metadata mapping rather
+        # than crashing on attrs.get(...).
+        if not isinstance(attrs, dict):
+            continue
         if attrs.get("mode") != "chat":
             continue
         provider = attrs.get("litellm_provider", "").lower()

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -30,6 +30,22 @@ class TestModels(unittest.TestCase):
         info = manager.get_model_info("non-existent-model")
         self.assertEqual(info, {})
 
+    def test_fuzzy_match_models_handles_non_dict_metadata(self):
+        # litellm.model_cost can contain non-dict entries (e.g. a list under
+        # "sample_spec"); fuzzy_match_models must skip them instead of raising
+        # AttributeError: 'list' object has no attribute 'get'.
+        import litellm
+
+        from aider.models import fuzzy_match_models
+
+        bogus = {
+            "sample_spec": ["not", "a", "dict"],
+            "gpt-4-test": {"mode": "chat", "litellm_provider": "openai"},
+        }
+        with patch.object(litellm, "model_cost", bogus):
+            result = fuzzy_match_models("gpt-4-test")
+        self.assertIn("openai/gpt-4-test", result)
+
     def test_max_context_tokens(self):
         model = Model("gpt-3.5-turbo")
         self.assertEqual(model.info["max_input_tokens"], 16385)


### PR DESCRIPTION
Fixes #5537

### Problem

`fuzzy_match_models` iterates `litellm.model_cost` and immediately calls `attrs.get("mode")` on each value:

```python
for orig_model, attrs in model_metadata:
    model = orig_model.lower()
    if attrs.get("mode") != "chat":
```

`model_cost` is not uniformly a mapping of dicts. It contains at least one non-dict entry (a list under `sample_spec`), so the call raises:

```
AttributeError: 'list' object has no attribute 'get'
```

This surfaces as the uncaught exception in #5537, thrown from `sanity_check_model` -> `fuzzy_match_models` during startup.

### Fix

Skip any entry whose value is not a dict before reading its metadata fields.

### Test

Added `test_fuzzy_match_models_handles_non_dict_metadata`, which patches `litellm.model_cost` with a list-valued entry alongside a normal chat model and asserts the chat model is still matched. It reproduces the `AttributeError` without this change and passes with it. Full `tests/basic/test_models.py` passes (25 passed).