### PR TITLE
feat: allow disabling model warning browser prompts

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -210,6 +210,12 @@ def get_parser(default_config_files, git_root):
         help="Only work with models that have meta-data available (default: True)",
     )
     group.add_argument(
+        "--open-model-warnings",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Allow opening model warning documentation in a browser (default: True)",
+    )
+    group.add_argument(
         "--check-model-accepts-settings",
         action=argparse.BooleanOptionalAction,
         default=True,

--- a/aider/main.py
+++ b/aider/main.py
@@ -893,12 +893,13 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             analytics.event("model warning", main_model=main_model)
             io.tool_output("You can skip this check with --no-show-model-warnings")
 
-            try:
-                io.offer_url(urls.model_warnings, "Open documentation url for more info?")
-                io.tool_output()
-            except KeyboardInterrupt:
-                analytics.event("exit", reason="Keyboard interrupt during model warnings")
-                return 1
+            if args.open_model_warnings:
+                try:
+                    io.offer_url(urls.model_warnings, "Open documentation url for more info?")
+                    io.tool_output()
+                except KeyboardInterrupt:
+                    analytics.event("exit", reason="Keyboard interrupt during model warnings")
+                    return 1
 
     repo = None
     if args.git:

--- a/aider/website/assets/sample.aider.conf.yml
+++ b/aider/website/assets/sample.aider.conf.yml
@@ -113,6 +113,9 @@
 ## Only work with models that have meta-data available (default: True)
 #show-model-warnings: true
 
+## Allow opening model warning documentation in a browser (default: True)
+#open-model-warnings: true
+
 ## Check if model accepts settings like reasoning_effort/thinking_tokens (default: True)
 #check-model-accepts-settings: true
 

--- a/aider/website/assets/sample.env
+++ b/aider/website/assets/sample.env
@@ -102,6 +102,9 @@
 ## Only work with models that have meta-data available (default: True)
 #AIDER_SHOW_MODEL_WARNINGS=true
 
+## Allow opening model warning documentation in a browser (default: True)
+#AIDER_OPEN_MODEL_WARNINGS=true
+
 ## Check if model accepts settings like reasoning_effort/thinking_tokens (default: True)
 #AIDER_CHECK_MODEL_ACCEPTS_SETTINGS=true
 

--- a/aider/website/docs/config/aider_conf.md
+++ b/aider/website/docs/config/aider_conf.md
@@ -167,6 +167,9 @@ cog.outl("```")
 ## Only work with models that have meta-data available (default: True)
 #show-model-warnings: true
 
+## Allow opening model warning documentation in a browser (default: True)
+#open-model-warnings: true
+
 ## Check if model accepts settings like reasoning_effort/thinking_tokens (default: True)
 #check-model-accepts-settings: true
 

--- a/aider/website/docs/config/dotenv.md
+++ b/aider/website/docs/config/dotenv.md
@@ -142,6 +142,9 @@ cog.outl("```")
 ## Only work with models that have meta-data available (default: True)
 #AIDER_SHOW_MODEL_WARNINGS=true
 
+## Allow opening model warning documentation in a browser (default: True)
+#AIDER_OPEN_MODEL_WARNINGS=true
+
 ## Check if model accepts settings like reasoning_effort/thinking_tokens (default: True)
 #AIDER_CHECK_MODEL_ACCEPTS_SETTINGS=true
 

--- a/aider/website/docs/config/options.md
+++ b/aider/website/docs/config/options.md
@@ -33,6 +33,7 @@ usage: aider [-h] [--model] [--openai-api-key] [--anthropic-api-key]
              [--auto-accept-architect | --no-auto-accept-architect]
              [--weak-model] [--editor-model] [--editor-edit-format]
              [--show-model-warnings | --no-show-model-warnings]
+             [--open-model-warnings | --no-open-model-warnings]
              [--check-model-accepts-settings | --no-check-model-accepts-settings]
              [--max-chat-history-tokens]
              [--cache-prompts | --no-cache-prompts]
@@ -228,6 +229,14 @@ Environment variable: `AIDER_SHOW_MODEL_WARNINGS`
 Aliases:
   - `--show-model-warnings`
   - `--no-show-model-warnings`
+
+### `--open-model-warnings`
+Allow opening model warning documentation in a browser (default: True)  
+Default: True  
+Environment variable: `AIDER_OPEN_MODEL_WARNINGS`  
+Aliases:
+  - `--open-model-warnings`
+  - `--no-open-model-warnings`
 
 ### `--check-model-accepts-settings`
 Check if model accepts settings like reasoning_effort/thinking_tokens (default: True)  

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -1120,6 +1120,27 @@ class TestMain(TestCase):
                 self.assertEqual(result, 1)  # Expect failure since no model could be selected
                 mock_offer_oauth.assert_called_once()
 
+    @patch("aider.main.models.sanity_check_models", return_value=True)
+    def test_no_open_model_warnings_keeps_terminal_warning(self, _):
+        with patch.object(InputOutput, "offer_url") as mock_offer_url:
+            with patch.object(InputOutput, "tool_output") as mock_tool_output:
+                main(
+                    [
+                        "--model",
+                        "gpt-4o",
+                        "--no-open-model-warnings",
+                        "--no-show-release-notes",
+                        "--no-git",
+                        "--exit",
+                        "--yes",
+                    ],
+                    input=DummyInput(),
+                    output=DummyOutput(),
+                )
+
+        mock_offer_url.assert_not_called()
+        mock_tool_output.assert_any_call("You can skip this check with --no-show-model-warnings")
+
     def test_model_precedence(self):
         with GitTemporaryDirectory():
             # Test that earlier API keys take precedence


### PR DESCRIPTION
## Summary

- add `--open-model-warnings` / `--no-open-model-warnings` so browser prompts can be disabled independently
- keep model metadata and cost warnings visible in the terminal
- document the CLI, environment-variable, and YAML configuration forms
- add regression coverage proving the warning remains visible while `offer_url` is skipped

## Motivation

Headless automation commonly uses `--yes`, which also accepts the model-warning documentation prompt and opens a browser on every new process. The existing `--no-show-model-warnings` option prevents the popup but also hides useful terminal diagnostics. This change separates those two behaviors while preserving the current default.

## Validation

- Python AST parsing passed for `aider/args.py`, `aider/main.py`, and `tests/basic/test_main.py`
- branch comparison is one commit ahead of `main` with only the eight intended files changed
- focused regression test added; the full pytest run is left to CI because the local GitHub source checkout repeatedly timed out

Fixes #5547
