### PR TITLE
fix: ignore unreadable default config files instead of crashing

### DIFF
--- a/aider/args.py
+++ b/aider/args.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
+import io
 import os
 import sys
 from pathlib import Path
@@ -32,12 +33,48 @@ def default_env_file(git_root):
     return os.path.join(git_root, ".env") if git_root else ".env"
 
 
+# Args are parsed several times per run, so only warn about each file once
+_skipped_config_files = set()
+
+
+def config_file_opener(default_config_files):
+    """Build the function configargparse uses to open config files.
+
+    configargparse opens every default config file it finds, so an existing but
+    unreadable .aider.conf.yml would crash aider on startup. Skip those, but let
+    errors for config files the user named explicitly propagate so configargparse
+    can report them.
+    """
+    default_paths = {os.path.abspath(os.path.expanduser(fname)) for fname in default_config_files}
+
+    def open_config_file(filename, mode="r", **kwargs):
+        try:
+            return open(filename, mode, **kwargs)
+        except OSError as err:
+            if any(char in mode for char in "wxa+"):
+                raise
+            path = os.path.abspath(os.path.expanduser(filename))
+            if path not in default_paths:
+                raise
+            if path not in _skipped_config_files:
+                _skipped_config_files.add(path)
+                print(
+                    f"Warning: skipping unreadable config file {filename}: {err}", file=sys.stderr
+                )
+            stream = io.StringIO("{}\n")
+            stream.name = str(filename)
+            return stream
+
+    return open_config_file
+
+
 def get_parser(default_config_files, git_root):
     parser = configargparse.ArgumentParser(
         description="aider is AI pair programming in your terminal",
         add_config_file_help=True,
         default_config_files=default_config_files,
         config_file_parser_class=configargparse.YAMLConfigFileParser,
+        config_file_open_func=config_file_opener(default_config_files),
         auto_env_var_prefix="AIDER_",
     )
     # List of valid edit formats for argparse validation & shtab completion.

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import configargparse
 import git
 from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
@@ -99,6 +100,73 @@ class TestMain(TestCase):
             main([], input=DummyInput(), output=DummyOutput())
             _, kwargs = MockCoder.call_args
             assert kwargs["auto_commits"] is True
+
+    def test_main_with_unreadable_config_yml(self):
+        # A config file we don't have permission to read should be skipped, not crash aider
+        make_repo()
+
+        Path(".aider.conf.yml").write_text("auto-commits: false\n")
+
+        real_open = open
+
+        def open_denying_config(fname, *args, **kwargs):
+            if isinstance(fname, (str, os.PathLike)):
+                if os.path.basename(os.fspath(fname)) == ".aider.conf.yml":
+                    raise PermissionError(13, "Permission denied")
+            return real_open(fname, *args, **kwargs)
+
+        with patch("builtins.open", side_effect=open_denying_config):
+            with patch("aider.coders.Coder.create") as MockCoder:
+                main(["--yes", "--exit"], input=DummyInput(), output=DummyOutput())
+                _, kwargs = MockCoder.call_args
+                # The unreadable config was ignored, so auto-commits keeps its default
+                assert kwargs["auto_commits"] is True
+
+    def test_config_file_opener_with_unreadable_default_config(self):
+        from aider.args import config_file_opener
+
+        Path("unreadable.yml").write_text("auto-commits: false\n")
+        open_config_file = config_file_opener(["unreadable.yml"])
+
+        with patch("builtins.open", side_effect=PermissionError(13, "Permission denied")):
+            stream = open_config_file("unreadable.yml")
+
+        # An empty yaml mapping, so the config file parser has nothing to complain about
+        parser = configargparse.YAMLConfigFileParser()
+        self.assertEqual(parser.parse(stream), {})
+        self.assertEqual(stream.name, "unreadable.yml")
+
+    def test_config_file_opener_with_readable_default_config(self):
+        from aider.args import config_file_opener
+
+        Path("readable.yml").write_text("auto-commits: false\n")
+        open_config_file = config_file_opener(["readable.yml"])
+
+        with open_config_file("readable.yml") as stream:
+            self.assertEqual(stream.read(), "auto-commits: false\n")
+
+    def test_config_file_opener_propagates_other_errors(self):
+        from aider.args import config_file_opener
+
+        open_config_file = config_file_opener(["unreadable.yml"])
+
+        with patch("builtins.open", side_effect=PermissionError(13, "Permission denied")):
+            # Config files named by the user, not defaults, should still raise
+            with self.assertRaises(PermissionError):
+                open_config_file("named.yml")
+
+            # As should writing out a config file
+            with self.assertRaises(PermissionError):
+                open_config_file("unreadable.yml", "w")
+
+    def test_main_with_missing_config_arg(self):
+        with patch("aider.coders.Coder.create"):
+            with self.assertRaises(SystemExit):
+                main(
+                    ["--yes", "--exit", "--no-git", "--config", "missing.yml"],
+                    input=DummyInput(),
+                    output=DummyOutput(),
+                )
 
     def test_main_with_empty_git_dir_new_subdir_file(self):
         make_repo()


### PR DESCRIPTION
Fixes #5466.

An existing-but-unreadable .aider.conf.yml made main() raise PermissionError out of configargparse. Default config files that cannot be opened now warn and are skipped. --config still errors if the named file is unusable.

tests/basic/test_main.py: 81 passed.