### PR TITLE
fix: remove every img from slimdown_html, not just the first

### DIFF
--- a/aider/scrape.py
+++ b/aider/scrape.py
@@ -254,8 +254,8 @@ def slimdown_html(soup):
     for svg in soup.find_all("svg"):
         svg.decompose()
 
-    if soup.img:
-        soup.img.decompose()
+    for img in soup.find_all("img"):
+        img.decompose()
 
     for tag in soup.find_all(href=lambda x: x and x.startswith("data:")):
         tag.decompose()

--- a/tests/scrape/test_scrape.py
+++ b/tests/scrape/test_scrape.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 
 from aider.commands import Commands
 from aider.io import InputOutput
-from aider.scrape import Scraper
+from aider.scrape import Scraper, slimdown_html
 
 
 class TestScrape(unittest.TestCase):
@@ -169,6 +169,33 @@ class TestScrape(unittest.TestCase):
 
         # Assert that html_to_markdown was called with the HTML content
         scraper.html_to_markdown.assert_called_once_with(html_content)
+
+
+class TestSlimdownHtml(unittest.TestCase):
+    def slimdown(self, html):
+        from bs4 import BeautifulSoup
+
+        return slimdown_html(BeautifulSoup(html, "html.parser"))
+
+    def test_removes_every_img(self):
+        html = (
+            "<body>"
+            '<img src="https://example.com/1.png">'
+            "<p>text</p>"
+            '<img src="https://example.com/2.png">'
+            '<img src="https://example.com/3.png">'
+            "</body>"
+        )
+        soup = self.slimdown(html)
+
+        self.assertEqual(soup.find_all("img"), [])
+        self.assertIn("text", str(soup))
+
+    def test_removes_every_svg(self):
+        soup = self.slimdown("<body><svg></svg><p>text</p><svg></svg></body>")
+
+        self.assertEqual(soup.find_all("svg"), [])
+        self.assertIn("text", str(soup))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
\`slimdown_html()\` used \`soup.img.decompose()\`, which only drops the first \`<img>\`. Later images lost \`src\`/\`alt\` in the attribute-stripping pass and reached the model as empty \`<img/>\` tags.

Loop with \`find_all(\"img\")\`, matching the existing \`<svg>\` handling.

## Test plan
- [x] \`pytest tests/scrape/ tests/basic/test_commands.py -q\` → 82 passed
- [x] \`test_removes_every_img\` fails on current main (\`[<img/>, <img/>] != []\`) and passes after