### PR TITLE
Handle inaccessible OAuth keys file when loading dotenv files

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -368,11 +368,14 @@ def load_dotenv_files(git_root, dotenv_fname, encoding="utf-8"):
 
     # Explicitly add the OAuth keys file to the beginning of the list
     oauth_keys_file = Path.home() / ".aider" / "oauth-keys.env"
-    if oauth_keys_file.exists():
-        # Insert at the beginning so it's loaded first (and potentially overridden)
-        dotenv_files.insert(0, str(oauth_keys_file.resolve()))
-        # Remove duplicates if it somehow got included by generate_search_path_list
-        dotenv_files = list(dict.fromkeys(dotenv_files))
+    try:
+        if oauth_keys_file.exists():
+            # Insert at the beginning so it's loaded first (and potentially overridden)
+            dotenv_files.insert(0, str(oauth_keys_file.resolve()))
+            # Remove duplicates if it somehow got included by generate_search_path_list
+            dotenv_files = list(dict.fromkeys(dotenv_files))
+    except OSError as e:
+        print(f"OSError loading {oauth_keys_file}: {e}")
 
     loaded = []
     for fname in dotenv_files:

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -1470,6 +1470,32 @@ class TestMain(TestCase):
             # Restore CWD
             os.chdir(original_cwd)
 
+    def test_load_dotenv_files_continues_after_inaccessible_oauth_file(self):
+        with GitTemporaryDirectory() as git_dir:
+            git_dir = Path(git_dir)
+            fake_home = git_dir / "fake_home"
+            fake_home.mkdir()
+            oauth_keys_file = fake_home / ".aider" / "oauth-keys.env"
+
+            git_root_env = git_dir / ".env"
+            git_root_env.write_text("ACCESSIBLE_VAR=loaded\n")
+
+            original_exists = Path.exists
+
+            def exists_with_inaccessible_oauth(path):
+                if path == oauth_keys_file:
+                    raise PermissionError("permission denied")
+                return original_exists(path)
+
+            with (
+                patch("pathlib.Path.home", return_value=fake_home),
+                patch("pathlib.Path.exists", new=exists_with_inaccessible_oauth),
+            ):
+                loaded_files = load_dotenv_files(str(git_dir), None)
+
+            self.assertIn(str(git_root_env.resolve()), loaded_files)
+            self.assertEqual(os.environ.get("ACCESSIBLE_VAR"), "loaded")
+
     @patch("aider.main.InputOutput")
     def test_cache_without_stream_no_warning(self, MockInputOutput):
         mock_io_instance = MockInputOutput.return_value


### PR DESCRIPTION
## Summary

- catch `OSError` while probing the optional `~/.aider/oauth-keys.env` file
- continue loading other dotenv files when that OAuth file is inaccessible
- add a regression test that raises `PermissionError` for the OAuth path and verifies the git-root `.env` still loads

## Tests

- `pytest -q tests/basic/test_main.py` (77 passed)
- `uvx pre-commit run --files aider/main.py tests/basic/test_main.py`

Fixes #5462