### PR TITLE
repomap: stop including prompt mentions in the repo-map cache key (fixes repeated full scans on huge repos)

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -583,17 +583,19 @@ class RepoMap:
         force_refresh=False,
     ):
         # Create a cache key
+        #
+        # The key is built only from the file set (chat_fnames + other_fnames)
+        # and the token budget, NOT from the prompt-derived mentioned_fnames /
+        # mentioned_idents. Those only affect per-request ranking
+        # personalization; they do not change the underlying (expensive) repo
+        # scan. Including them in the key means every prompt that mentions a
+        # different file/identifier misses the cache and re-runs the full scan
+        # -- ~20 minutes on a repo the size of the Linux kernel. See #5529.
         cache_key = [
             tuple(sorted(chat_fnames)) if chat_fnames else None,
             tuple(sorted(other_fnames)) if other_fnames else None,
             max_map_tokens,
         ]
-
-        if self.refresh == "auto":
-            cache_key += [
-                tuple(sorted(mentioned_fnames)) if mentioned_fnames else None,
-                tuple(sorted(mentioned_idents)) if mentioned_idents else None,
-            ]
         cache_key = tuple(cache_key)
 
         use_cache = False

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -274,6 +274,71 @@ print(my_function(3, 4))
             del repo_map
 
 
+    def test_repo_map_auto_cache_not_polluted_by_mentions(self):
+        # Regression test for #5529.
+        #
+        # On a huge repo, refresh="auto" arms the repo-map cache once a single
+        # map generation is slow (>1s). The cache key must NOT include the
+        # prompt-derived mentioned_fnames/mentioned_idents: they only affect
+        # ranking personalization, so including them makes every prompt that
+        # mentions a different file/identifier miss the cache and re-run the
+        # full (20-minute on the Linux kernel) repo scan.
+        with GitTemporaryDirectory() as temp_dir:
+            repo = git.Repo(temp_dir)
+
+            file1_content = "def function1():\n    return 'Hello from file1'\n"
+            file2_content = "def function2():\n    return 'Hello from file2'\n"
+
+            with open(os.path.join(temp_dir, "file1.py"), "w") as f:
+                f.write(file1_content)
+            with open(os.path.join(temp_dir, "file2.py"), "w") as f:
+                f.write(file2_content)
+
+            repo.index.add(["file1.py", "file2.py"])
+            repo.index.commit("Initial commit")
+
+            io = InputOutput()
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io, refresh="auto")
+            other_files = [
+                os.path.join(temp_dir, "file1.py"),
+                os.path.join(temp_dir, "file2.py"),
+            ]
+
+            # Count how many times the expensive (uncached) scan runs.
+            scans = {"count": 0}
+            original_uncached = repo_map.get_ranked_tags_map_uncached
+
+            def counting_uncached(*args, **kwargs):
+                scans["count"] += 1
+                return original_uncached(*args, **kwargs)
+
+            repo_map.get_ranked_tags_map_uncached = counting_uncached
+
+            # First request: full scan happens once (nothing cached yet).
+            first_map = repo_map.get_repo_map(
+                [], other_files, mentioned_fnames={"file1.py"}, mentioned_idents={"function1"}
+            )
+            self.assertIn("function1", first_map)
+            self.assertEqual(scans["count"], 1)
+
+            # Simulate a huge repo where the first generation was slow (>1s),
+            # which is what arms the refresh="auto" map cache.
+            repo_map.map_processing_time = 2.0
+
+            # Second request mentions different files/identifiers. The files on
+            # disk are unchanged, so the expensive scan must NOT run again.
+            second_map = repo_map.get_repo_map(
+                [], other_files, mentioned_fnames={"file2.py"}, mentioned_idents={"function2"}
+            )
+            self.assertIn("file1.py", second_map)
+            self.assertIn("file2.py", second_map)
+            self.assertEqual(scans["count"], 1)
+
+            # close the open cache files, so Windows won't error
+            del repo_map
+            del repo
+
+
 class TestRepoMapTypescript(unittest.TestCase):
     def setUp(self):
         self.GPT35 = Model("gpt-3.5-turbo")


### PR DESCRIPTION
Fixes #5529

## Problem

On a repo the size of the Linux kernel, every request re-runs the full repo-map scan (~20 min each), making aider unusable. The map is cached, but the cache key in `get_ranked_tags_map()` includes `mentioned_fnames`/`mentioned_idents` whenever `refresh="auto"` is active:

```python
if self.refresh == "auto":
    cache_key += [
        tuple(sorted(mentioned_fnames)) if mentioned_fnames else None,
        tuple(sorted(mentioned_idents)) if mentioned_idents else None,
    ]
```

Those prompt-derived values change on every request (the user mentions different files/identifiers each turn), so every request misses the cache and re-runs the expensive scan, even though the file set and file contents are unchanged.

## Fix

Build the cache key only from the things the expensive scan actually depends on: the file set (`chat_fnames` + `other_fnames`) and the token budget. `mentioned_fnames`/`mentioned_idents` only affect per-request *ranking personalization* inside `get_ranked_tags()`; they do not change the underlying scan. Leaving them out of the key means the scan result is reused across prompts for an unchanged file set.

This matches the existing `refresh="files"` behavior, which has never put mentions in the key, and is consistent with the "auto" refresh intent: once a map is expensive to build, reuse it until the file set changes.

## Verification

Added `tests/basic/test_repomap.py::test_repo_map_auto_cache_not_polluted_by_mentions`. It arms the `refresh="auto"` cache (simulating a slow first scan via `map_processing_time`) and asserts that a second request with *different* mentioned files/identifiers does not run the uncached scan again:

```
$ AIDER_ANALYTICS=false PYTHONPATH=. python -m pytest -q tests/basic/test_repomap.py -k test_repo_map_auto_cache_not_polluted_by_mentions -p no:cacheprovider
1 passed
```

The test fails against `main` (the second request re-runs the scan) and passes with this change. The existing repo-map tests (`test_repo_map_refresh_files`, `test_repo_map_refresh_auto`) are unaffected.

## Notes

This is a small, localized change to the repo-map cache only; it does not touch other subsystems. No other open pull request in this repo is related.