### PR TITLE
fix: handle None content in get_cur_message_text

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -672,7 +672,8 @@ class Coder:
     def get_cur_message_text(self):
         text = ""
         for msg in self.cur_messages:
-            text += msg["content"] + "\n"
+            if msg["content"] is not None:
+                text += msg["content"] + "\n"
         return text
 
     def get_ident_mentions(self, text):

--- a/tests/basic/test_coder.py
+++ b/tests/basic/test_coder.py
@@ -1433,6 +1433,43 @@ This command will print 'Hello, World!' to the console."""
                     # (because user rejected the changes)
                     mock_editor.run.assert_not_called()
 
+    def test_get_cur_message_text_with_none_content(self):
+        """Test that get_cur_message_text handles None content gracefully.
+
+        This can happen when assistant messages have no text content
+        (e.g., image-only responses or refusals).
+        """
+        with GitTemporaryDirectory():
+            io = InputOutput(yes=True)
+            coder = Coder.create(self.GPT35, "diff", io=io)
+
+            # Test with mixed None and string content
+            coder.cur_messages = [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": None},  # Image-only or refusal
+                {"role": "user", "content": "Continue"},
+            ]
+
+            # Should not raise TypeError
+            result = coder.get_cur_message_text()
+            self.assertEqual(result, "Hello\nContinue\n")
+
+    def test_get_cur_message_text_all_none(self):
+        """Test that get_cur_message_text handles all None content."""
+        with GitTemporaryDirectory():
+            io = InputOutput(yes=True)
+            coder = Coder.create(self.GPT35, "diff", io=io)
+
+            # Test with all None content
+            coder.cur_messages = [
+                {"role": "assistant", "content": None},
+                {"role": "assistant", "content": None},
+            ]
+
+            # Should not raise and return empty string
+            result = coder.get_cur_message_text()
+            self.assertEqual(result, "")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fixes #5649

## Problem
When an assistant message has no text content (e.g., image-only responses or rejections), `msg[content]` is `None`. This causes a `TypeError` in `get_cur_message_text()` when attempting string concatenation with `None`.

## Solution
Added a null check before concatenating message content:
```python
if msg["content"] is not None:
    text += msg["content"] + "\n"
```

## Test
Added test cases in `tests/basic/test_coder.py` to verify handling of messages with `None` content.