### PR TITLE
docs: add OpenZoo provider page under Connecting to LLMs

### DIFF
--- a/aider/website/docs/llms/openzoo.md
+++ b/aider/website/docs/llms/openzoo.md
@@ -39,11 +39,12 @@ Start working with aider and OpenZoo on your codebase:
 cd /to/your/project
 
 # Prefix the model name with openai/
-aider --model openai/z-ai/glm-5.3-flash
+aider --model openai/auto
 ```
 
-The free model list at `http://localhost:8402/v1/models` shows every
-available model id with live pricing.
+`auto` lets the proxy pick a model per request; the free model list at
+`http://localhost:8402/v1/models` shows every available model id (bare names
+like `claude-sonnet-5` or `gpt-4o-mini`) with live pricing.
 
 The hosted endpoint `https://api.openzoo.fun/v1` answers HTTP 402 unless the
 caller pays x402 or presents an OpenZoo subscription key (`ozk_live_…`);

--- a/aider/website/docs/llms/openzoo.md
+++ b/aider/website/docs/llms/openzoo.md
@@ -1,0 +1,48 @@
+---
+parent: Connecting to LLMs
+nav_order: 500
+---
+
+# OpenZoo
+
+Aider can connect to [OpenZoo](https://openzoo.fun), an OpenAI compatible
+provider with no signup: any API key value is accepted, and usage is paid
+per request (by card, or via the x402 protocol from a local burner wallet).
+
+First, install aider:
+
+{% include install.md %}
+
+Then start OpenZoo locally and configure your endpoint:
+
+```
+npx openzoo   # serves http://localhost:8402/v1
+
+# Mac/Linux:
+export OPENAI_API_BASE=http://localhost:8402/v1
+export OPENAI_API_KEY=sk-openzoo
+
+# Windows:
+setx OPENAI_API_BASE http://localhost:8402/v1
+setx OPENAI_API_KEY sk-openzoo
+# ... restart shell after setx commands
+```
+
+A hosted endpoint is also available at `https://api.openzoo.fun/v1`.
+
+Start working with aider and OpenZoo on your codebase:
+
+```bash
+# Change directory into your codebase
+cd /to/your/project
+
+# Prefix the model name with openai/
+aider --model openai/z-ai/glm-5.3-flash
+```
+
+The free model list at `http://localhost:8402/v1/models` shows every
+available model id with live pricing.
+
+See the [model warnings](warnings.html)
+section for information on warnings which will occur
+when working with models that aider is not familiar with.

--- a/aider/website/docs/llms/openzoo.md
+++ b/aider/website/docs/llms/openzoo.md
@@ -6,21 +6,22 @@ nav_order: 500
 # OpenZoo
 
 Aider can connect to [OpenZoo](https://openzoo.fun), an OpenAI compatible
-provider with no signup: any API key value is accepted, and usage is paid
-per request (by card, or via the x402 protocol from a local burner wallet).
+provider with no account: a small local proxy (`npx openzoo`) pays for each
+request via the x402 protocol from a local burner wallet, and aider talks to
+the proxy like any other OpenAI compatible endpoint.
 
 First, install aider:
 
 {% include install.md %}
 
-Then start OpenZoo locally and configure your endpoint:
+Then start the OpenZoo proxy and point aider at it:
 
 ```
 npx openzoo   # serves http://localhost:8402/v1
 
 # Mac/Linux:
 export OPENAI_API_BASE=http://localhost:8402/v1
-export OPENAI_API_KEY=sk-openzoo
+export OPENAI_API_KEY=sk-openzoo   # the proxy ignores the key; any non-empty value
 
 # Windows:
 setx OPENAI_API_BASE http://localhost:8402/v1
@@ -28,7 +29,8 @@ setx OPENAI_API_KEY sk-openzoo
 # ... restart shell after setx commands
 ```
 
-A hosted endpoint is also available at `https://api.openzoo.fun/v1`.
+`npx openzoo address` prints the proxy's wallet — fund it with USDC on Solana
+or Base; `npx openzoo balance` shows what is left.
 
 Start working with aider and OpenZoo on your codebase:
 
@@ -42,6 +44,10 @@ aider --model openai/z-ai/glm-5.3-flash
 
 The free model list at `http://localhost:8402/v1/models` shows every
 available model id with live pricing.
+
+The hosted endpoint `https://api.openzoo.fun/v1` answers HTTP 402 unless the
+caller pays x402 or presents an OpenZoo subscription key (`ozk_live_…`);
+aider cannot pay x402 itself, so use the local proxy.
 
 See the [model warnings](warnings.html)
 section for information on warnings which will occur


### PR DESCRIPTION
Updated 2026-09-02: corrected — the hosted `https://api.openzoo.fun/v1` endpoint answers HTTP 402 to a plain OpenAI client (it only serves calls that pay x402 or carry an OpenZoo subscription key, `ozk_live_…`). The page now sets up the local `npx openzoo` proxy (`http://localhost:8402/v1`), which pays x402 per call from a local burner wallet and ignores the API key.

Adds a provider page for [OpenZoo](https://openzoo.fun) following the format of the existing `llms/` pages (front matter self-registers under Connecting to LLMs, nav_order 500 like the other providers).

OpenZoo is an OpenAI-compatible provider that needs no signup — a local `npx openzoo` proxy pays per request over x402 and ignores the API key — so aider users can try it with `npx openzoo` plus the two env vars on the page (base `http://localhost:8402/v1`). It already works today via the generic openai-compat instructions; this page is purely discoverability.

Disclosure: I operate OpenZoo. Verification: `npx openzoo` then `curl http://localhost:8402/v1/models` is free and lists models + pricing; the page's env-var setup runs as-is against the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
