### PR TITLE
fix: strip anchored glob patterns on Windows to avoid NotImplementedError

### DIFF
--- a/aider/commands.py
+++ b/aider/commands.py
@@ -33,6 +33,20 @@ class SwitchCoder(Exception):
         self.placeholder = placeholder
 
 
+def _safe_glob_pattern(pattern):
+    """Normalize a glob pattern so pathlib.Path.glob() accepts it on Windows.
+
+    On Windows, a pattern starting with "/" is not absolute per
+    os.path.isabs() (no drive letter), but pathlib treats it as an
+    "anchored" pattern and raises NotImplementedError. Strip the leading
+    slash so the pattern is treated as relative to the glob root, which
+    is what the user almost certainly intended.
+    """
+    if os.name == "nt" and pattern.startswith("/"):
+        return pattern.lstrip("/")
+    return pattern
+
+
 class Commands:
     voice = None
     scraper = None
@@ -771,8 +785,8 @@ class Commands:
                 raw_matched_files = [Path(pattern)]
             else:
                 try:
-                    raw_matched_files = list(Path(self.coder.root).glob(pattern))
-                except (IndexError, AttributeError):
+                    raw_matched_files = list(Path(self.coder.root).glob(_safe_glob_pattern(pattern)))
+                except (IndexError, AttributeError, NotImplementedError):
                     raw_matched_files = []
         except ValueError as err:
             self.io.tool_error(f"Error matching {pattern}: {err}")
@@ -1358,7 +1372,7 @@ class Commands:
                     matches = [Path(p) for p in glob.glob(expanded_pattern)]
                 else:
                     # For relative paths and globs, use glob from the root directory
-                    matches = list(Path(self.coder.root).glob(expanded_pattern))
+                    matches = list(Path(self.coder.root).glob(_safe_glob_pattern(expanded_pattern)))
 
             if not matches:
                 self.io.tool_error(f"No matches found for: {pattern}")

--- a/tests/basic/test_commands.py
+++ b/tests/basic/test_commands.py
@@ -12,7 +12,7 @@ import git
 import pyperclip
 
 from aider.coders import Coder
-from aider.commands import Commands, SwitchCoder
+from aider.commands import Commands, SwitchCoder, _safe_glob_pattern
 from aider.dump import dump  # noqa: F401
 from aider.io import InputOutput
 from aider.models import Model
@@ -2224,3 +2224,32 @@ class TestCommands(TestCase):
             )
             self.assertEqual(new_coder.done_messages, [{"role": "user", "content": "d1"}])
             self.assertEqual(new_coder.cur_messages, [{"role": "user", "content": "c1"}])
+
+class TestSafeGlobPattern(unittest.TestCase):
+    """Windows pathlib.Path.glob() rejects anchored patterns (leading /)
+    with NotImplementedError even though os.path.isabs() says they are
+    relative (no drive letter). _safe_glob_pattern strips the anchor on
+    Windows so the pattern is treated as relative to the glob root.
+    Non-regression test for #5679 / #5675.
+    """
+
+    def test_posix_passthrough(self):
+        with mock.patch("os.name", "posix"):
+            assert _safe_glob_pattern("/foo/bar") == "/foo/bar"
+            assert _safe_glob_pattern("*.py") == "*.py"
+            assert _safe_glob_pattern("src/**/*.py") == "src/**/*.py"
+
+    def test_windows_strips_anchor(self):
+        with mock.patch("os.name", "nt"):
+            assert _safe_glob_pattern("/foo/bar") == "foo/bar"
+            assert _safe_glob_pattern("//nested") == "nested"
+
+    def test_windows_preserves_non_anchored(self):
+        with mock.patch("os.name", "nt"):
+            assert _safe_glob_pattern("*.py") == "*.py"
+            assert _safe_glob_pattern("src/file.py") == "src/file.py"
+
+    def test_windows_preserves_drive_path(self):
+        with mock.patch("os.name", "nt"):
+            assert _safe_glob_pattern("C:/drive/file.py") == "C:/drive/file.py"
+


### PR DESCRIPTION
## Issue

Fixes #5679
Fixes #5675

On Windows, a pattern starting with `/` is not absolute per `os.path.isabs()` (no drive letter), but `pathlib.Path.glob()` treats it as an "anchored" pattern and raises `NotImplementedError: Non-relative patterns are unsupported`. This crashes `/add` and `/read-only` when the user passes a forward-slash path like `/add /some/file.py`.

## Fix

- Add `_safe_glob_pattern()` helper: on Windows (`os.name == "nt"`), strips the leading `/` from a pattern so `Path.glob()` treats it as relative to the glob root (which is what the user intended). No-op on POSIX.
- Apply it at both `Path.glob()` call sites in `commands.py` (`glob_filtered_to_repo` ~line 774, read-only file collection ~line 1361).
- Add `NotImplementedError` to the existing exception handler in `glob_filtered_to_repo` as a fallback for any other anchored-pattern shapes.

## Testing

4 new unit tests in `TestSafeGlobPattern` cover:
- POSIX passthrough (unchanged)
- Windows strips `/foo/bar` → `foo/bar`
- Windows preserves non-anchored patterns (`*.py`, `src/file.py`)
- Windows preserves drive paths (`C:/drive/file.py`)

Note: the full test suite could not be run locally because Python 3.14 removed `audioop`, which `pydub` (an aider dependency) requires. The helper function logic was verified independently with mocked `os.name` on both platforms.