### PR TITLE
fix: honor silent and specific errors in read_image

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -432,27 +432,31 @@ class InputOutput:
 
         return Style.from_dict(style_dict)
 
-    def read_image(self, filename):
+    def read_image(self, filename, silent=False):
         try:
             with open(str(filename), "rb") as image_file:
                 encoded_string = base64.b64encode(image_file.read())
                 return encoded_string.decode("utf-8")
-        except OSError as err:
-            self.tool_error(f"{filename}: unable to read: {err}")
-            return
         except FileNotFoundError:
-            self.tool_error(f"{filename}: file not found error")
+            if not silent:
+                self.tool_error(f"{filename}: file not found error")
             return
         except IsADirectoryError:
-            self.tool_error(f"{filename}: is a directory")
+            if not silent:
+                self.tool_error(f"{filename}: is a directory")
+            return
+        except OSError as err:
+            if not silent:
+                self.tool_error(f"{filename}: unable to read: {err}")
             return
         except Exception as e:
-            self.tool_error(f"{filename}: {e}")
+            if not silent:
+                self.tool_error(f"{filename}: {e}")
             return
 
     def read_text(self, filename, silent=False):
         if is_image_file(filename):
-            return self.read_image(filename)
+            return self.read_image(filename, silent=silent)
 
         try:
             with open(str(filename), "r", encoding=self.encoding) as f:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -173,6 +173,28 @@ class TestInputOutput(unittest.TestCase):
             self.assertEqual(result, "test input")
             mock_input.assert_called_once()
 
+    def test_read_image_file_not_found(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+        io.tool_error = MagicMock()
+
+        self.assertIsNone(io.read_image("missing_image.png"))
+        io.tool_error.assert_called_once_with("missing_image.png: file not found error")
+
+    def test_read_image_is_a_directory(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+        io.tool_error = MagicMock()
+
+        with patch("aider.io.open", side_effect=IsADirectoryError):
+            self.assertIsNone(io.read_image("some_dir.png"))
+        io.tool_error.assert_called_once_with("some_dir.png: is a directory")
+
+    def test_read_text_image_silent(self):
+        io = InputOutput(pretty=False, fancy_input=False)
+        io.tool_error = MagicMock()
+
+        self.assertIsNone(io.read_text("missing_image.png", silent=True))
+        io.tool_error.assert_not_called()
+
     @patch("builtins.input")
     def test_confirm_ask_explicit_yes_required(self, mock_input):
         io = InputOutput(pretty=False, fancy_input=False)


### PR DESCRIPTION
read_image caught OSError before FileNotFoundError/IsADirectoryError so those handlers were dead. silent was also dropped when read_text delegated to read_image, so --watch-files printed errors for unreadable images. Tests: python -m pytest tests/basic/test_io.py tests/basic/test_watch.py -q -> 29 passed, 1 pre-existing color failure.