### PR TITLE
Don't force locale-detected language when --chat-language is not set

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1179,7 +1179,7 @@ class Coder:
             final_reminders.append(self.gpt_prompts.overeager_prompt)
 
         user_lang = self.get_user_language()
-        if user_lang:
+        if user_lang and self.chat_language:
             final_reminders.append(f"Reply in {user_lang}.\n")
 
         platform_text = self.get_platform_info()
@@ -1195,10 +1195,10 @@ class Coder:
             )
             rename_with_shell = ""
 
-        if user_lang:  # user_lang is the result of self.get_user_language()
+        if user_lang and self.chat_language:
             language = user_lang
         else:
-            language = "the same language they are using"  # Default if no specific lang detected
+            language = "the same language they are using"
 
         if self.fence[0] == "`" * 4:
             quad_backtick_reminder = (


### PR DESCRIPTION
When `get_user_language()` detects a language from the system locale (e.g. "English" from `LANG=en_US.UTF-8`), the system prompt was unconditionally instructing the model to "Reply in English." This caused the model to refuse to respond in other languages, since it would say it was configured to reply only in English. Users who want to chat in a language different from their system locale had no way to do so without the `--chat-language` workaround.

The fix is to only inject the "Reply in {lang}." instruction and set the `{language}` template variable when `--chat-language` was explicitly provided. Auto-detected locale language still appears in the platform info block as informational context, but no longer hard-codes the model reply language. With this change, omitting `--chat-language` restores the previous behaviour where the model replies in whatever language the user is writing in.

Fixes #4018