### PR TITLE
fix: do not append newlines for an empty system reminder

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -1312,10 +1312,8 @@ class Coder:
 
         max_input_tokens = self.main_model.info.get("max_input_tokens") or 0
         # Add the reminder prompt if we still have room to include it.
-        if (
-            not max_input_tokens
-            or total_tokens < max_input_tokens
-            and self.gpt_prompts.system_reminder
+        if self.gpt_prompts.system_reminder and (
+            not max_input_tokens or total_tokens < max_input_tokens
         ):
             if self.main_model.reminder == "sys":
                 chunks.reminder = reminder_message

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1433,6 +1433,71 @@ This command will print 'Hello, World!' to the console."""
                     # (because user rejected the changes)
                     mock_editor.run.assert_not_called()
 
+    def test_format_chat_chunks_empty_reminder_preserves_user_message(self):
+        model = Model("openai/my-custom-model")
+        io = InputOutput(pretty=False, fancy_input=False, yes=True)
+        coder = Coder.create(
+            model,
+            "help",
+            io=io,
+            stream=False,
+            map_tokens=0,
+            use_git=False,
+        )
+
+        self.assertEqual(model.info, {})
+        self.assertEqual(model.reminder, "user")
+        self.assertEqual(coder.gpt_prompts.system_reminder, "")
+
+        coder.cur_messages = [
+            {"role": "user", "content": "original user content"},
+        ]
+
+        chunks = coder.format_chat_chunks()
+
+        self.assertEqual(
+            chunks.cur[-1]["content"],
+            "original user content",
+        )
+
+    def test_format_chat_chunks_reminder_max_input_tokens_combinations(self):
+        original = "original user content"
+        reminder = "Stay concise."
+        cases = (
+            ("", None, original),
+            ("", 100000, original),
+            (reminder, None, f"{original}\n\n{reminder}"),
+            (reminder, 100000, f"{original}\n\n{reminder}"),
+        )
+
+        for system_reminder, max_input_tokens, expected in cases:
+            with self.subTest(system_reminder=system_reminder, max_input_tokens=max_input_tokens):
+                model = Model("openai/my-custom-model")
+                model.reminder = "user"
+                if max_input_tokens is None:
+                    model.info = {}
+                else:
+                    model.info = {"max_input_tokens": max_input_tokens}
+
+                io = InputOutput(pretty=False, fancy_input=False, yes=True)
+                coder = Coder.create(
+                    model,
+                    "help",
+                    io=io,
+                    stream=False,
+                    map_tokens=0,
+                    use_git=False,
+                )
+                coder.gpt_prompts = type(coder.gpt_prompts)()
+                coder.gpt_prompts.system_reminder = system_reminder
+                coder.cur_messages = [
+                    {"role": "user", "content": original},
+                ]
+
+                chunks = coder.format_chat_chunks()
+
+                self.assertEqual(chunks.cur[-1]["content"], expected)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`Coder.format_chat_chunks` treated a missing `max_input_tokens` as “always add the reminder” because `or` binds looser than `and`. With the help coder’s empty `system_reminder` and `reminder="user"`, that still concatenated `"\n\n"` onto the last user message even though there was no reminder text.

Require a non-empty reminder before either placement branch. Keep adding a real reminder when the limit is missing or the prompt is under budget.

Closes #5611

## Test plan

- [x] `pytest tests/basic/test_coder.py::TestCoder::test_format_chat_chunks_empty_reminder_preserves_user_message`
- [x] `pytest tests/basic/test_coder.py::TestCoder::test_format_chat_chunks_reminder_max_input_tokens_combinations`
  - empty reminder, missing `max_input_tokens` → user text unchanged
  - empty reminder, present `max_input_tokens` → user text unchanged
  - non-empty reminder, missing `max_input_tokens` → `"\n\n" + reminder`
  - non-empty reminder, present `max_input_tokens` → `"\n\n" + reminder`