### PR TITLE
fix: keep short MarkdownStream updates fully visible

### DIFF
--- a/aider/mdstream.py
+++ b/aider/mdstream.py
@@ -188,7 +188,9 @@ class MarkdownStream:
         # How many lines have "left" the live window and are now considered stable?
         # Or if final, consider all lines to be stable.
         if not final:
-            num_lines -= self.live_window
+            # Clamp so a short render does not become a negative slice index
+            # (e.g. 4 lines with live_window=5 must keep all lines in Live).
+            num_lines = max(0, num_lines - self.live_window)
 
         # If we have stable content to display...
         if final or num_lines > 0:

--- a/tests/basic/test_mdstream_short_window.py
+++ b/tests/basic/test_mdstream_short_window.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+from aider.mdstream import MarkdownStream
+
+
+class LiveStub:
+    def __init__(self):
+        self.update_calls = []
+        self.console = SimpleNamespace(
+            print=lambda _value: None,
+        )
+
+    def update(self, value):
+        self.update_calls.append(value)
+
+
+def test_update_preserves_all_lines_shorter_than_live_window():
+    rendered_lines = [
+        "line1\n",
+        "line2\n",
+        "line3\n",
+        "line4\n",
+    ]
+
+    stream = MarkdownStream()
+    stream.live_window = 5
+    stream.when = 0
+    stream.min_delay = 0
+    stream._live_started = True
+    stream.live = LiveStub()
+    stream._render_markdown_to_lines = lambda _text: list(rendered_lines)
+
+    stream.update("ignored text", final=False)
+
+    assert len(stream.live.update_calls) == 1
+
+    rendered = stream.live.update_calls[0]
+    rendered_text = getattr(rendered, "plain", None) or str(rendered)
+
+    assert rendered_text.splitlines() == [
+        "line1",
+        "line2",
+        "line3",
+        "line4",
+    ]
+
+
+def test_update_prints_stable_prefix_when_longer_than_live_window():
+    rendered_lines = [f"line{i}\n" for i in range(1, 9)]
+
+    printed = []
+
+    class LiveStubWithPrint(LiveStub):
+        def __init__(self):
+            super().__init__()
+            self.console = SimpleNamespace(print=lambda value: printed.append(str(value)))
+
+    stream = MarkdownStream()
+    stream.live_window = 6
+    stream.when = 0
+    stream.min_delay = 0
+    stream._live_started = True
+    stream.live = LiveStubWithPrint()
+    stream._render_markdown_to_lines = lambda _text: list(rendered_lines)
+
+    stream.update("ignored text", final=False)
+
+    assert "".join(printed).splitlines() == ["line1", "line2"]
+    rendered = stream.live.update_calls[0]
+    rendered_text = getattr(rendered, "plain", None) or str(rendered)
+    assert rendered_text.splitlines() == [
+        "line3",
+        "line4",
+        "line5",
+        "line6",
+        "line7",
+        "line8",
+    ]


### PR DESCRIPTION
## Summary
- Fixes #5654: when rendered output is shorter than `live_window`, `num_lines - live_window` becomes negative and `lines[num_lines:]` keeps only a suffix (e.g. 4 lines with window 5 → only the last line).
- Clamp with `max(0, num_lines - live_window)` so all early lines stay in the Rich live area until they are actually stable.
- Add regressions for the short-window and longer-than-window cases.

## Test plan
- [x] `pytest tests/basic/test_mdstream_short_window.py -q` → 2 passed
- [x] Short case (`live_window=5`, 4 lines): all four lines retained in Live
- [x] Longer case (`live_window=6`, 8 lines): first two printed above Live, last six retained


Made with [Cursor](https://cursor.com)