### PR TITLE
fix: retry commit messages after blank responses

### DIFF
--- a/aider/repo.py
+++ b/aider/repo.py
@@ -360,6 +360,8 @@ class GitRepo:
 
                 commit_message = model.simple_send_with_retries(messages)
                 if commit_message:
+                    commit_message = commit_message.strip()
+                if commit_message:
                     break  # Found a model that could generate the message
 
         if not commit_message:

--- a/tests/basic/test_repo.py
+++ b/tests/basic/test_repo.py
@@ -153,6 +153,19 @@ class TestRepo(unittest.TestCase):
         self.assertEqual(first_call_messages, second_call_messages)
 
     @patch("aider.models.Model.simple_send_with_retries")
+    def test_get_commit_message_skips_whitespace_only_response(self, mock_send):
+        mock_send.side_effect = [" \t\n", "fallback commit message"]
+
+        model1 = Model("gpt-3.5-turbo")
+        model2 = Model("gpt-4")
+        repo = GitRepo(InputOutput(), None, None, models=[model1, model2])
+
+        result = repo.get_commit_message("dummy diff", "dummy context")
+
+        self.assertEqual(result, "fallback commit message")
+        self.assertEqual(mock_send.call_count, 2)
+
+    @patch("aider.models.Model.simple_send_with_retries")
     def test_get_commit_message_strip_quotes(self, mock_send):
         mock_send.return_value = '"a good commit message"'
 


### PR DESCRIPTION
## Summary

- normalize each generated commit message before deciding whether fallback is needed
- continue to the next configured model when a response contains only whitespace
- add regression coverage for spaces, tabs, and newlines

Fixes #5581

## Validation

- `python -m pytest tests/basic/test_repo.py::TestRepo::test_get_commit_message_skips_whitespace_only_response -q` — 1 passed
- `python -m pytest tests/basic/test_repo.py -q` — 17 passed, 5 skipped on Windows
- `python -m flake8 aider/repo.py tests/basic/test_repo.py --show-source`
- `python -m black --check --line-length 100 --preview aider/repo.py tests/basic/test_repo.py`
- `python -m isort --check-only --profile black aider/repo.py tests/basic/test_repo.py`

Implementation and regression tests were prepared with AI assistance and manually validated against the reported fallback behavior.
