### PR TITLE
docs: document --message with --auto-test for headless runs

### DIFF
--- a/aider/website/docs/scripting.md
+++ b/aider/website/docs/scripting.md
@@ -52,7 +52,39 @@ but these are useful for scripting:
                       AIDER_DRY_RUN]
 --commit              Commit all pending changes with a suitable commit message, then exit
                       [env var: AIDER_COMMIT]
+--auto-test, --no-auto-test
+                      Enable/disable automatic testing after changes (default: False) [env var:
+                      AIDER_AUTO_TEST]
+--test-cmd TEST_CMD   Specify command to run tests [env var: AIDER_TEST_CMD]
 ```
+
+### Verifying headless changes with tests
+
+By default, a scripted `--message` run applies aider's edits and exits,
+without checking that the result still compiles or passes tests.
+Combine `--auto-test` with `--test-cmd` to have aider run your test
+suite after each round of edits and automatically attempt to fix any
+failures, just like it does in an interactive session:
+
+```bash
+aider --message "fix the failing tests in the payments module" \
+    --yes-always \
+    --no-auto-commits \
+    --auto-test \
+    --test-cmd "go build ./... && go test ./..."
+```
+
+The test command should print errors on stdout/stderr
+and return a non-zero exit code when the tests fail.
+Aider will feed that output back to the model and retry,
+for up to three reflection rounds.
+This makes `--message` runs much safer for CI jobs and benchmarks,
+where nobody is watching to catch broken output.
+
+See
+[linting and testing](/docs/usage/lint-test.html)
+for more about configuring test commands,
+including per-language lint commands.
 
 
 ## Python


### PR DESCRIPTION
## Summary

Documents how to combine `--auto-test` / `--test-cmd` with `--message` for headless (CI, scripting, benchmark) runs, as requested in #4923.

## The problem

The [scripting docs](https://aider.chat/docs/scripting.html) show how to run aider one-shot with `--message`, and the [linting and testing docs](https://aider.chat/docs/usage/lint-test.html) explain `--auto-test`/`--test-cmd` - but only in an interactive context. Nothing tells headless users that a scripted `--message` run by default applies edits and exits *without* any compile/test verification, or that adding `--yes-always --auto-test --test-cmd "..."` gives them the same automatic fix-the-failing-tests loop in CI. As #4923 describes, this leads to benchmark/CI results full of unverified, broken edits.

## Changes

In `aider/website/docs/scripting.md`:

- Add `--auto-test` and `--test-cmd` to the list of command-line options useful for scripting (help text copied verbatim from `aider --help`)
- New subsection **"Verifying headless changes with tests"** with a concrete example combining `--message`, `--yes-always`, `--no-auto-commits`, `--auto-test`, and `--test-cmd`
- Explain the contract (print errors to stdout/stderr, non-zero exit code on failure), the automatic retry behavior (up to three reflection rounds, matching `max_reflections = 3` in `base_coder.py`), and link to the linting/testing docs for per-language configuration

Docs-only change; no code affected.

Fixes #4923
