### PR TITLE
fix(mdstream): clamp stable line count to prevent dropping lines shorter than live window

### DIFF
--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -188,7 +188,7 @@ class MarkdownStream:
         # How many lines have "left" the live window and are now considered stable?
         # Or if final, consider all lines to be stable.
         if not final:
-            num_lines -= self.live_window
+            num_lines = max(0, num_lines - self.live_window)
 
         # If we have stable content to display...
         if final or num_lines > 0:

--- a/tests/basic/test_mdstream.py
+++ b/tests/basic/test_mdstream.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+from aider.mdstream import MarkdownStream
+
+
+class LiveStub:
+    def __init__(self):
+        self.update_calls = []
+        self.printed_calls = []
+        self.console = SimpleNamespace(
+            print=lambda value: self.printed_calls.append(value),
+        )
+
+    def update(self, value):
+        self.update_calls.append(value)
+
+    def stop(self):
+        pass
+
+
+def test_update_preserves_all_lines_shorter_than_live_window():
+    rendered_lines = [
+        "line1\n",
+        "line2\n",
+        "line3\n",
+        "line4\n",
+    ]
+
+    stream = MarkdownStream()
+    stream.live_window = 5
+    stream.when = 0
+    stream.min_delay = 0
+    stream._live_started = True
+    stream.live = LiveStub()
+    stream._render_markdown_to_lines = lambda _text: list(rendered_lines)
+
+    stream.update("ignored text", final=False)
+
+    assert len(stream.live.update_calls) == 1
+    assert len(stream.live.printed_calls) == 0
+
+    rendered = stream.live.update_calls[0]
+    rendered_text = getattr(rendered, "plain", None) or str(rendered)
+
+    assert rendered_text.splitlines() == [
+        "line1",
+        "line2",
+        "line3",
+        "line4",
+    ]
+
+
+def test_update_emits_stable_lines_when_longer_than_live_window():
+    rendered_lines = [
+        f"line{i}\n" for i in range(1, 9)
+    ]
+
+    stream = MarkdownStream()
+    stream.live_window = 5
+    stream.when = 0
+    stream.min_delay = 0
+    stream._live_started = True
+    stream.live = LiveStub()
+    stream._render_markdown_to_lines = lambda _text: list(rendered_lines)
+
+    stream.update("ignored text", final=False)
+
+    assert len(stream.live.update_calls) == 1
+    assert len(stream.live.printed_calls) == 1
+
+    printed = stream.live.printed_calls[0]
+    printed_text = getattr(printed, "plain", None) or str(printed)
+    assert printed_text.splitlines() == ["line1", "line2", "line3"]
+
+    rendered = stream.live.update_calls[0]
+    rendered_text = getattr(rendered, "plain", None) or str(rendered)
+    assert rendered_text.splitlines() == ["line4", "line5", "line6", "line7", "line8"]


### PR DESCRIPTION
## Problem
When the rendered output is shorter than `live_window`, `MarkdownStream.update` computes a negative `num_lines` (`len(lines) - self.live_window`), which causes Python slice `lines[num_lines:]` to drop leading rendered lines from the Rich live display instead of displaying all lines.

## Root Cause
In `aider/mdstream.py`, `num_lines -= self.live_window` yields a negative index when `len(lines) < self.live_window`. Slicing with a negative index takes only the suffix rather than treating the stable line count as 0.

## Fix
Clamp `num_lines` to 0 with `max(0, num_lines - self.live_window)`.

## Testing
Added unit tests in `tests/basic/test_mdstream.py` covering short window preservation and stable line emission, verified with pytest.