### PR TITLE
fix: do not let system messages break user/assistant alternation

### DIFF
--- a/aider/sendchat.py
+++ b/aider/sendchat.py
@@ -30,7 +30,8 @@ def ensure_alternating_roles(messages):
     """Ensure messages alternate between 'assistant' and 'user' roles.
 
     Inserts empty messages of the opposite role when consecutive messages
-    of the same role are found.
+    of the same role are found. System messages can be interspersed anywhere
+    and don't take part in the alternation.
 
     Args:
         messages: List of message dictionaries with 'role' and 'content' keys.
@@ -46,6 +47,10 @@ def ensure_alternating_roles(messages):
 
     for msg in messages:
         current_role = msg.get("role")  # Get 'role', None if missing
+
+        if current_role == "system":
+            fixed_messages.append(msg)
+            continue
 
         # If current role same as previous, insert empty message
         # of the opposite role

--- a/tests/basic/test_sendchat.py
+++ b/tests/basic/test_sendchat.py
@@ -148,6 +148,34 @@ class TestSendChat(unittest.TestCase):
         result = ensure_alternating_roles(messages)
         assert result == expected
 
+    def test_ensure_alternating_roles_consecutive_system(self):
+        from aider.sendchat import ensure_alternating_roles
+
+        messages = [
+            {"role": "system", "content": "You are helpful"},
+            {"role": "system", "content": "Be brief"},
+            {"role": "user", "content": "Hello"},
+        ]
+        result = ensure_alternating_roles(messages)
+        assert result == messages
+
+    def test_ensure_alternating_roles_system_does_not_reset_alternation(self):
+        from aider.sendchat import ensure_alternating_roles
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Reminder"},
+            {"role": "user", "content": "Are you there?"},
+        ]
+        expected = [
+            {"role": "user", "content": "Hello"},
+            {"role": "system", "content": "Reminder"},
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "Are you there?"},
+        ]
+        result = ensure_alternating_roles(messages)
+        assert result == expected
+
     def test_ensure_alternating_roles_mixed_sequence(self):
         from aider.sendchat import ensure_alternating_roles
 


### PR DESCRIPTION
ensure_alternating_roles counted system messages as part of the user/assistant sequence. Two consecutive system messages got a bogus empty user turn between them, and a system message between two user turns reset prev_role so the consecutive users were left unfixed (DeepSeek R1 / deepseek-reasoner then rejects the request).

sanity_check_messages already says system messages can be interspersed anywhere. System messages now pass through and leave prev_role alone.

Tests: python3 -m pytest tests/basic/test_sendchat.py -q — 14 passed. Distinct from #5583-#5590.