### PR TITLE
fix: handle unreadable config files gracefully at startup

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -484,6 +484,10 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
             if check_config_files_for_yes(default_config_files):
                 return 1
         raise e
+    except OSError as err:
+        print(f"Unable to read configuration file: {err}")
+        print("Check the file's permissions and that it is a readable file, not a directory.")
+        return 1
 
     if args.verbose:
         print("Config files search order, if no --config:")
@@ -495,13 +499,23 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
 
     parser = get_parser(default_config_files, git_root)
 
-    args, unknown = parser.parse_known_args(argv)
+    try:
+        args, unknown = parser.parse_known_args(argv)
+    except OSError as err:
+        print(f"Unable to read configuration file: {err}")
+        print("Check the file's permissions and that it is a readable file, not a directory.")
+        return 1
 
     # Load the .env file specified in the arguments
     loaded_dotenvs = load_dotenv_files(git_root, args.env_file, args.encoding)
 
     # Parse again to include any arguments that might have been defined in .env
-    args = parser.parse_args(argv)
+    try:
+        args = parser.parse_args(argv)
+    except OSError as err:
+        print(f"Unable to read configuration file: {err}")
+        print("Check the file's permissions and that it is a readable file, not a directory.")
+        return 1
 
     if args.shell_completions:
         # Ensure parser.prog is set for shtab, though it should be by default

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -1,3 +1,4 @@
+import contextlib
 import json
 import os
 import subprocess
@@ -99,6 +100,18 @@ class TestMain(TestCase):
             main([], input=DummyInput(), output=DummyOutput())
             _, kwargs = MockCoder.call_args
             assert kwargs["auto_commits"] is True
+
+    def test_main_with_unreadable_config_file(self):
+        # A directory named .aider.conf.yml can not be opened as a config file.
+        # aider should print a friendly error and exit non-zero instead of
+        # dumping an uncaught PermissionError/IsADirectoryError traceback.
+        # https://github.com/Aider-AI/aider/issues/5466
+        Path(".aider.conf.yml").mkdir()
+        stdout = StringIO()
+        with contextlib.redirect_stdout(stdout):
+            result = main(["--exit"], input=DummyInput(), output=DummyOutput())
+        self.assertEqual(result, 1)
+        self.assertIn("Unable to read configuration file", stdout.getvalue())
 
     def test_main_with_empty_git_dir_new_subdir_file(self):
         make_repo()


### PR DESCRIPTION
## The problem

Aider crashes with an uncaught traceback at startup when one of its config files exists but cannot be opened:

- #5466 - `PermissionError: [Errno 13] Permission denied: 'D:\project\...\.aider.conf.yml'` raised from `configargparse._open_config_files` while parsing args
- #4774 - `OSError in configargparse.py line 1216` with a symlinked/broken config file

`configargparse` opens every file in the default config search path (cwd, git root, home) during `parse_known_args()`. If a file named `.aider.conf.yml` exists but is unreadable - permission denied, a broken symlink, or a directory with that name - the raw exception propagates out of `aider.main.main()` and the user gets a Python traceback instead of a usable message.

## The fix

Wrap all three argument-parse calls in `main()` (`parse_known_args` twice, then `parse_args`) with an `except OSError` handler that:

- prints `Unable to read configuration file: <err>` plus a hint to check permissions / that it is a readable file
- returns exit code `1` instead of dumping a traceback

`OSError` covers `PermissionError`, `FileNotFoundError`, and `IsADirectoryError`, which are the realistic failure modes here. The existing `except AttributeError` handling for the boolean-config bug is untouched.

## Testing

- Added `tests/basic/test_main.py::TestMain::test_main_with_unreadable_config_file`: creates a *directory* named `.aider.conf.yml` in cwd (which raises `IsADirectoryError` on POSIX and `PermissionError` on Windows when opened), runs `main(["--exit"])`, and asserts the friendly error is printed and the return code is `1`.
- Full `tests/basic/test_main.py` suite passes locally (77 passed) on Windows/Python 3.12.
- `pre-commit run --files aider/main.py tests/basic/test_main.py` passes (isort, black, flake8, codespell with repo-pinned hook versions).

Fixes #5466
Fixes #4774
