### PR TITLE
fix(run_cmd): read subprocess stdout in chunks instead of single characters

### DIFF
--- a/aider/run_cmd.py
+++ b/aider/run_cmd.py
@@ -74,7 +74,7 @@ def run_cmd_subprocess(command, verbose=False, cwd=None, encoding=sys.stdout.enc
 
         output = []
         while True:
-            chunk = process.stdout.read(1)
+            chunk = process.stdout.read(4096)
             if not chunk:
                 break
             print(chunk, end="", flush=True)  # Print the chunk in real-time

--- a/tests/basic/test_run_cmd.py
+++ b/tests/basic/test_run_cmd.py
@@ -9,3 +9,17 @@ def test_run_cmd_echo():
 
     assert exit_code == 0
     assert output.strip() == "Hello, World!"
+
+def test_run_cmd_subprocess_reads_in_chunks(mocker):
+    mock_process = mocker.MagicMock()
+    mock_process.stdout.read.side_effect = ["chunk1", "chunk2", ""]
+    mock_process.wait.return_value = None
+    mock_process.returncode = 0
+    mocker.patch("aider.run_cmd.subprocess.Popen", return_value=mock_process)
+
+    from aider.run_cmd import run_cmd_subprocess
+
+    code, out = run_cmd_subprocess("echo test")
+    assert code == 0
+    assert out == "chunk1chunk2"
+    mock_process.stdout.read.assert_called_with(4096)


### PR DESCRIPTION
## Summary

Fixes #5624.

In `run_cmd_subprocess()`, stdout was previously read one character at a time (`process.stdout.read(1)`) with `print(chunk, end="", flush=True)` in each iteration. For commands producing large output (such as verbose test suites or builds during `/run`, `/test`, or `--auto-test`), this introduced significant Python interpreter and text-decoding overhead.

## Changes

- Update `run_cmd_subprocess()` to read stdout in 4KB chunks (`process.stdout.read(4096)`) while preserving real-time output printing and overall stdout capture.
- Add a unit test verifying `run_cmd_subprocess` reads stdout in chunks.

## Verification

- Ran `pytest tests/basic/test_run_cmd.py` to verify RED (failed on single-char read) and GREEN (passed on chunk read) states.