### PR TITLE
fix: prefer exact OpenRouter model id over the :suffix-stripped base

### DIFF
--- a/aider/openrouter.py
+++ b/aider/openrouter.py
@@ -57,12 +57,18 @@ class OpenRouterModelManager:
 
         route = self._strip_prefix(model)
 
-        # Consider both the exact id and id without any “:suffix”.
-        candidates = {route}
+        # Prefer the exact id, then fall back to the id without any “:suffix”.
+        candidates = [route]
         if ":" in route:
-            candidates.add(route.split(":", 1)[0])
+            candidates.append(route.split(":", 1)[0])
 
-        record = next((item for item in self.content["data"] if item.get("id") in candidates), None)
+        record = None
+        for candidate in candidates:
+            record = next(
+                (item for item in self.content["data"] if item.get("id") == candidate), None
+            )
+            if record:
+                break
         if not record:
             return {}
 

--- a/tests/basic/test_openrouter.py
+++ b/tests/basic/test_openrouter.py
@@ -44,6 +44,65 @@ def test_openrouter_get_model_info_from_cache(monkeypatch, tmp_path):
     assert info["litellm_provider"] == "openrouter"
 
 
+def test_openrouter_get_model_info_prefers_exact_variant(monkeypatch, tmp_path):
+    """
+    A model id with a ":variant" suffix should match the exact record, even when
+    the base model appears earlier in the payload.
+    """
+    payload = {
+        "data": [
+            {
+                "id": "deepseek/deepseek-r1",
+                "context_length": 32768,
+                "pricing": {"prompt": "100", "completion": "200"},
+                "top_provider": {"context_length": 32768},
+            },
+            {
+                "id": "deepseek/deepseek-r1:free",
+                "context_length": 8192,
+                "pricing": {"prompt": "0", "completion": "0"},
+                "top_provider": {"context_length": 8192},
+            },
+        ]
+    }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = OpenRouterModelManager()
+    info = manager.get_model_info("openrouter/deepseek/deepseek-r1:free")
+
+    assert info["max_input_tokens"] == 8192
+    assert info["input_cost_per_token"] == 0.0
+    assert info["output_cost_per_token"] == 0.0
+
+
+def test_openrouter_get_model_info_falls_back_to_base_model(monkeypatch, tmp_path):
+    """
+    Routing suffixes such as ":nitro" are not listed as separate models, so the
+    base model record should still be used.
+    """
+    payload = {
+        "data": [
+            {
+                "id": "deepseek/deepseek-r1",
+                "context_length": 32768,
+                "pricing": {"prompt": "100", "completion": "200"},
+                "top_provider": {"context_length": 32768},
+            }
+        ]
+    }
+
+    monkeypatch.setattr("requests.get", lambda *a, **k: DummyResponse(payload))
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    manager = OpenRouterModelManager()
+    info = manager.get_model_info("openrouter/deepseek/deepseek-r1:nitro")
+
+    assert info["max_input_tokens"] == 32768
+    assert info["input_cost_per_token"] == 100.0
+
+
 def test_model_info_manager_uses_openrouter_manager(monkeypatch):
     """
     ModelInfoManager should delegate to OpenRouterModelManager when litellm


### PR DESCRIPTION
## Summary
`OpenRouterModelManager.get_model_info` treated the requested route and its `:suffix`-stripped base as equal candidates, so `openrouter/deepseek/deepseek-r1:free` could pick the paid base record (wrong context length and non-zero cost).

Try the exact id first; fall back to the base id only when the exact id is missing (needed for routing suffixes like `:nitro`). Distinct from #4931 and #5550/#5518/#5425.

## Test plan
- [x] New exact-variant test fails on current main (`32768 == 8192`) and passes after
- [x] `python -m pytest tests/basic/test_openrouter.py -v` → 4 passed