### PR TITLE
docs: add MindsHub connection guide

### DIFF
--- a/aider/website/docs/llms/mindshub.md
+++ b/aider/website/docs/llms/mindshub.md
@@ -1,0 +1,78 @@
+---
+parent: Connecting to LLMs
+nav_order: 500
+---
+
+# MindsHub
+
+[MindsHub](https://mindshub.ai) is an OpenAI-compatible inference gateway that
+gives you one API key and one bill for many models from different providers
+(Claude, GPT, Kimi, DeepSeek and others), all served through a standard
+OpenAI chat completions endpoint. Since aider can talk to any
+[OpenAI compatible API](openai-compat.md), it works with MindsHub without any
+code changes. See the
+[MindsHub inference docs](https://docs.mindshub.ai/inference/) for full API
+details.
+
+You'll need a [MindsHub API key](https://console.mindshub.ai).
+
+First, install aider:
+
+{% include install.md %}
+
+Then configure your API key and endpoint:
+
+```
+# Mac/Linux:
+export OPENAI_API_KEY=<your MindsHub API key>
+export OPENAI_API_BASE=https://api.mindshub.ai/v1
+
+# Windows:
+setx OPENAI_API_KEY <your MindsHub API key>
+setx OPENAI_API_BASE https://api.mindshub.ai/v1
+# ... restart shell after setx commands
+```
+
+Start working with aider and MindsHub on your codebase. Prefix the model
+name with `openai/` and use one of the aliases from the
+[MindsHub model catalog](https://docs.mindshub.ai/inference/models):
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+aider --model openai/sonnet     # Claude Sonnet 5
+aider --model openai/opus       # Claude Opus 5
+aider --model openai/gpt-codex  # GPT 5.3 Codex
+aider --model openai/kimi       # Kimi K3
+aider --model openai/deepseek   # DeepSeek V4-Pro
+```
+
+The full, current list of aliases is returned by MindsHub's models endpoint
+and documented at
+[docs.mindshub.ai/inference/models](https://docs.mindshub.ai/inference/models).
+Aliases track the newest version of a model family, so you don't need to
+update your `--model` argument when MindsHub upgrades the underlying model.
+
+Note: send the bare alias to MindsHub, without a vendor prefix, e.g.
+`sonnet` rather than `claude-sonnet-5`. Aider itself is the thing that gets
+the `openai/` prefix, since that's what tells aider/litellm to talk to your
+custom `OPENAI_API_BASE` using the OpenAI protocol.
+
+## Optional: pin settings with `.aider.model.settings.yml`
+
+If you always use the same MindsHub model, you can set it as the default and
+pin any extra parameters in a
+[`.aider.model.settings.yml`](https://aider.chat/docs/config/adv-model-settings.html#model-settings)
+file in your home directory or the root of your git project:
+
+```yaml
+- name: openai/sonnet
+  extra_params:
+    max_tokens: 8192
+```
+
+See the [model warnings](warnings.html) page for information on the warnings
+aider shows for models it isn't already familiar with; MindsHub's aliases are
+not in aider's built-in model metadata, so this warning is expected and can
+be ignored.


### PR DESCRIPTION
## Summary

Adds a docs page for connecting aider to [MindsHub](https://mindshub.ai), an OpenAI-compatible inference gateway that fronts Claude, GPT, Kimi, DeepSeek and other models behind one API key and bill.

This is a **documentation-only** change. Aider's existing generic OpenAI-compatible-API support (`OPENAI_API_BASE` + `OPENAI_API_KEY` + the `openai/<model>` prefix, as already documented in `docs/llms/openai-compat.md`) already covers MindsHub with zero code changes — I verified this against aider's own `openai-compat.md` recipe and `aider/main.py`'s handling of `--openai-api-base`/`OPENAI_API_BASE`, and against MindsHub's own API docs (https://docs.mindshub.ai/inference/). No new provider abstraction, litellm provider, or model-metadata entry is needed or added.

New file: `aider/website/docs/llms/mindshub.md`, following the same structure/front-matter as the neighboring `openrouter.md` and `deepseek.md` pages (`parent: Connecting to LLMs`, `nav_order: 500`, so it's picked up automatically in the sidebar). It covers:
- Setting `OPENAI_API_KEY` / `OPENAI_API_BASE` for MindsHub
- Using `aider --model openai/<alias>` with MindsHub's model aliases (`sonnet`, `opus`, `kimi`, `deepseek`, `gpt-codex`, etc.)
- An optional `.aider.model.settings.yml` snippet
- A link to the full model catalog and API docs at https://docs.mindshub.ai/inference/

## Disclosure

I'm Jorge Torres, affiliated with MindsHub/mindsdb.com (I work there). This PR documents/promotes my own company's product, so flagging that affiliation explicitly here rather than leaving it unstated.

## Test plan

- [x] Confirmed the mechanism this doc describes is fully generic and requires no aider code changes (traced `--openai-api-base` handling in `aider/main.py` and the existing `openai-compat.md` recipe)
- [x] Verified request/response shapes against MindsHub's own docs (`chat-completions.mdx`, `models.mdx`) rather than paraphrasing
- [x] New page follows the existing `docs/llms/*.md` front-matter and structure conventions so it appears correctly in the "Connecting to LLMs" nav
- [ ] Not independently re-tested against a live MindsHub key from within aider's test suite (no code paths changed, so no new automated test is applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)