### PR TITLE
fix: treat whitespace-only commit messages as failed generation

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -359,6 +359,7 @@ class GitRepo:
                     continue
 
                 commit_message = model.simple_send_with_retries(messages)
+                commit_message = commit_message.strip() if commit_message else None
                 if commit_message:
                     break  # Found a model that could generate the message
 
@@ -366,8 +367,7 @@ class GitRepo:
             self.io.tool_error("Failed to generate commit message!")
             return
 
-        commit_message = commit_message.strip()
-        if commit_message and commit_message[0] == '"' and commit_message[-1] == '"':
+        if commit_message[0] == '"' and commit_message[-1] == '"':
             commit_message = commit_message[1:-1].strip()
 
         return commit_message

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -153,6 +153,20 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(first_call_messages, second_call_messages)
 
     @patch("aider.models.Model.simple_send_with_retries")
+    def test_get_commit_message_skips_whitespace_only_response(self, mock_send):
+        mock_send.side_effect = ["   \n", "a good commit message"]
+
+        model1 = Model("gpt-3.5-turbo")
+        model2 = Model("gpt-4")
+        repo = GitRepo(InputOutput(), None, None, models=[model1, model2])
+
+        result = repo.get_commit_message("dummy diff", "dummy context")
+
+        # A whitespace-only response is a failed generation, so the fallback continues
+        self.assertEqual(result, "a good commit message")
+        self.assertEqual(mock_send.call_count, 2)
+
+    @patch("aider.models.Model.simple_send_with_retries")
     def test_get_commit_message_strip_quotes(self, mock_send):
         mock_send.return_value = '"a good commit message"'
 


### PR DESCRIPTION
Fixes #5581.

GitRepo.get_commit_message used to treat a whitespace-only model response as success, skip remaining fallback models, then strip it to an empty string.

Strip the response before the truthiness check so fallback continues. Adds test_get_commit_message_skips_whitespace_only_response.

tests/basic/test_repo.py: 22 passed.