### PR TITLE
docs: clarify benchmark model settings option

### DIFF
--- a/aider/website/docs/config/adv-model-settings.md
+++ b/aider/website/docs/config/adv-model-settings.md
@@ -78,6 +78,8 @@ You can override or add settings for any model by creating a `.aider.model.setti
 - The current directory where you launch aider.
 - Or specify a specific file with the `--model-settings-file <filename>` switch.
 
+The benchmark script uses a different option name, `--read-model-settings=<filename.yml>`, when loading model settings for a benchmark run.
+
 If the files above exist, they will be loaded in that order. 
 Files loaded last will take priority.
 

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -82,7 +82,7 @@ You can run `./benchmark/benchmark.py --help` for a list of all the arguments, b
 - `--threads` specifies how many exercises to benchmark in parallel. Start with a single thread if you are working out the kinks on your benchmarking setup or working with a new model, etc. Once you are getting reliable results, you can speed up the process by running with more threads. 10 works well against the OpenAI APIs.
 - `--num-tests` specifies how many of the tests to run before stopping. This is another way to start gently as you debug your benchmarking setup.
 - `--keywords` filters the tests to run to only the ones whose name match the supplied argument (similar to `pytest -k xxxx`).
-- `--read-model-settings=<filename.yml>` specify model settings, see here: https://aider.chat/docs/config/adv-model-settings.html#model-settings
+- `--read-model-settings=<filename.yml>` specifies model settings for a benchmark run. This is the benchmark script's option; the main `aider` CLI uses `--model-settings-file <filename>` instead. See [model settings](https://aider.chat/docs/config/adv-model-settings.html#model-settings).
 
 ### Benchmark report
 


### PR DESCRIPTION
## Summary

- Clarify that the benchmark script uses --read-model-settings=<filename.yml>.
- Distinguish it from the main aider CLI option, --model-settings-file <filename>.
- Cross-reference the model settings documentation.

Fixes #5131

## Scope

This is a docs-only change. benchmark/benchmark.py is intentionally unchanged.

## Tests

- D:\pytorchAnaconda\envs\pytorch2\python.exe benchmark/benchmark.py --help with PYTHONPATH=.: passed
- D:\pytorchAnaconda\envs\pytorch2\python.exe -m pip check: passed
- git diff --check: passed