### PR TITLE
fix: keep streaming markdown live window updating mid-line

### DIFF
--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -188,7 +188,9 @@ class MarkdownStream:
         # How many lines have "left" the live window and are now considered stable?
         # Or if final, consider all lines to be stable.
         if not final:
-            num_lines -= self.live_window
+            # Clamp at 0, otherwise a negative count would slice off the *start*
+            # of the lines destined for the live window.
+            num_lines = max(num_lines - self.live_window, 0)
 
         # If we have stable content to display...
         if final or num_lines > 0:
@@ -196,18 +198,17 @@ class MarkdownStream:
             num_printed = len(self.printed)
             show = num_lines - num_printed
 
-            # Skip if no new lines to show above live window
-            if show <= 0:
-                return
+            # Only emit above the live window if there are new stable lines.
+            # Either way we still need to repaint/tear down the live window below.
+            if show > 0:
+                # Get the new lines and display them
+                show = lines[num_printed:num_lines]
+                show = "".join(show)
+                show = Text.from_ansi(show)
+                self.live.console.print(show)  # to the console above the live area
 
-            # Get the new lines and display them
-            show = lines[num_printed:num_lines]
-            show = "".join(show)
-            show = Text.from_ansi(show)
-            self.live.console.print(show)  # to the console above the live area
-
-            # Update our record of printed lines
-            self.printed = lines[:num_lines]
+                # Update our record of printed lines
+                self.printed = lines[:num_lines]
 
         # Handle final update cleanup
         if final:

--- a/tests/basic/test_mdstream.py
+++ b/tests/basic/test_mdstream.py
@@ -1,0 +1,70 @@
+from unittest.mock import MagicMock
+
+from aider.mdstream import MarkdownStream
+
+
+def make_stream():
+    """A MarkdownStream with a mocked-out Live display and no update throttling."""
+    mdstream = MarkdownStream()
+    mdstream.live = MagicMock()
+    mdstream._live_started = True
+    return mdstream
+
+
+def update(mdstream, text, final=False):
+    mdstream.when = 0  # defeat the min_delay throttle
+    mdstream.update(text, final=final)
+
+
+def long_markdown(num_paras, suffix=""):
+    """Markdown long enough that some lines scroll out of the live window."""
+    return "\n\n".join(f"para {i}" for i in range(num_paras)) + suffix
+
+
+def test_live_window_repaints_without_new_stable_lines():
+    mdstream = make_stream()
+
+    text = long_markdown(20)
+    update(mdstream, text)
+    assert mdstream.printed  # some lines left the live window and were printed
+
+    # Appending to the last line doesn't add any new stable lines, but the
+    # live window still has to be repainted to show the new text.
+    mdstream.live.reset_mock()
+    update(mdstream, text + " and more")
+
+    assert mdstream.live.update.call_count == 1
+    mdstream.live.console.print.assert_not_called()
+
+
+def test_live_window_shows_all_lines_before_it_fills_up():
+    mdstream = make_stream()
+
+    # Fewer rendered lines than live_window, so nothing is stable yet and the
+    # live window has to show everything rendered so far.
+    text = long_markdown(3)
+    rendered = mdstream._render_markdown_to_lines(text)
+    assert 0 < len(rendered) < mdstream.live_window
+
+    update(mdstream, text)
+
+    assert not mdstream.printed
+    mdstream.live.console.print.assert_not_called()
+    shown = mdstream.live.update.call_args[0][0]
+    assert len(shown.plain.splitlines()) == len(rendered)
+
+
+def test_final_update_stops_live_without_new_stable_lines():
+    mdstream = make_stream()
+
+    text = long_markdown(20)
+    update(mdstream, text)
+
+    # Pretend everything has already been printed above the live window, so the
+    # final update has no new stable lines to emit. It must still tear down Live.
+    live = mdstream.live
+    mdstream.printed = mdstream._render_markdown_to_lines(text)
+    update(mdstream, text, final=True)
+
+    live.stop.assert_called_once()
+    assert mdstream.live is None


### PR DESCRIPTION
MarkdownStream.update returned early when no new stable lines were ready, so the live window froze mid-line and a final update with no new lines left the rich Live renderer running. When fewer lines than live_window had rendered, a negative slice also hid the first lines.

Guard only the print-above-window path and clamp the stable line count at 0. Tests: python3 -m pytest tests/basic/test_mdstream.py -q -> 3 passed. Distinct from #4577/#4579 (theming) and #5583-#5589.