### PR TITLE
fix: interpolate closing fence in cmd_tokens (fix #5561)

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -488,7 +488,7 @@ class Commands:
                 tokens = self.coder.main_model.token_count_for_image(fname)
             else:
                 # approximate
-                content = f"{relative_fname}\n{fence}\n" + content + "{fence}\n"
+                content = f"{relative_fname}\n{fence}\n" + content + f"{fence}\n"
                 tokens = self.coder.main_model.token_count(content)
             file_res.append((tokens, f"{relative_fname}", "/drop to remove"))
 
@@ -498,7 +498,7 @@ class Commands:
             content = self.io.read_text(fname)
             if content is not None and not is_image_file(relative_fname):
                 # approximate
-                content = f"{relative_fname}\n{fence}\n" + content + "{fence}\n"
+                content = f"{relative_fname}\n{fence}\n" + content + f"{fence}\n"
                 tokens = self.coder.main_model.token_count(content)
                 file_res.append((tokens, f"{relative_fname} (read-only)", "/drop to remove"))
 

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -386,6 +386,58 @@ class TestCommands(TestCase):
         self.assertIn("foo.txt", console_output)
         self.assertIn("bar.txt", console_output)
 
+    def test_cmd_tokens_uses_closing_fence_for_files(self):
+        Path("example.txt").write_text("file body\n")
+
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+        commands.cmd_add("example.txt")
+
+        with mock.patch.object(
+            coder.main_model,
+            "token_count",
+            return_value=1,
+        ) as token_count:
+            commands.cmd_tokens("")
+
+        file_content = next(
+            call.args[0]
+            for call in token_count.call_args_list
+            if isinstance(call.args[0], str) and "file body" in call.args[0]
+        )
+
+        self.assertEqual(
+            file_content,
+            "example.txt\n```\nfile body\n```\n",
+        )
+
+    def test_cmd_tokens_uses_closing_fence_for_read_only_files(self):
+        Path("ref.txt").write_text("read-only body\n")
+
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(self.GPT35, None, io)
+        commands = Commands(io, coder)
+        commands.cmd_read_only("ref.txt")
+
+        with mock.patch.object(
+            coder.main_model,
+            "token_count",
+            return_value=1,
+        ) as token_count:
+            commands.cmd_tokens("")
+
+        file_content = next(
+            call.args[0]
+            for call in token_count.call_args_list
+            if isinstance(call.args[0], str) and "read-only body" in call.args[0]
+        )
+
+        self.assertEqual(
+            file_content,
+            "ref.txt\n```\nread-only body\n```\n",
+        )
+
     def test_cmd_add_from_subdir(self):
         repo = git.Repo.init()
         repo.config_writer().set_value("user", "name", "Test User").release()


### PR DESCRIPTION
## Description

`cmd_tokens` (the `/tokens` command) builds the token-count input for text files with an opening code fence but appends the literal text `{fence}` instead of the actual closing fence. This affects both the editable-file and read-only-file branches, so the token/cost estimate is computed against content that differs from the intended fenced representation.

## Root cause

In `aider/commands.py`, both text-file branches construct content as:

```python
content = f"{relative_fname}\n{fence}\n" + content + "{fence}\n"
```

The trailing `"{fence}\n"` is an ordinary (non-f) string, so `{fence}` is appended literally rather than interpolated to ` ``` `.

## Fix

Interpolate the closing fence in both branches:

```python
content = f"{relative_fname}\n{fence}\n" + content + f"{fence}\n"
```

## Testing

Added two regression tests in `tests/basic/test_commands.py`:

- `test_cmd_tokens_uses_closing_fence_for_files`
- `test_cmd_tokens_uses_closing_fence_for_read_only_files`

Both assert the exact content passed to `token_count` contains a matching closing fence.

- RED (before fix): `pytest tests/basic/test_commands.py -q -k closing_fence` → 2 failed.
- GREEN (after fix): `pytest tests/basic/test_commands.py -q` → 72 passed (70 original + 2 new), no regressions.

## Closes

Closes #5561
