### PR TITLE
Grade benchmarks with runner configs from the pristine exercise tree

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -978,6 +978,36 @@ def run_test_real(
     return results
 
 
+# Runner configuration files per language, restored from the pristine exercise
+# tree before grading (see run_unit_tests).
+RUNNER_CONFIG_FILES = {
+    ".py": ["conftest.py", "pytest.ini", "pyproject.toml", "setup.cfg", "tox.ini"],
+    ".js": ["package.json"],
+    ".cpp": ["CMakeLists.txt"],
+    ".java": ["build.gradle", "settings.gradle", "gradle.properties"],
+    ".rs": ["Cargo.toml"],
+    ".go": ["go.mod"],
+}
+
+# Summary lines each runner prints when tests failed, used to distrust a 0
+# exit code. Matched against the cleaned test output.
+FAILURE_SUMMARY_PATTERNS = {
+    ".py": (r"\b[1-9]\d* failed\b",),
+    ".js": (r"\b[1-9]\d* failing\b",),
+    ".rs": (r"test result: FAILED",),
+    ".go": (r"^FAIL\b",),
+    ".java": (r"> Task .* FAILED", r"BUILD FAILED"),
+}
+
+
+def _output_reports_failures(output, extensions):
+    for ext in extensions:
+        for pattern in FAILURE_SUMMARY_PATTERNS.get(ext, ()):
+            if re.search(pattern, output, re.MULTILINE):
+                return True
+    return False
+
+
 def run_unit_tests(original_dname, testdir, history_fname, test_files):
     timeout = 60 * 3
 
@@ -1003,6 +1033,24 @@ def run_unit_tests(original_dname, testdir, history_fname, test_files):
 
     if not command:
         raise ValueError(f"No test command found for files with extensions: {extensions}")
+
+    # Runner configuration must come from the pristine exercise tree, not the
+    # model's working tree: the harness auto-approves file creation, and a
+    # model-created conftest.py (or a rewritten package.json, CMakeLists.txt,
+    # gradle or Cargo file) can force the test command to exit 0 while every
+    # test fails. Restore these files from the original copy when it has them,
+    # and remove any model-created ones when it does not.
+    exercise_dname = original_dname / Path(*testdir.parts[-4:])
+    for ext in extensions:
+        for config_name in RUNNER_CONFIG_FILES.get(ext, []):
+            config_src = exercise_dname / config_name
+            config_dst = testdir / config_name
+            if config_src.exists():
+                print("restoring", config_src, config_dst)
+                shutil.copy(config_src, config_dst)
+            elif config_dst.exists():
+                print("removing model-created", config_dst)
+                config_dst.unlink()
 
     # Copy test files from original directory
     for file_path in test_files:
@@ -1036,6 +1084,11 @@ def run_unit_tests(original_dname, testdir, history_fname, test_files):
     )
 
     success = result.returncode == 0
+    if success and _output_reports_failures(result.stdout, extensions):
+        # Safety net for exit-code channels the config restore above cannot
+        # reach: the command exited 0 but its own summary reports failures.
+        print(f"Test command exited 0 but reported failures: {testdir}")
+        success = False
     res = result.stdout
     res = cleanup_test_output(res, testdir)
     dump(res)

--- a/tests/test_benchmark_run_unit_tests.py
+++ b/tests/test_benchmark_run_unit_tests.py
@@ -1,0 +1,90 @@
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(REPO_ROOT / "benchmark"))
+
+from benchmark.benchmark import _output_reports_failures, run_unit_tests
+
+LEAP_TEST = '''\
+def test_leap():
+    from leap import is_leap
+    assert is_leap(1996)
+    assert not is_leap(1997)
+'''
+
+WRONG_SOLUTION = '''\
+def is_leap(year):
+    return True
+'''
+
+RIGHT_SOLUTION = '''\
+def is_leap(year):
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+'''
+
+CONTEST_CONFTEST = '''\
+def pytest_sessionfinish(session, exitstatus):
+    if exitstatus != 0:
+        session.exitstatus = 0
+'''
+
+
+def make_exercise(tmp_path, solution, conftest=None):
+    original_root = tmp_path / "original"
+    exercise = original_root / "a" / "b" / "c" / "d"
+    testdir = tmp_path / "run" / "a" / "b" / "c" / "d"
+    exercise.mkdir(parents=True)
+    (exercise / "tests").mkdir()
+    (exercise / "tests" / "test_leap.py").write_text(LEAP_TEST)
+    if conftest is not None:
+        (exercise / "conftest.py").write_text(conftest)
+
+    testdir.mkdir(parents=True)
+    (testdir / "tests").mkdir()
+    (testdir / "tests" / "test_leap.py").write_text(LEAP_TEST)
+    (testdir / "leap.py").write_text(solution)
+    return original_root, testdir
+
+
+def test_model_created_conftest_cannot_force_pass(tmp_path):
+    original, testdir = make_exercise(tmp_path, WRONG_SOLUTION)
+    # The model plants a conftest.py that forces pytest to exit 0.
+    (testdir / "conftest.py").write_text(CONTEST_CONFTEST)
+    history = tmp_path / "history.md"
+
+    errors = run_unit_tests(original, testdir, history, ["tests/test_leap.py"])
+
+    assert errors is not None
+    assert not (testdir / "conftest.py").exists()
+
+
+def test_pristine_conftest_is_restored_for_grading(tmp_path):
+    marker = "def pytest_configure(config):\n    print('PRISTINE_CONFTEST_LOADED')\n"
+    original, testdir = make_exercise(tmp_path, WRONG_SOLUTION, conftest=marker)
+    (testdir / "conftest.py").write_text(CONTEST_CONFTEST)
+    history = tmp_path / "history.md"
+
+    errors = run_unit_tests(original, testdir, history, ["tests/test_leap.py"])
+
+    assert errors is not None
+    assert (testdir / "conftest.py").read_text() == marker
+
+
+def test_honest_pass_still_passes(tmp_path):
+    original, testdir = make_exercise(tmp_path, RIGHT_SOLUTION)
+    history = tmp_path / "history.md"
+
+    errors = run_unit_tests(original, testdir, history, ["tests/test_leap.py"])
+
+    assert errors is None
+
+
+def test_output_reports_failures_detects_runner_summaries():
+    assert _output_reports_failures("2 failed, 3 passed in 0.01s", {".py"})
+    assert _output_reports_failures("  1 failing", {".js"})
+    assert _output_reports_failures("test result: FAILED. 0 passed", {".rs"})
+    assert _output_reports_failures("FAIL\t./leap [build failed]", {".go"})
+    assert _output_reports_failures("> Task :test FAILED", {".java"})
+    assert not _output_reports_failures("5 passed in 0.01s", {".py"})
+    assert not _output_reports_failures("1 passed, 0 failing", {".py", ".js"})


### PR DESCRIPTION
## Summary

`run_unit_tests` restores only the test files before grading, while the test command runs in the model-writable working tree and the benchmark harness auto-approves file creation (`InputOutput(pretty=False, yes=True)`). A four-line model-created `conftest.py` that resets `session.exitstatus` therefore makes pytest exit 0 while every test fails, and the exercise is recorded as solved:

```python
def pytest_sessionfinish(session, exitstatus):
    if exitstatus != 0:
        session.exitstatus = 0
```

The chat history still contains the FAILED test lines while the exercise is scored solved, and a gamed run is indistinguishable from an honest one in the results yaml and on the leaderboard, which accepts community-submitted results. The same primitive reaches the other languages through their runner config files (`package.json` for JavaScript, `CMakeLists.txt` for C++, `build.gradle` for Java, `Cargo.toml` for Rust), none of which are restored.

Fixes #5681.

## Changes

- Before grading, the runner config files for the exercise's language are restored from the original exercise copy when it has them, and any model-created ones are removed when it does not (conftest.py, pytest.ini, pyproject.toml, setup.cfg, tox.ini for Python, plus the equivalents for JS, C++, Java, Rust, Go).
- As a safety net, a 0 exit code is distrusted when the command's own summary reports failed tests (pytest's "N failed", mocha's "N failing", cargo's "test result: FAILED", go's "FAIL", gradle's "> Task FAILED" / "BUILD FAILED").

## Testing

New tests in `tests/test_benchmark_run_unit_tests.py`:

- a model-created conftest.py can no longer force a pass: the exercise scores failed, and the conftest is removed before grading
- a pristine conftest.py is restored over a model-modified one
- an honest pass still passes
- the summary-pattern helper matches each runner's failure line and does not match zero-count summaries

Verified behaviorally in both directions with the exact scenario above: on the pre-fix code the exercise with a failing suite is recorded as solved via the conftest; with the change the conftest is removed and the exercise scores failed.
