### PR TITLE
fix: defer history mkdir warning until console exists

### DIFF
--- a/aider/io.py
+++ b/aider/io.py
@@ -308,11 +308,13 @@ class InputOutput:
         self.yes = yes
 
         self.input_history_file = input_history_file
+        pending_history_warning = None
         if self.input_history_file:
             try:
                 Path(self.input_history_file).parent.mkdir(parents=True, exist_ok=True)
             except (PermissionError, OSError) as e:
-                self.tool_warning(f"Could not create directory for input history: {e}")
+                # Defer until console exists; tool_warning needs self.console.
+                pending_history_warning = f"Could not create directory for input history: {e}"
                 self.input_history_file = None
         self.llm_history_file = llm_history_file
         if chat_history_file is not None:
@@ -367,6 +369,9 @@ class InputOutput:
 
         self.file_watcher = file_watcher
         self.root = root
+
+        if pending_history_warning:
+            self.tool_warning(pending_history_warning)
 
         # Validate color settings after console is initialized
         self._validate_color_settings()

--- a/tests/basic/test_io_history_mkdir.py
+++ b/tests/basic/test_io_history_mkdir.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from aider.io import InputOutput
+
+
+def test_input_history_mkdir_failure_does_not_crash(tmp_path):
+    """Regression for #5669: mkdir failure must not call tool_warning before console exists."""
+    history = tmp_path / "missing-parent" / "history"
+
+    with patch.object(Path, "mkdir", side_effect=OSError("No such file or directory: '.'")):
+        io = InputOutput(
+            pretty=False,
+            fancy_input=False,
+            input_history_file=str(history),
+            chat_history_file=str(tmp_path / "chat.md"),
+        )
+
+    assert io.input_history_file is None
+    assert io.console is not None


### PR DESCRIPTION
## Summary
- Fixes #5669: when creating the input-history directory failed, `__init__` called `tool_warning` before `self.console` existed, raising `AttributeError` and aborting startup.
- Defer that warning until after console initialization, then emit it normally.
- Add a regression that patches `Path.mkdir` to fail and asserts construction succeeds with `input_history_file` cleared.

## Test plan
- [x] `pytest tests/basic/test_io_history_mkdir.py -q` → 1 passed
- [x] Confirmed no crash / `console` is available after the failed mkdir path


Made with [Cursor](https://cursor.com)