### PR TITLE
fix: exit non-zero on fatal API errors in --message/--message-file

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -95,6 +95,7 @@ class Coder:
     repo_map = None
     functions = None
     num_exhausted_context_windows = 0
+    num_llm_errors = 0
     num_malformed_responses = 0
     last_keyboard_interrupt = None
     num_reflections = 0
@@ -1474,6 +1475,7 @@ class Coder:
                     if not should_retry:
                         self.mdstream = None
                         self.check_and_open_urls(err, ex_info.description)
+                        self.num_llm_errors += 1
                         break
 
                     err_msg = str(err)

--- a/aider/main.py
+++ b/aider/main.py
@@ -1131,7 +1131,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         except SwitchCoder:
             pass
         analytics.event("exit", reason="Completed --message")
-        return
+        return 1 if coder.num_llm_errors else None
 
     if args.message_file:
         try:
@@ -1148,7 +1148,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             return 1
 
         analytics.event("exit", reason="Completed --message-file")
-        return
+        return 1 if coder.num_llm_errors else None
 
     if args.exit:
         analytics.event("exit", reason="Exit flag set")

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -338,6 +338,40 @@ class TestMain(TestCase):
 
         os.remove(message_file_path)
 
+    def test_main_message_returns_1_on_llm_error(self):
+        with patch("aider.coders.Coder.create") as MockCoder:
+            mock_coder = MagicMock()
+            mock_coder.num_llm_errors = 1
+            MockCoder.return_value = mock_coder
+            res = main(["--yes", "--message", "hi"], input=DummyInput(), output=DummyOutput())
+            self.assertEqual(res, 1)
+
+    def test_main_message_returns_none_without_llm_error(self):
+        with patch("aider.coders.Coder.create") as MockCoder:
+            mock_coder = MagicMock()
+            mock_coder.num_llm_errors = 0
+            MockCoder.return_value = mock_coder
+            res = main(["--yes", "--message", "hi"], input=DummyInput(), output=DummyOutput())
+            self.assertIsNone(res)
+
+    def test_main_message_file_returns_1_on_llm_error(self):
+        message_file_path = tempfile.mktemp()
+        with open(message_file_path, "w", encoding="utf-8") as message_file:
+            message_file.write("This is a test message from a file.")
+
+        with patch("aider.coders.Coder.create") as MockCoder:
+            mock_coder = MagicMock()
+            mock_coder.num_llm_errors = 1
+            MockCoder.return_value = mock_coder
+            res = main(
+                ["--yes", "--message-file", message_file_path],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+            self.assertEqual(res, 1)
+
+        os.remove(message_file_path)
+
     def test_encodings_arg(self):
         fname = "foo.py"
 

--- a/tests/basic/test_sendchat.py
+++ b/tests/basic/test_sendchat.py
@@ -148,6 +148,26 @@ class TestSendChat(unittest.TestCase):
         result = ensure_alternating_roles(messages)
         assert result == expected
 
+    def test_send_message_num_llm_errors_fatal_error(self):
+        from aider.coders import Coder
+        from aider.io import InputOutput
+
+        coder = Coder.create(
+            Model("gpt-4"),
+            None,
+            io=InputOutput(pretty=False, yes=True),
+            map_tokens=0,
+            use_git=False,
+        )
+        with patch(
+            "litellm.completion",
+            side_effect=litellm.NotFoundError(
+                "invalid", llm_provider="test", model="gpt-4"
+            ),
+        ):
+            coder.run(with_message="hi")
+        self.assertEqual(coder.num_llm_errors, 1)
+
     def test_ensure_alternating_roles_mixed_sequence(self):
         from aider.sendchat import ensure_alternating_roles
 


### PR DESCRIPTION
## Problem

Aider exits with code 0 on fatal API connection errors when run headless/scripted via `--message` or `--message-file`, so automation pipelines report SUCCESS even though the model request never succeeded.

## Root cause

In `aider/coders/base_coder.py`, `send_message()` swallows fatal litellm exceptions:

- Retryable errors (e.g. `APIConnectionError`, `InternalServerError`) back off until `retry_delay` exceeds `RETRY_TIMEOUT`, then `break`.
- Non-retryable errors (e.g. `NotFoundError`, `AuthenticationError`) `break` immediately.

Neither path records that an error occurred. `aider/main.py`'s `--message` and `--message-file` branches therefore `return None`, which `sys.exit(None)` turns into exit code 0. The only tracked failure was `ContextWindowExceededError` via the pre-existing `num_exhausted_context_windows` counter.

## Fix (minimal, follows existing patterns)

1. Add a `num_llm_errors = 0` class attribute to `Coder`, alongside `num_exhausted_context_windows`.
2. Increment `self.num_llm_errors` in the `if not should_retry:` break branch of `send_message()` (after the `ContextWindowExceededError` special-case), so both retry-exhausted and non-retryable fatal errors are recorded.
3. In `aider/main.py`, the `--message` and `--message-file` success branches now `return 1 if coder.num_llm_errors else None`, so a fatal API error surfaces as a non-zero exit code for headless/scripted callers. Interactive mode is unaffected.

## Tests (TDD)

RED (both fail on `main`):

- `tests/basic/test_sendchat.py::test_send_message_num_llm_errors_fatal_error` — drives `Coder.run(with_message="hi")` with `litellm.completion` raising a non-retryable `NotFoundError` and asserts `coder.num_llm_errors == 1`. Fails with `AttributeError: 'EditBlockCoder' object has no attribute 'num_llm_errors'`.
- `tests/basic/test_main.py::test_main_message_returns_1_on_llm_error` and `test_main_message_file_returns_1_on_llm_error` — assert `main([...])` returns `1` when `coder.num_llm_errors` is set. Fail with `AssertionError: None != 1`.

GREEN (all pass after the fix):

- The three tests above plus `test_main_message_returns_none_without_llm_error` (exit stays `None`/0 when no error occurred).
- Full `tests/basic/test_sendchat.py` + `tests/basic/test_main.py`: 92 passed.
- `tests/basic/test_coder.py`: 42 passed, 29 subtests passed.

## ICLA

Note: aider's CONTRIBUTING.md requires contributors to complete the Individual Contributor License Agreement (https://aider.chat/docs/legal/contributor-agreement.html). I am happy to complete it as part of the PR process.