### PR TITLE
fix: treat image file extensions as case-insensitive

### DIFF
--- a/aider/utils.py
+++ b/aider/utils.py
@@ -89,7 +89,7 @@ def is_image_file(file_name):
     :param file_name: The name of the file to check.
     :return: True if the file is an image, False otherwise.
     """
-    file_name = str(file_name)  # Convert file_name to string
+    file_name = str(file_name).lower()  # Convert file_name to string, extensions are lowercase
     return any(file_name.endswith(ext) for ext in IMAGE_EXTENSIONS)
 
 

--- a/tests/basic/test_utils.py
+++ b/tests/basic/test_utils.py
@@ -1,6 +1,25 @@
+import base64
 import os
 
-from aider.utils import safe_abs_path
+from aider.io import InputOutput
+from aider.utils import is_image_file, safe_abs_path
+
+
+def test_is_image_file_ignores_extension_case():
+    assert is_image_file("photo.png")
+    assert is_image_file("DSC_0001.JPG")
+    assert is_image_file("scan.Jpeg")
+    assert is_image_file("report.PDF")
+    assert not is_image_file("main.py")
+
+
+def test_read_text_of_uppercase_image_returns_base64(tmp_path):
+    data = b"\x89PNG\r\n\x1a\n not really a png"
+    fname = tmp_path / "shot.PNG"
+    fname.write_bytes(data)
+
+    io = InputOutput(pretty=False, fancy_input=False)
+    assert io.read_text(str(fname)) == base64.b64encode(data).decode("utf-8")
 
 
 def test_safe_abs_path_symlink_loop(tmp_path):


### PR DESCRIPTION
## Summary
`is_image_file()` compared filenames against the lowercase `IMAGE_EXTENSIONS` set with `str.endswith()`, so `DSC_0001.JPG` and `scan.PDF` were treated as text. `InputOutput.read_text()` then opened the binary as text (`UnicodeDecodeError` / "Unable to read"), `/add` skipped the vision guard, and `get_image_message()` never sent the image.

The filename is now lowercased before the comparison. Distinct from #5587 (OpenRouter variant lookup).

## Test plan
- [x] New tests fail on unmodified main and pass after
- [x] `python -m pytest tests/basic/test_utils.py -v` → 3 passed