### PR TITLE
fix: round token counts up at the halfway thousand

### DIFF
--- a/aider/utils.py
+++ b/aider/utils.py
@@ -282,7 +282,8 @@ def format_tokens(count):
     elif count < 10000:
         return f"{count / 1000:.1f}k"
     else:
-        return f"{round(count / 1000)}k"
+        # round() breaks ties to even, so 10500 would show as "10k" but 11500 as "12k"
+        return f"{int(count / 1000 + 0.5)}k"
 
 
 def touch_file(fname):

--- a/tests/basic/test_utils.py
+++ b/tests/basic/test_utils.py
@@ -1,6 +1,8 @@
 import os
 
-from aider.utils import safe_abs_path
+import pytest
+
+from aider.utils import format_tokens, safe_abs_path
 
 
 def test_safe_abs_path_symlink_loop(tmp_path):
@@ -13,3 +15,23 @@ def test_safe_abs_path_symlink_loop(tmp_path):
     # safe_abs_path must not raise, and must return an absolute path
     result = safe_abs_path(str(link_a))
     assert os.path.isabs(result)
+
+
+@pytest.mark.parametrize(
+    "count,expected",
+    [
+        (0, "0"),
+        (999, "999"),
+        (1000, "1.0k"),
+        (9999, "10.0k"),
+        (10000, "10k"),
+        (10499, "10k"),
+        # Halfway values must round up, not to the nearest even thousand
+        (10500, "11k"),
+        (11500, "12k"),
+        (12500, "13k"),
+        (12501, "13k"),
+    ],
+)
+def test_format_tokens(count, expected):
+    assert format_tokens(count) == expected


### PR DESCRIPTION
format_tokens used round(count / 1000), and Python round() breaks ties to even, so 10500 rendered as 10k while 11500 rendered as 12k. Halves now round up.

Tests: python -m pytest tests/basic/test_utils.py tests/basic/test_coder.py -q — 53 passed, 29 subtests. Distinct from #5583-#5591.