### PR TITLE
fix: avoid duplicate read-only files in ls

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -1073,7 +1073,7 @@ class Commands:
             abs_file_path = self.coder.abs_root_path(file)
             if abs_file_path in self.coder.abs_fnames:
                 chat_files.append(file)
-            else:
+            elif abs_file_path not in self.coder.abs_read_only_fnames:
                 other_files.append(file)
 
         # Add read-only files

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -1410,6 +1410,23 @@ class TestCommands(TestCase):
                 )
             )
 
+    def test_cmd_ls_lists_tracked_read_only_file_once(self):
+        with GitTemporaryDirectory():
+            tracked = Path("tracked.txt")
+            tracked.write_text("tracked content\n")
+            git.Repo().index.add([str(tracked)])
+
+            io = InputOutput(pretty=False, fancy_input=False, yes=False)
+            coder = Coder.create(self.GPT35, None, io)
+            commands = Commands(io, coder)
+            commands.cmd_read_only(str(tracked))
+
+            with mock.patch.object(io, "tool_output") as tool_output:
+                commands.cmd_ls("")
+
+            outputs = [call.args[0] for call in tool_output.call_args_list]
+            self.assertEqual(outputs, ["\nRead-only files:\n", "  tracked.txt"])
+
     def test_cmd_read_only_from_working_dir(self):
         with GitTemporaryDirectory() as repo_dir:
             io = InputOutput(pretty=False, fancy_input=False, yes=False)


### PR DESCRIPTION
Fixes #5575.

Tracked read-only files are now listed only in the read-only section of /ls.

Tests:
- Focused regression: 1 passed
- Full tests/basic/test_commands.py: 70 passed; 1 unrelated Windows home-directory permission failure