### PR TITLE
fix: catch tree-sitter QueryError in repomap get_tags_raw

### DIFF
--- a/aider/repomap.py
+++ b/aider/repomap.py
@@ -16,7 +16,7 @@ from grep_ast import TreeContext, filename_to_lang
 from pygments.lexers import guess_lexer_for_filename
 from pygments.token import Token
 from tqdm import tqdm
-from tree_sitter import Query
+from tree_sitter import Query, QueryError
 
 from aider.dump import dump
 from aider.special import filter_important_files
@@ -299,7 +299,14 @@ class RepoMap:
         tree = parser.parse(bytes(code, "utf-8"))
 
         # Run the tags queries
-        captures = self._run_captures(Query(language, query_scm), tree.root_node)
+        try:
+            captures = self._run_captures(Query(language, query_scm), tree.root_node)
+        except QueryError as err:
+            # The tags query references a node type that isn't in this grammar
+            # (e.g. a language whose tree-sitter grammar is missing a construct).
+            # Skip the file rather than crashing the whole repo-map build.
+            print(f"Skipping file {fname}: {err}")
+            return
 
         captures_by_tag = defaultdict(list)
         matches = []

--- a/tests/basic/test_repomap.py
+++ b/tests/basic/test_repomap.py
@@ -4,8 +4,10 @@ import re
 import time
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 import git
+from tree_sitter import QueryError
 
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
@@ -271,6 +273,21 @@ print(my_function(3, 4))
             self.assertIn("test_file4.json", result)
 
             # close the open cache files, so Windows won't error
+            del repo_map
+
+    def test_get_tags_raw_skips_query_error(self):
+        with IgnorantTemporaryDirectory() as temp_dir:
+            py_file = os.path.join(temp_dir, "test_query_error.py")
+            with open(py_file, "w") as f:
+                f.write("def foo():\n    return 1\n")
+
+            io = InputOutput()
+            repo_map = RepoMap(main_model=self.GPT35, root=temp_dir, io=io)
+
+            with patch("aider.repomap.Query", side_effect=QueryError("Invalid node type: module")):
+                result = list(repo_map.get_tags_raw(py_file, "test_query_error.py"))
+
+            self.assertEqual(result, [])
             del repo_map
 
 


### PR DESCRIPTION
Fixes #5557

## Problem
`tree_sitter.QueryError` escapes `RepoMap.get_tags_raw()` when the tags query for a language references a node type that is not present in the installed tree-sitter grammar. Because the exception is uncaught, it propagates up through `get_repo_map()` and crashes the whole run (see the traceback in the issue).

## Root cause
In `aider/repomap.py`, `get_tags_raw()` constructs the tree-sitter query at `Query(language, query_scm)` (line 302) without handling the case where the query is invalid for the installed grammar.

## Fix
Wrap the query construction/captures in a `try/except tree_sitter.QueryError` and skip the unparseable file gracefully (print a "Skipping file ..." message and return), mirroring the existing handling of missing languages/parsers in the same function.

## Test
Added `test_get_tags_raw_skips_query_error`, which patches `aider.repomap.Query` to raise `QueryError` and asserts that `get_tags_raw()` yields no tags and does not crash.