### PR TITLE
fix(args): honor no-stream config key and prevent extra_params stream override (issue #5531)

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -32,8 +32,29 @@ def default_env_file(git_root):
     return os.path.join(git_root, ".env") if git_root else ".env"
 
 
+class AiderArgumentParser(configargparse.ArgumentParser):
+    def convert_item_to_command_line_arg(self, action, key, value):
+        # Work around configargparse mapping any truthy value for a
+        # BooleanOptionalAction config key to the positive flag, even when
+        # the config key is the negated form (eg `no-stream: true` was
+        # silently treated as `--stream`).
+        if (
+            action is not None
+            and isinstance(action, argparse.BooleanOptionalAction)
+            and isinstance(value, str)
+            and len(action.option_strings) > 1
+            and key == action.option_strings[-1].lstrip("-")
+            and key != action.option_strings[0].lstrip("-")
+        ):
+            if value.lower() in ("true", "yes", "on", "1"):
+                return [action.option_strings[-1]]
+            if value.lower() in ("false", "no", "off", "0"):
+                return [action.option_strings[0]]
+        return super().convert_item_to_command_line_arg(action, key, value)
+
+
 def get_parser(default_config_files, git_root):
-    parser = configargparse.ArgumentParser(
+    parser = AiderArgumentParser(
         description="aider is AI pair programming in your terminal",
         add_config_file_help=True,
         default_config_files=default_config_files,

--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -233,6 +233,8 @@ class Coder:
             output += ", prompt cache"
         if main_model.info.get("supports_assistant_prefill"):
             output += ", infinite output"
+        if not self.stream:
+            output += ", non-streaming"
 
         lines.append(output)
 

--- a/aider/main.py
+++ b/aider/main.py
@@ -881,6 +881,7 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             val = getattr(main_model, attr.name)
             val = json.dumps(val, indent=4)
             io.tool_output(f"{attr.name}: {val}")
+        io.tool_output(f"stream: {json.dumps(args.stream and main_model.streaming)}")
 
     lint_cmds = parse_lint_cmds(args.lint_cmd, io)
     if lint_cmds is None:

--- a/aider/models.py
+++ b/aider/models.py
@@ -1009,6 +1009,8 @@ class Model(ModelSettings):
             kwargs["tool_choice"] = {"type": "function", "function": {"name": function["name"]}}
         if self.extra_params:
             kwargs.update(self.extra_params)
+            # Don't let extra_params override the explicit stream setting
+            kwargs["stream"] = stream
         if self.is_ollama() and "num_ctx" not in kwargs:
             num_ctx = int(self.token_count(messages) * 1.25) + 8192
             kwargs["num_ctx"] = num_ctx

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -972,6 +972,22 @@ two
             self.assertEqual(len(coder1.abs_fnames), 1)
             self.assertEqual(len(coder2.abs_fnames), 1)
 
+    def test_stream_false_preserved_by_from_coder(self):
+        with GitTemporaryDirectory():
+            io = InputOutput(yes=True)
+
+            # stream defaults to True
+            coder = Coder.create(self.GPT35, None, io=io)
+            self.assertTrue(coder.stream)
+
+            # Explicit stream=False is respected
+            coder = Coder.create(self.GPT35, None, io=io, stream=False)
+            self.assertFalse(coder.stream)
+
+            # And is preserved when creating a new coder from this one
+            coder2 = Coder.create(from_coder=coder)
+            self.assertFalse(coder2.stream)
+
     def test_suggest_shell_commands(self):
         with GitTemporaryDirectory():
             io = InputOutput(yes=True)

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -1481,3 +1481,67 @@ class TestMain(TestCase):
             )
         for call in mock_io_instance.tool_warning.call_args_list:
             self.assertNotIn("Cost estimates may be inaccurate", call[0][0])
+
+    def test_no_stream_sets_coder_stream_false(self):
+        with GitTemporaryDirectory():
+            coder = main(
+                ["--no-stream", "--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+                return_coder=True,
+            )
+            self.assertFalse(coder.stream)
+
+            coder = main(
+                ["--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+                return_coder=True,
+            )
+            self.assertTrue(coder.stream)
+
+    def test_no_stream_from_config_yml(self):
+        with GitTemporaryDirectory():
+            Path(".aider.conf.yml").write_text("stream: false\n")
+            coder = main(
+                ["--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+                return_coder=True,
+            )
+            self.assertFalse(coder.stream)
+
+            Path(".aider.conf.yml").write_text("no-stream: true\n")
+            coder = main(
+                ["--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+                return_coder=True,
+            )
+            self.assertFalse(coder.stream)
+
+    @patch("aider.main.InputOutput")
+    def test_verbose_shows_effective_stream(self, MockInputOutput):
+        mock_io_instance = MockInputOutput.return_value
+        with GitTemporaryDirectory():
+            main(
+                ["--no-stream", "--verbose", "--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+        output_calls = [
+            call.args[0] for call in mock_io_instance.tool_output.call_args_list if call.args
+        ]
+        self.assertIn("stream: false", output_calls)
+
+        mock_io_instance.reset_mock()
+        with GitTemporaryDirectory():
+            main(
+                ["--verbose", "--exit", "--yes"],
+                input=DummyInput(),
+                output=DummyOutput(),
+            )
+        output_calls = [
+            call.args[0] for call in mock_io_instance.tool_output.call_args_list if call.args
+        ]
+        self.assertIn("stream: true", output_calls)

--- a/tests/basic/test_models.py
+++ b/tests/basic/test_models.py
@@ -523,6 +523,33 @@ class TestModels(unittest.TestCase):
         )
 
     @patch("aider.models.litellm.completion")
+    def test_extra_params_cannot_override_stream(self, mock_completion):
+        # extra_params with stream=True must not override an explicit stream=False
+        model = Model("gpt-4")
+        model.extra_params = {"stream": True}
+        messages = [{"role": "user", "content": "Hello"}]
+        model.send_completion(messages, functions=None, stream=False)
+        mock_completion.assert_called_with(
+            model=model.name,
+            messages=messages,
+            stream=False,
+            temperature=0,
+            timeout=600,
+        )
+
+        # And the reverse: stream=True must not be clobbered by extra_params stream=False
+        model = Model("gpt-4")
+        model.extra_params = {"stream": False}
+        model.send_completion(messages, functions=None, stream=True)
+        mock_completion.assert_called_with(
+            model=model.name,
+            messages=messages,
+            stream=True,
+            temperature=0,
+            timeout=600,
+        )
+
+    @patch("aider.models.litellm.completion")
     def test_use_temperature_in_send_completion(self, mock_completion):
         # Test use_temperature=True sends temperature=0
         model = Model("gpt-4")


### PR DESCRIPTION
Fixes #5531

## Summary

`no-stream: true` in `.aider.conf.yml` was silently parsed as `--stream`, and `extra_params` could override an explicit `--no-stream`. This PR fixes both paths and surfaces the effective stream setting at startup and in verbose output.

## Technical Details

**Root Cause**

Two distinct defects:

1. configargparse's `convert_item_to_command_line_arg` maps any truthy config value for a `BooleanOptionalAction` option to the positive flag, regardless of which key was used. `no-stream: true` was therefore converted to `--stream`, inverting user intent. This applies to every boolean-optional flag (`no-pretty`, `no-git`, etc.), not just streaming.
2. In `Model.send_completion`, `kwargs.update(self.extra_params)` runs after `stream=stream` is set, so a model-settings yaml containing `extra_params: {stream: true}` silently re-enabled streaming.

Additionally, `--verbose` printed only the `streaming` model-capability field (whether the model supports streaming), never the effective run-time value, which made the inversion impossible to diagnose from output.

**Mechanism**

- `aider/args.py`: new `AiderArgumentParser` subclass overrides `convert_item_to_command_line_arg`. When the config key matches the negated option string of a `BooleanOptionalAction`, a truthy value emits the negative flag and a falsy value emits the positive flag. All other keys defer to the parent implementation; env vars are unaffected.
- `aider/models.py`: `send_completion` re-asserts `kwargs["stream"] = stream` after the `extra_params` merge, so the explicit argument always wins.
- `aider/main.py`: verbose model-settings dump now appends the effective `stream:` value (`args.stream and main_model.streaming`).
- `aider/coders/base_coder.py`: `get_announcements` appends `, non-streaming` to the main-model line when streaming is off.

Manual repro at parser level: on `main` (5dc9490bb), a config dir with `no-stream: true` yields `args.stream = True`; on this branch it yields `args.stream = False`.

## Verification

Confirmed adherence to CONTRIBUTING.md. Pre-commit hooks (isort, black, flake8, codespell) pass.

New tests: CLI `--no-stream`, config-yml `stream: false` and `no-stream: true`, verbose effective-stream output, `extra_params` stream override in both directions, and `stream=False` preservation through `Coder.create`/`from_coder`.

Ran `pytest tests/basic/test_main.py tests/basic/test_models.py tests/basic/test_coder.py tests/basic/test_sendchat.py tests/basic/test_reasoning.py`:

```
........................................................................ [ 43%]
................................................ [ 71%]
...............................................         [100%]
167 passed, 41 subtests passed in 77.14s (0:01:17)
```

## Blast Radius

**Impact**: Medium. The parser change affects config-file parsing of all `BooleanOptionalAction` options: `no-<flag>: true` now means disable, `no-<flag>: false` now means enable. Previously both meant enable. This is a behavior change only for configs that relied on the inverted semantics, which contradict the documented meaning of the flags.

**Trade-offs**: The override depends on configargparse's `convert_item_to_command_line_arg` hook (stable across the pinned version). No new dependencies, no runtime cost outside argument parsing.