### PR TITLE
fix: fail unsupported slash commands in message mode

### DIFF
--- a/aider/main.py
+++ b/aider/main.py
@@ -1129,7 +1129,9 @@ def main(argv=None, input=None, output=None, force_git_root=None, return_coder=F
         try:
             coder.run(with_message=args.message)
         except SwitchCoder:
-            pass
+            io.tool_error(f"Command '{args.message}' is only supported in interactive mode.")
+            analytics.event("exit", reason="Unsupported --message command")
+            return 1
         analytics.event("exit", reason="Completed --message")
         return
 

--- a/tests/basic/test_main.py
+++ b/tests/basic/test_main.py
@@ -12,6 +12,7 @@ from prompt_toolkit.input import DummyInput
 from prompt_toolkit.output import DummyOutput
 
 from aider.coders import Coder
+from aider.commands import SwitchCoder
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.main import check_gitignore, load_dotenv_files, main, setup_git
@@ -372,6 +373,19 @@ class TestMain(TestCase):
         main(["--message", test_message], input=DummyInput(), output=DummyOutput())
 
         mock_io_instance.add_to_input_history.assert_called_once_with(test_message)
+
+    @patch("aider.main.InputOutput")
+    @patch("aider.coders.base_coder.Coder.run", side_effect=SwitchCoder())
+    def test_main_message_rejects_switch_coder_commands(self, mock_run, MockInputOutput):
+        test_message = "/ask explain this module"
+        mock_io_instance = MockInputOutput.return_value
+
+        result = main(["--message", test_message], input=DummyInput(), output=DummyOutput())
+
+        self.assertEqual(result, 1)
+        mock_io_instance.tool_error.assert_called_once_with(
+            f"Command '{test_message}' is only supported in interactive mode."
+        )
 
     @patch("aider.main.InputOutput")
     @patch("aider.coders.base_coder.Coder.run")


### PR DESCRIPTION
## Summary

- fail headless `--message` invocations that request an interactive coder switch instead of silently exiting successfully
- preserve the existing behavior for ordinary `--message` input and for the interactive coder-switch loop
- add a regression test for the exit code and user-facing error

Fixes #5623.

## Testing

- focused pytest: `2 passed` (`test_main_message_rejects_switch_coder_commands` and `test_main_message_adds_to_input_history`)
- `black==23.3.0 --check --line-length 100 --preview aider/main.py tests/basic/test_main.py`
- `isort==5.12.0 --check-only --profile black aider/main.py tests/basic/test_main.py`
- `flake8==7.1.0 aider/main.py tests/basic/test_main.py`
- `git diff --check`

The focused pytest run used the current `main.py` and test file against the released `aider-chat==0.86.2` dependency set because GitHub blob fetches were intermittently resetting on this Windows host.