### PR TITLE
ci: set explicit permissions on workflows missing them

### DIFF
--- a/.github/workflows/check_pypi_version.yml
+++ b/.github/workflows/check_pypi_version.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   check_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   docker_build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: read
+
 jobs:
   docker_build_and_push:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: read
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/ubuntu-tests.yml
+++ b/.github/workflows/ubuntu-tests.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/windows-tests.yml
+++ b/.github/workflows/windows-tests.yml
@@ -20,6 +20,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/windows_check_pypi_version.yml
+++ b/.github/workflows/windows_check_pypi_version.yml
@@ -10,6 +10,9 @@ on:
     - cron: '0 1 * * *'
   workflow_dispatch: # Allows manual triggering
 
+permissions:
+  contents: read
+
 jobs:
   check_version:
     runs-on: windows-latest


### PR DESCRIPTION
Eight of the ten workflows here don't declare `permissions:`, so their `GITHUB_TOKEN` falls back to whatever the repository default is instead of being scoped to the job. `pages.yml` and `issues.yml` already declare one, so this just brings the rest in line.

All eight only read the repo, so `contents: read` covers them:

| Workflow | What it does |
| --- | --- |
| `ubuntu-tests.yml`, `windows-tests.yml` | checkout + pytest |
| `pre-commit.yml` | checkout + pre-commit |
| `docker-build-test.yml` | checkout + buildx build |
| `docker-release.yml` | checkout + build/push **to Docker Hub** |
| `release.yml` | checkout + build + twine upload |
| `check_pypi_version.yml`, `windows_check_pypi_version.yml` | install from PyPI, compare against latest git tag |

I checked the two publishing workflows specifically, since those are the ones where a too-narrow scope would break a release:

- `docker-release.yml` authenticates with `secrets.DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` and pushes to Docker Hub, not GHCR — so it needs no `packages: write`.
- `release.yml` uploads with `TWINE_PASSWORD: secrets.PYPI_API_TOKEN`, not OIDC trusted publishing — so it needs no `id-token: write`.

Neither touches the GitHub API, so read is enough for both.

This is hardening rather than a bug fix — if the repo default is already read-only, nothing changes at runtime. It just stops these eight depending on that default.

## Testing

I couldn't run these workflows from a fork, so I verified statically: each file was parsed with a YAML parser after editing to confirm it still loads and that `permissions` resolves to `{'contents': 'read'}` with the job list unchanged. The diff is additive only — three lines per file, no existing line touched. Every step in all eight was read to confirm none writes to the repo, creates releases, comments, or pushes to GHCR.
