### PR TITLE
docs: add Standard Compute connection guide

### DIFF
--- a/aider/website/docs/llms/standardcompute.md
+++ b/aider/website/docs/llms/standardcompute.md
@@ -1,0 +1,47 @@
+---
+parent: Connecting to LLMs
+nav_order: 510
+---
+
+# Standard Compute
+
+You can use [Standard Compute](https://standardcompute.com/) with aider
+through its OpenAI-compatible API. Its `standardcompute` model routes
+requests across models and providers, so you can keep using aider without
+manually switching between provider accounts.
+
+You need a [Standard Compute API key](https://standardcompute.com/dashboard).
+
+First, install aider:
+
+{% include install.md %}
+
+Set the endpoint and your API key in the shell where you run aider:
+
+```bash
+# Mac/Linux
+export OPENAI_API_BASE=https://api.stdcmpt.com/v1
+export OPENAI_API_KEY="your-standard-compute-api-key"
+```
+
+```powershell
+# Windows PowerShell (current session)
+$env:OPENAI_API_BASE = "https://api.stdcmpt.com/v1"
+$env:OPENAI_API_KEY = "<your-standard-compute-api-key>"
+```
+
+Start aider in your project:
+
+```bash
+aider --model openai/standardcompute
+```
+
+Keep the `openai/` prefix: it selects aider's OpenAI-compatible connection.
+The model sent to Standard Compute is `standardcompute`, a routing alias,
+rather than the name of a pinned upstream model.
+
+If aider reports unknown model metadata, see
+[model warnings](warnings.html) and
+[advanced model settings](../config/adv-model-settings.html).
+Standard Compute's subscription and usage are billed separately from aider;
+see its [current plans](https://standardcompute.com/pricing).


### PR DESCRIPTION
Adds a Standard Compute connection guide under Connecting to LLMs. It gives the endpoint, shell-local key setup for macOS/Linux and Windows, and `aider --model openai/standardcompute`. The guide explains why the `openai/` prefix and routing alias matter and links to the existing model-warning guidance.

Disclosure: I run Standard Compute. This is a documentation addition using aider's existing OpenAI-compatible connection; it does not depend on the pending native LiteLLM provider PR.

Validation performed with AI assistance on macOS:

- Parsed and validated the new Markdown with Markdoc, replacing the existing Jekyll install include for that parser check.
- Both Bash examples pass `bash -n`.
- Checked endpoint/model configuration against the existing OpenAI-compatible guide and Standard Compute's published setup.
- `git diff --check` passes. No existing page content changes.

This does not claim a live Aider coding benchmark. The Jekyll site build was not run locally.
