### PR TITLE
fix: fail headless coder-switch commands clearly

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -1129,7 +1129,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         try:
             coder.run(with_message=args.message)
         except SwitchCoder:
-            pass
+            io.tool_error("Coder-switching commands are only supported in interactive mode.")
+            analytics.event("exit", reason="Unsupported --message coder switch")
+            return 1
         analytics.event("exit", reason="Completed --message")
         return
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -12,6 +12,7 @@ from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
 
 from aider.coders import Coder
+from aider.commands import SwitchCoder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.main import check_gitignore, load_dotenv_files, main, setup_git
@@ -372,6 +373,18 @@ class TestMain(TestCase):
         main(["--message", test_message], input=DummyInput(), output=DummyOutput())
 
         mock_io_instance.add_to_input_history.assert_called_once_with(test_message)
+
+    @patch("aider.main.InputOutput")
+    @patch("aider.coders.base_coder.Coder.run")
+    def test_message_coder_switch_returns_error(self, mock_run, MockInputOutput):
+        mock_run.side_effect = SwitchCoder(edit_format="ask")
+
+        result = main(["--message", "/ask explain this module"])
+
+        self.assertEqual(result, 1)
+        MockInputOutput.return_value.tool_error.assert_called_once_with(
+            "Coder-switching commands are only supported in interactive mode."
+        )
 
     @patch("aider.main.InputOutput")
     @patch("aider.coders.base_coder.Coder.run")


### PR DESCRIPTION
## Summary

- return a non-zero status when `--message` triggers a coder-switching slash command
- print a clear interactive-only error instead of silently exiting successfully
- add focused coverage for the `SwitchCoder` path

## Why

The one-shot `--message` branch swallowed `SwitchCoder`, reported a completed run, and returned success even though commands such as `/ask`, `/model`, and `/architect` were not applied.

Fixes #5623

## Test

- `python -m pytest tests/basic/test_main.py::TestMain::test_message_coder_switch_returns_error -q`
