### PR TITLE
Fix incorrect flag name in scripting docs (--yes → --yes-always)

### DIFF
--- a/aider/website/docs/scripting.md
+++ b/aider/website/docs/scripting.md
@@ -40,7 +40,7 @@ but these are useful for scripting:
 --message-file MESSAGE_FILE, -f MESSAGE_FILE
                       Specify a file containing the message to send GPT, process reply,
                       then exit (disables chat mode) [env var: AIDER_MESSAGE_FILE]
---yes                 Always say yes to every confirmation [env var: AIDER_YES]
+--yes-always          Always say yes to every confirmation [env var: AIDER_YES_ALWAYS]
 --auto-commits, --no-auto-commits
                       Enable/disable auto commit of GPT changes (default: True) [env var:
                       AIDER_AUTO_COMMITS]
@@ -86,7 +86,7 @@ See the
 [Coder.create() and Coder.__init__() methods](https://github.com/Aider-AI/aider/blob/main/aider/coders/base_coder.py)
 for all the supported arguments.
 
-It can also be helpful to set the equivalent of `--yes` by doing this:
+It can also be helpful to set the equivalent of `--yes-always` by doing this:
 
 ```python
 from aider.io import InputOutput


### PR DESCRIPTION
## What

`aider/website/docs/scripting.md` documents a `--yes` flag and an `AIDER_YES` environment variable that don't exist. The actual flag is `--yes-always` (env var `AIDER_YES_ALWAYS`).

## Why it matters

This page is specifically about non-interactive / CI usage, where auto-confirming prompts is the single most relevant flag. A reader who follows the docs and runs `aider --yes` hits `error: unrecognized arguments: --yes`.

The correct names are confirmed by the source and by Aider's own generated reference docs:

- `aider/args.py` registers `--yes-always` (and there is no `--yes`)
- `aider/website/docs/config/options.md` → `--yes-always`, `Environment variable: AIDER_YES_ALWAYS`
- `aider/website/docs/config/dotenv.md` → `AIDER_YES_ALWAYS`

## Change

Two one-line doc corrections in `scripting.md`, no code changes:

- the `--help` listing: `--yes` / `AIDER_YES` → `--yes-always` / `AIDER_YES_ALWAYS`
- the prose "set the equivalent of `--yes`" → `--yes-always` (above the `InputOutput(yes=True)` example)

---
*Drafted with AI assistance (Claude Code); the flag and env-var names were verified against `aider/args.py` and the generated options reference.*
