### PR TITLE
fix: refresh commit-message models after /model or /weak-model switch

### DIFF
--- a/aider/coders/base_coder.py
+++ b/aider/coders/base_coder.py
@@ -445,6 +445,9 @@ class Coder:
 
         if self.repo:
             self.root = self.repo.root
+            # Refresh the commit-message models so /model and /weak-model
+            # switches take effect for an already-constructed GitRepo.
+            self.repo.models = main_model.commit_message_models()
 
         for fname in fnames:
             fname = Path(fname)


### PR DESCRIPTION
Fixes #5213

## Problem

`GitRepo` only receives `commit_message_models()` when it is first constructed. `/model` and `/weak-model` raise `SwitchCoder`, and `main.py` rebuilds the coder via `Coder.create(..., from_coder=old_coder)` — but the new coder inherits the original `repo` object from `from_coder.original_kwargs`, so `Coder.__init__` skips the `GitRepo` construction branch (`self.repo` is not `None`) and `repo.models` keeps pointing at the old `[weak_model, main_model]` pair. Commit messages — both manual `/commit` and the automatic post-edit ones — keep using the previous weak model until aider is restarted.

## Change

While attaching an already-constructed repo in `Coder.__init__`, refresh `repo.models` from the current `main_model`:

```python
if self.repo:
    self.root = self.repo.root
    # Refresh the commit-message models so /model and /weak-model
    # switches take effect for an already-constructed GitRepo.
    self.repo.models = main_model.commit_message_models()
```

`repo.models` is only consumed by `GitRepo.get_commit_message()`, and `commit_message_models()` is a pure accessor returning `[self.weak_model, self]`, so the refresh is an idempotent no-op on first construction and cannot bypass any normalization (`GitRepo.__init__` stores `models` as-is).

## Testing

- Reproduction with a real `GitRepo` and two `Coder.create()` calls using different weak models: on `main`, `repo.models` stayed `['gpt-4o-mini', 'gpt-4o-mini']` after the switch; with this change it becomes `['gpt-3.5-turbo', 'gpt-4o-mini']`.
- `pytest tests/basic/test_repo.py tests/basic/test_coder.py`: 58 passed, 5 skipped, 29 subtests passed — identical before and after the change.