### PR TITLE
Fix deepseek cache-hit cost fallback subtracting a price from a count

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -2089,7 +2089,7 @@ class Coder:
         if input_cost_per_token_cache_hit:
             # must be deepseek
             cost += input_cost_per_token_cache_hit * cache_hit_tokens
-            cost += (prompt_tokens - input_cost_per_token_cache_hit) * input_cost_per_token
+            cost += (prompt_tokens - cache_hit_tokens) * input_cost_per_token
         else:
             # hard code the anthropic adjustments, no-ops for other models since cache_x_tokens==0
             cost += cache_write_tokens * input_cost_per_token * 1.25

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1433,6 +1433,35 @@ This command will print 'Hello, World!' to the console."""
                     # (because user rejected the changes)
                     mock_editor.run.assert_not_called()
 
+    def test_compute_costs_from_tokens_deepseek_cache_hit(self):
+        # Deepseek-style pricing: input_cost_per_token_cache_hit is set,
+        # so the deepseek branch of compute_costs_from_tokens is taken.
+        with GitTemporaryDirectory():
+            io = InputOutput()
+            coder = Coder.create(self.GPT35, None, io)
+            coder.main_model.info = {
+                "input_cost_per_token": 2.7e-07,
+                "output_cost_per_token": 1.1e-06,
+                "input_cost_per_token_cache_hit": 2.8e-08,
+            }
+
+            # 10,000 total prompt tokens, 9,000 of which were cache hits.
+            cost = coder.compute_costs_from_tokens(
+                prompt_tokens=10000,
+                completion_tokens=0,
+                cache_write_tokens=0,
+                cache_hit_tokens=9000,
+            )
+
+            # The 9,000 cache-hit tokens are billed at the cache-hit rate,
+            # and only the remaining 1,000 uncached tokens at the full
+            # input rate. Before the fix, the uncached remainder was
+            # (prompt_tokens - input_cost_per_token_cache_hit), i.e. still
+            # ~10,000, so the full prompt got double-billed on top of the
+            # cache-hit charge.
+            expected = 9000 * 2.8e-08 + 1000 * 2.7e-07
+            self.assertAlmostEqual(cost, expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #5516

## What

`compute_costs_from_tokens`'s deepseek branch:

```python
if input_cost_per_token_cache_hit:
    # must be deepseek
    cost += input_cost_per_token_cache_hit * cache_hit_tokens
    cost += (prompt_tokens - input_cost_per_token_cache_hit) * input_cost_per_token
```

subtracts a **per-token price** (`input_cost_per_token_cache_hit`, e.g. `2.8e-08`)
from a **token count** (`prompt_tokens`) on the second line. That leaves
`prompt_tokens` unchanged to 8 decimal places, so the whole prompt gets charged at
the full input rate on top of the cache-hit charge, and the cache-hit tokens are
effectively billed twice. This uses `cache_hit_tokens` (already available as a
parameter) instead, which is what the line reads like it intended.

As the issue's own follow-up comment clarifies, this fallback path only runs when
`litellm.completion_cost()` throws or returns 0 (an uncosted model or an
exception), so the primary cost path is correct and unaffected. That makes this a
narrower fix than the issue's original framing, matching the author's own reduced
scope ("take just the deepseek line, which is wrong whether or not it executes").

## How this was tested

Added `test_compute_costs_from_tokens_deepseek_cache_hit` in
`tests/basic/test_coder.py`, following the existing pattern in that file of setting
`coder.main_model.info` directly (e.g. `test_show_exhausted_error`) to drive a pure
function call without needing network or model API access.

The test fails on `main` and passes with this change. With deepseek-shaped pricing,
10,000 prompt tokens and 9,000 cache hits, the old line overcharges by 5.65x:

```
$ python -m pytest tests/basic/test_coder.py::TestCoder::test_compute_costs_from_tokens_deepseek_cache_hit -v

# before the fix:
E  AssertionError: 0.0029519999999924403 != 0.000522 within 7 places
   (0.0024299999999924404 difference)
FAILED tests/basic/test_coder.py::TestCoder::test_compute_costs_from_tokens_deepseek_cache_hit
1 failed in 3.44s

# with the fix:
tests/basic/test_coder.py::TestCoder::test_compute_costs_from_tokens_deepseek_cache_hit PASSED [100%]
1 passed in 3.69s
```

Full file, no regressions:

```
$ python -m pytest tests/basic/test_coder.py
collected 43 items
tests/basic/test_coder.py ...........................................  [100%]
43 passed in 14.64s
```

The `.pre-commit-config.yaml` hooks on both changed files, all clean:

```
$ black --line-length 100 --preview --check aider/coders/base_coder.py tests/basic/test_coder.py
All done! 2 files would be left unchanged.
$ isort --profile black --check-only <same files>     # clean
$ flake8 --show-source <same files>                   # clean
$ codespell <same files>                              # clean
```

Python 3.11.2, installed with `pip install -e .`.

## AI disclosure

This PR was authored by an AI coding agent (Claude). The verification above was
run before submission, and a human reviewed the diff.
