### PR TITLE
fix: recover filenames when fenced markers are indented

### DIFF
--- a/aider/coders/editblock_coder.py
+++ b/aider/coders/editblock_coder.py
@@ -564,8 +564,9 @@ def find_filename(lines, fence, valid_fnames):
         if filename:
             filenames.append(filename)
 
-        # Only continue as long as we keep seeing fences
-        if not line.startswith(fence[0]) and not line.startswith(triple_backticks):
+        # Only continue as long as we keep seeing fences (allow indented markers)
+        stripped = line.strip()
+        if not stripped.startswith(fence[0]) and not stripped.startswith(triple_backticks):
             break
 
     if not filenames:

--- a/tests/basic/test_editblock.py
+++ b/tests/basic/test_editblock.py
@@ -29,6 +29,10 @@ class TestUtils(unittest.TestCase):
         lines = ["```python", "file3.py", "```"]
         self.assertEqual(eb.find_filename(lines, fence, valid_fnames), "dir/file3.py")
 
+        # Test with indented fenced markers (regression for #5662)
+        lines = ["  ```python", "file3.py", "  ```"]
+        self.assertEqual(eb.find_filename(lines, fence, valid_fnames), "dir/file3.py")
+
         # Test with no valid filename
         lines = ["```", "invalid_file.py", "```"]
         self.assertEqual("invalid_file.py", eb.find_filename(lines, fence, valid_fnames))


### PR DESCRIPTION
## Summary
- Fixes #5662: `find_filename` stopped scanning when fenced markers had leading whitespace because it checked the raw line with `startswith("```")` instead of the stripped line.
- Use `line.strip()` for the fence-continuation check so indented markers (as in the function docstring example) still allow recovering the filename.
- Add a regression case with indented fences next to the existing unindented fence test.

## Test plan
- [x] Baseline: indented fences returned `None`
- [x] After fix: `find_filename(["  ```python", "file3.py", "  ```"], ...)` → `dir/file3.py`
- [x] `pytest tests/basic/test_editblock.py::TestUtils::test_find_filename -q` → 1 passed


Made with [Cursor](https://cursor.com)