### PR TITLE
fix: replace undecodable bytes in read_text to prevent surrogate UnicodeEncodeError

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -455,7 +455,7 @@ class InputOutput:
             return self.read_image(filename)
 
         try:
-            with open(str(filename), "r", encoding=self.encoding) as f:
+            with open(str(filename), "r", encoding=self.encoding, errors="replace") as f:
                 return f.read()
         except FileNotFoundError:
             if not silent:

--- a/tests/basic/test_io.py
+++ b/tests/basic/test_io.py
@@ -475,6 +475,25 @@ class TestInputOutputMultilineMode(unittest.TestCase):
             mock_print.assert_called_once()
 
 
+    def test_read_text_no_surrogates(self):
+        with ChdirTemporaryDirectory():
+            path = "test_invalid.txt"
+            with open(path, "wb") as f:
+                f.write(b"hello\xb0world")  # 0xb0 is undecodable as strict UTF-8
+
+            io = InputOutput(fancy_input=False, encoding="utf-8")
+            content = io.read_text(path)
+
+            self.assertIsNotNone(content)
+            for ch in content:
+                self.assertFalse(
+                    0xD800 <= ord(ch) <= 0xDFFF,
+                    f"Surrogate character found: {repr(ch)}",
+                )
+            # The content must be encodable as UTF-8 (required for JSON API payloads)
+            content.encode("utf-8")
+
+
 @patch("aider.io.is_dumb_terminal", return_value=False)
 @patch.dict(os.environ, {"NO_COLOR": ""})
 class TestInputOutputFormatFiles(unittest.TestCase):


### PR DESCRIPTION
When aider runs on a system using a non-UTF-8 locale (e.g. cp936 on Chinese Windows), reading a file without an errors= parameter can produce Python strings with lone surrogate characters via surrogateescape. These surrogates later cause UnicodeEncodeError when the file content is JSON-serialised and sent to a local model such as Ollama. Adding errors="replace" to the open() call in read_text() substitutes undecodable bytes with U+FFFD instead of creating surrogates. Fixes #3460