### PR TITLE
fix(editblock): allow find_filename to look past indented fenced block markers

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -565,7 +565,8 @@ def find_filename(lines, fence, valid_fnames):
             filenames.append(filename)
 
         # Only continue as long as we keep seeing fences
-        if not line.startswith(fence[0]) and not line.startswith(triple_backticks):
+        stripped = line.strip()
+        if not stripped.startswith(fence[0]) and not stripped.startswith(triple_backticks):
             break
 
     if not filenames:

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -49,6 +49,10 @@ class TestUtils(unittest.TestCase):
         lines = [r"\windows__init__.py", "```"]
         self.assertEqual(eb.find_filename(lines, fence, valid_fnames), r"\windows\__init__.py")
 
+        # Test with indented fences
+        lines = ["  ```python", "file3.py", "  ```"]
+        self.assertEqual(eb.find_filename(lines, fence, valid_fnames), "dir/file3.py")
+
     # fuzzy logic disabled v0.11.2-dev
     def __test_replace_most_similar_chunk(self):
         whole = "This is a sample text.\nAnother line of text.\nYet another line.\n"


### PR DESCRIPTION
## Problem
When fenced code block markers contain leading whitespace (e.g. `"  ```python"`), `find_filename` in `editblock_coder.py` breaks early on the continuation check and returns `None`, failing to recover valid filenames in SEARCH/REPLACE blocks.

## Root Cause
In `aider/coders/editblock_coder.py`, `find_filename` checked `if not line.startswith(fence[0]) and not line.startswith(triple_backticks):` using the unstripped `line`. When preceding fence lines have leading spaces, the condition evaluated to true and broke the lookback loop before inspecting the filename line.

## Fix
Strip whitespace before checking whether the line starts with a fence or triple backticks (`stripped = line.strip()`), allowing the lookback search to proceed through indented fence lines.

## Testing
Added test case in `tests/basic/test_editblock.py::TestUtils::test_find_filename` verifying filename recovery with indented fenced markers.